### PR TITLE
chore: add minimal pre-commit config for docs repo

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD029": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+        files: \.(md|mdx)$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,6 +3,7 @@
 ## Our Standards
 
 Contributors are expected to:
+
 1. Be respectful and constructive.
 2. Focus feedback on ideas and implementation.
 3. Avoid harassment, discrimination, and personal attacks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ python3 scripts/validate_skill_quality.py
 ## Reporting Issues
 
 Open a GitHub Issue with:
+
 1. skill slug
 2. expected behavior
 3. actual behavior

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ Use when you want the fastest route from raw material to runnable lesson scripts
 3. Run `ai-shifu-lesson-script-optimizer` for final quality hardening.
 
 Expected artifacts:
+
 - Lesson-by-lesson MarkdownFlow scripts
 - Course index and global variable table
 - Optimized lesson prompts and risk report
 
 Note:
+
 - `ai-shifu-transcript-to-lessons` already orchestrates segmentation and lesson script generation internally.
 - Do not run `ai-shifu-lesson-script-generator` again unless you are intentionally regenerating selected lessons.
 
@@ -58,6 +60,7 @@ Use when you need precise control over each stage.
 3. Run `ai-shifu-lesson-script-optimizer` to harden interaction logic and runtime stability.
 
 Expected artifacts:
+
 - Structured segmentation JSON
 - Runnable lesson MarkdownFlow scripts
 - Optimized scripts with issue-level change traceability
@@ -80,6 +83,7 @@ Skills are language-flexible for course generation. From a user perspective:
 - If you need bilingual output, set `bilingual_output: true`.
 
 Recommended controls for predictable language output:
+
 - `target_language` (for example `zh-CN`, `fr-FR`, `ja-JP`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
@@ -87,4 +91,4 @@ Recommended controls for predictable language output:
 
 ## AI-Shifu
 
-This suite is part of AI-Shifu's course authoring workflow: https://ai-shifu.com
+This suite is part of AI-Shifu's course authoring workflow: <https://ai-shifu.com>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 # AI 师傅 Skills（中文说明）
- 
+
 [English README](./README.md)
 
 本仓库聚焦 MarkdownFlow 课程制作，包含 4 个核心 skills。
@@ -41,11 +41,13 @@ skills/
 3. 运行 `ai-shifu-lesson-script-optimizer` 做最终质量加固。
 
 预期产物：
+
 - 分课节 MarkdownFlow 脚本
 - 课程索引与全局变量表
 - 优化后脚本与风险报告
 
 注意：
+
 - `ai-shifu-transcript-to-lessons` 已内置分段与脚本生成编排。
 - 除非你要定向重生成某些课节，否则不要重复运行 `ai-shifu-lesson-script-generator`。
 
@@ -58,6 +60,7 @@ skills/
 3. 运行 `ai-shifu-lesson-script-optimizer`，加固交互逻辑和运行稳定性。
 
 预期产物：
+
 - 结构化分段 JSON
 - 可运行 MarkdownFlow 课节脚本
 - 带问题级变更追踪的优化脚本
@@ -80,6 +83,7 @@ python3 scripts/validate_skill_quality.py
 - 需要双语输出时，设置 `bilingual_output: true`。
 
 建议使用以下控制项提升可预期性：
+
 - `target_language`（例如 `zh-CN`、`fr-FR`、`ja-JP`）
 - `bilingual_output`（`true|false`）
 - `term_policy`（`preserve|translate|mixed`）
@@ -87,4 +91,4 @@ python3 scripts/validate_skill_quality.py
 
 ## AI 师傅
 
-本技能套件是 AI 师傅课程创作工作流的一部分：https://ai-shifu.com
+本技能套件是 AI 师傅课程创作工作流的一部分：<https://ai-shifu.com>

--- a/skills/ai-shifu-content-segmenter/SKILL.md
+++ b/skills/ai-shifu-content-segmenter/SKILL.md
@@ -15,6 +15,7 @@ Turn messy course source material into a reliable intermediate structure for dow
 ## Language Resolution Policy
 
 Resolve target language with this strict priority:
+
 1. `explicit_output_language_request`
 2. `target_language_parameter`
 3. `session_language_preference`
@@ -23,12 +24,14 @@ Resolve target language with this strict priority:
 6. `default_fallback_language`
 
 Use these optional control fields:
+
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
 - `quote_policy` (`translate_only|original_plus_translation`)
 
 Notes:
+
 - Do not restrict supported languages to a fixed list.
 - If output language is explicit, source-language distribution must not override it.
 
@@ -50,6 +53,7 @@ Use these optional controls to improve downstream lesson quality:
 ## Segment Schema
 
 Each segment includes:
+
 - `segment_id`
 - `segment_type` (`concept`, `example`, `code`, `image`, `exercise`, `transition`)
 - `core_point`
@@ -59,11 +63,13 @@ Each segment includes:
 ## Preservation Rules
 
 Must preserve:
+
 - Code content and fence language.
 - Image URLs, alt text, and relative placement.
 - Domain terms and factual statements.
 
 Can normalize:
+
 - Speech filler.
 - Sentence breaks and punctuation.
 - Redundant transitions.
@@ -71,6 +77,7 @@ Can normalize:
 ## Transfer Signals
 
 Capture these fields for downstream teaching quality:
+
 - `learner_hook`: statements that can trigger learner reflection.
 - `evidence_type`: one of history, phenomenon, data, mechanism, or conclusion.
 - `visual_cue`: fragments suited for SVG/HTML visual support.

--- a/skills/ai-shifu-content-segmenter/references/segmentation-rules.md
+++ b/skills/ai-shifu-content-segmenter/references/segmentation-rules.md
@@ -24,6 +24,7 @@ Produce stable lesson-oriented semantic segments from noisy source material whil
 ## Transfer Signals
 
 Every segment should include transferable signals for downstream script quality:
+
 - learner hook
 - evidence type
 - visual cue

--- a/skills/ai-shifu-lesson-script-generator/SKILL.md
+++ b/skills/ai-shifu-lesson-script-generator/SKILL.md
@@ -15,6 +15,7 @@ Generate runnable MarkdownFlow scripts for each lesson.
 ## Language Resolution Policy
 
 Resolve target language with this strict priority:
+
 1. `explicit_output_language_request`
 2. `target_language_parameter`
 3. `session_language_preference`
@@ -23,12 +24,14 @@ Resolve target language with this strict priority:
 6. `default_fallback_language`
 
 Use these optional control fields:
+
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
 - `quote_policy` (`translate_only|original_plus_translation`)
 
 Output rule:
+
 - Learner-facing script text must follow resolved target language unless `bilingual_output` is true.
 
 ## Authoring Control Inputs
@@ -65,6 +68,7 @@ Use these defaults unless lesson content requires a justified variation:
 ## Single-Lesson Generation Strategy
 
 Required anchors:
+
 1. Opening objective plus visual cover.
 2. Evidence-chain explanation.
 3. At least one effective interaction with visible downstream effect.
@@ -72,6 +76,7 @@ Required anchors:
 5. Lesson close with summary or decision checkpoint.
 
 Optional modules:
+
 - Viewpoint calibration.
 - Misconception correction.
 - Dual deliverables (understanding + action).
@@ -93,23 +98,28 @@ See `references/markdownflow-spec.md`, `references/example-teaching-patterns.md`
 ## MarkdownFlow Syntax (Required)
 
 1. Variables:
+
 - Use `{{var_name}}` for references.
 - Variable names cannot contain spaces.
 - Undefined variables default to `"UNKNOWN"`.
 
 2. Interactions:
+
 - Single-select: `?[%{{var}} Option A | Option B | Option C]`
 - Multi-select: `?[%{{var}} Option A || Option B || Option C]`
 - Input: `?[%{{var}} ... enter your answer]`
 - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
 3. Segments:
+
 - Use `---` to split modules.
 - Keep one clear objective per module.
 
 4. Deterministic output:
+
 - Single-line fixed text: `===fixed text===`
 - Multi-line fixed text:
+
 ```md
 !===
 Line 1
@@ -118,6 +128,7 @@ Line 2
 ```
 
 5. Authoring principle:
+
 - Script text should guide generation behavior.
 - Avoid dumping fully polished end-learner prose as fixed output.
 
@@ -148,6 +159,7 @@ Line 2
 ## Output Structure
 
 Return per lesson:
+
 - `lesson_id`
 - `lesson_title`
 - `mdf_script`

--- a/skills/ai-shifu-lesson-script-generator/references/cognitive-teaching-techniques.md
+++ b/skills/ai-shifu-lesson-script-generator/references/cognitive-teaching-techniques.md
@@ -7,16 +7,21 @@ Increase learner understanding through targeted cognitive moves rather than info
 ## Recommended Moves
 
 1. Calibration prompt
+
 - Ask learners to make a concrete judgment before explanation.
 
 2. Boundary framing
+
 - Clarify where the concept works and where it breaks.
 
 3. Counterintuitive contrast
+
 - Introduce a surprising but valid case to deepen mental models.
 
 4. Action translation
+
 - Turn conceptual understanding into an immediately executable step.
 
 5. Reflection loop
+
 - Ask learners to compare current understanding with prior assumptions.

--- a/skills/ai-shifu-lesson-script-optimizer/SKILL.md
+++ b/skills/ai-shifu-lesson-script-optimizer/SKILL.md
@@ -15,6 +15,7 @@ Systematically improve existing MarkdownFlow teaching prompts. This skill is not
 ## Language Resolution Policy
 
 Resolve target language with this strict priority:
+
 1. `explicit_output_language_request`
 2. `target_language_parameter`
 3. `session_language_preference`
@@ -23,12 +24,14 @@ Resolve target language with this strict priority:
 6. `default_fallback_language`
 
 Use these optional control fields:
+
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
 - `quote_policy` (`translate_only|original_plus_translation`)
 
 Output rule:
+
 - Optimized learner-facing script output must follow resolved target language unless `bilingual_output` is true.
 
 ## When to Use
@@ -80,23 +83,28 @@ Output rule:
 ## MarkdownFlow Syntax (Required)
 
 1. Variables:
+
 - Use `{{var_name}}`.
 - Variable names cannot contain spaces.
 - Undefined variables default to `"UNKNOWN"`.
 
 2. Interactions:
+
 - Single-select: `?[%{{var}} Option A | Option B | Option C]`
 - Multi-select: `?[%{{var}} Option A || Option B || Option C]`
 - Input: `?[%{{var}} ... enter your answer]`
 - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
 3. Segments:
+
 - Use `---` between modules.
 - Keep one objective per module.
 
 4. Deterministic output:
+
 - Single-line fixed text: `===fixed text===`
 - Multi-line fixed text:
+
 ```md
 !===
 Line 1
@@ -105,6 +113,7 @@ Line 2
 ```
 
 5. Authoring principle:
+
 - Regular text should guide generation behavior.
 - Avoid outputting full polished article content as fixed prose.
 
@@ -115,12 +124,14 @@ See `references/methodology.md`.
 1. Define scope (single lesson vs full course).
 2. Build coverage matrix: source points -> script coverage.
 3. Label issue classes:
+
 - `coverage_gap`
 - `meaning_shift`
 - `explanation_clarity`
 - `interaction_no_branching`
 - `visual_constraints_missing`
 - `variable_or_syntax_risk`
+
 4. Apply smallest safe edits first.
 5. Run checklist validation before final output.
 6. Re-check visual-text pairing for every core concept.

--- a/skills/ai-shifu-transcript-to-lessons/SKILL.md
+++ b/skills/ai-shifu-transcript-to-lessons/SKILL.md
@@ -15,6 +15,7 @@ Convert raw course material into runnable lesson-level MarkdownFlow scripts.
 ## Language Resolution Policy
 
 Resolve target language with this strict priority:
+
 1. `explicit_output_language_request`
 2. `target_language_parameter`
 3. `session_language_preference`
@@ -23,12 +24,14 @@ Resolve target language with this strict priority:
 6. `default_fallback_language`
 
 Use these optional control fields:
+
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
 - `quote_policy` (`translate_only|original_plus_translation`)
 
 Policy constraints:
+
 - Do not limit supported languages to a predefined set.
 - If explicit language output is requested, do not let mixed-source language override it.
 
@@ -49,10 +52,12 @@ Policy constraints:
 ## Input Contract
 
 At least one of the following is required:
+
 - A single long transcript or course document.
 - Multiple topic-aligned documents with ordering metadata.
 
 Optional constraints:
+
 - Learner persona.
 - Lesson granularity (`short`, `medium`, `long`).
 - Terminology and tone preservation requirements.
@@ -64,6 +69,7 @@ See `references/input-contract.md`.
 ## Output Contract
 
 Return:
+
 - Lesson MarkdownFlow scripts (one file per lesson).
 - Course index (lesson id, title, core question, source mapping).
 - Global variable table (definition, use, cross-lesson references).
@@ -73,6 +79,7 @@ See `references/output-contract.md`.
 ## Mandatory Gates
 
 All gates must pass:
+
 - Code blocks are preserved character-by-character.
 - Image links and relative placement are preserved.
 - Each lesson resolves one core question.
@@ -102,23 +109,28 @@ See `references/preservation-rules.md` and `references/markdownflow-spec.md`.
 ## MarkdownFlow Syntax (Required)
 
 1. Variables:
+
 - Use `{{var_name}}` for variable references.
 - Variable names cannot contain spaces.
 - Undefined variables default to `"UNKNOWN"`.
 
 2. Interactions:
+
 - Single-select: `?[%{{var}} Option A | Option B | Option C]`
 - Multi-select: `?[%{{var}} Option A || Option B || Option C]`
 - Input: `?[%{{var}} ... enter your answer]`
 - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
 3. Segments:
+
 - Use `---` between segments.
 - Each segment should serve one clear instructional objective.
 
 4. Deterministic output:
+
 - Single-line fixed text: `===fixed text===`
 - Multi-line fixed text:
+
 ```md
 !===
 Line 1
@@ -127,6 +139,7 @@ Line 2
 ```
 
 5. Authoring rule:
+
 - Regular content should guide generation behavior.
 - Do not output full polished learner prose as static text.
 
@@ -139,6 +152,7 @@ Line 2
 ## Failure Handling
 
 When source quality is weak:
+
 - Deliver coarse lesson drafts first.
 - Mark uncertain spans explicitly.
 - Continue with best-effort generation instead of stopping.

--- a/skills/ai-shifu-transcript-to-lessons/references/input-contract.md
+++ b/skills/ai-shifu-transcript-to-lessons/references/input-contract.md
@@ -3,6 +3,7 @@
 ## Required
 
 Provide one of:
+
 - A single long transcript or course document.
 - A set of topic-aligned documents with intended order.
 
@@ -70,6 +71,7 @@ Provide one of:
 ## Language Resolution Priority
 
 If language signals conflict, resolve with this strict order:
+
 1. explicit output language request
 2. `target_language` parameter
 3. session language preference

--- a/skills/ai-shifu-transcript-to-lessons/references/output-contract.md
+++ b/skills/ai-shifu-transcript-to-lessons/references/output-contract.md
@@ -3,16 +3,19 @@
 ## Required Artifacts
 
 1. `lesson_mdf_scripts`
+
 - One MarkdownFlow file per lesson.
 - Learner-facing language only.
 
 2. `course_index`
+
 - `lesson_id`
 - `lesson_title`
 - `core_question`
 - `source_span_map`
 
 3. `global_variable_table`
+
 - Variable name
 - Collection point
 - Downstream usage

--- a/skills/ai-shifu-transcript-to-lessons/references/preservation-rules.md
+++ b/skills/ai-shifu-transcript-to-lessons/references/preservation-rules.md
@@ -9,11 +9,13 @@
 ## Controlled Rewriting
 
 Allowed:
+
 - Filler removal.
 - Sentence smoothing.
 - Structural reorganization for lesson clarity.
 
 Not allowed:
+
 - Silent factual changes.
 - Unmarked omission of required source evidence.
 - Variable references before collection.


### PR DESCRIPTION
## Summary
- add a minimal `.pre-commit-config.yaml`
- add a relaxed `.markdownlint.json`
- keep markdownlint enabled but disable `MD029` to avoid blocking on existing ordered-list style

## Validation
- ran `pre-commit run --all-files` successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added project-wide Markdown linting and pre-commit hooks to automate Markdown and repository-file quality checks.

* **Documentation**
  * Expanded README with expected artifacts and language-policy guidance.
  * Minor formatting tweaks to contribution and conduct guidance.
  * Enhanced multiple skill and reference docs with richer language-resolution policies, authoring controls, transfer signals, and output/validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->