### PR TITLE
fix: refactor login to non-interactive two-step flow

### DIFF
--- a/skills/ai-shifu-course-manager/SKILL.md
+++ b/skills/ai-shifu-course-manager/SKILL.md
@@ -121,13 +121,15 @@ When no valid token is available, guide the user through login:
 1. Ask the user to choose their region:
    - 1: 中国大陆用户
    - 2: 非中国大陆用户
-2. Ask for their registered phone number
-3. Send SMS code:
-   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region <cn|global>`
-4. Ask the user for the verification code they received
-5. Complete login:
-   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region <cn|global> --sms-code <code>`
-6. Token is automatically saved — proceed with the requested operation
+2. **If the user chooses 非中国大陆用户**: CLI login is not supported for this region. Tell the user to log in manually at `https://app.ai-shifu.com`, copy their token from the browser, and set it via `--token` or by adding `SHIFU_TOKEN=<token>` and `SHIFU_BASE_URL=https://app.ai-shifu.com` to `{skillDir}/.env`. Then stop — do not proceed with the SMS flow.
+3. **If the user chooses 中国大陆用户**: continue with the SMS login flow below.
+4. Ask for their registered phone number
+5. Send SMS code:
+   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region cn`
+6. Ask the user for the verification code they received
+7. Complete login:
+   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region cn --sms-code <code>`
+8. Token is automatically saved — proceed with the requested operation
 
 Always use CLI commands. Never make raw HTTP/API calls directly.
 

--- a/skills/ai-shifu-course-manager/SKILL.md
+++ b/skills/ai-shifu-course-manager/SKILL.md
@@ -40,14 +40,18 @@ python3 {skillDir}/scripts/shifu-cli.py <command>
 Run login once — the token persists in `{skillDir}/.env` for subsequent commands:
 
 ```bash
-login --phone 13800138000 --base-url https://app.ai-shifu.cn
+# Step 1: Send SMS verification code
+login --phone 13800138000 --region cn
+
+# Step 2: Complete login with the code
+login --phone 13800138000 --region cn --sms-code 123456
 ```
+
+Region options: `cn` (中国大陆, maps to `https://app.ai-shifu.cn`) or `global` (非中国大陆, maps to `https://app.ai-shifu.com`). You can also use `--base-url` to override the URL directly.
 
 Alternatively, set environment variables or CLI flags:
 - `--base-url` or `SHIFU_BASE_URL` in `.env`
 - `--token` or `SHIFU_TOKEN` in `.env`
-
-Authentication uses Cookie (`Cookie: token=<JWT>`), not Bearer. The API prefix is `/api/shifu` (not `/api/v1`).
 
 ### Query Commands
 
@@ -112,16 +116,20 @@ unarchive <shifu_bid>     # Restore archived course
 
 ### Login Flow
 
-When no valid token is available, guide the user through SMS login interactively:
+When no valid token is available, guide the user through login:
 
-1. Ask the user for their AI-Shifu registered phone number
-2. Send verification code: `POST {base_url}/api/user/send_sms_code` with `{"mobile": "<phone>"}`
-3. Ask the user to reply with the code they received
-4. Verify: `POST {base_url}/api/user/verify_sms_code` with `{"mobile": "<phone>", "sms_code": "<code>"}`
-5. Extract the JWT token from `response.data`
-6. Save the token and proceed with the requested operation
+1. Ask the user to choose their region:
+   - 1: 中国大陆用户
+   - 2: 非中国大陆用户
+2. Ask for their registered phone number
+3. Send SMS code:
+   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region <cn|global>`
+4. Ask the user for the verification code they received
+5. Complete login:
+   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region <cn|global> --sms-code <code>`
+6. Token is automatically saved — proceed with the requested operation
 
-Do not run the CLI's interactive `input()` mode. Instead, handle the login conversation yourself and pass the token to the CLI via `--token` or by writing it to `.env`.
+Always use CLI commands. Never make raw HTTP/API calls directly.
 
 ### Common Workflows
 

--- a/skills/ai-shifu-course-manager/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-manager/scripts/shifu-cli.py
@@ -17,6 +17,11 @@ from dotenv import load_dotenv, set_key
 # ── Constants ──────────────────────────────────────────────────────────────────
 ENV_FILE = Path(__file__).resolve().parent.parent / ".env"
 
+REGION_URLS = {
+    "cn": "https://app.ai-shifu.cn",
+    "global": "https://app.ai-shifu.com",
+}
+
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
 def load_env():
@@ -111,10 +116,16 @@ def fmt_time(ts):
 
 # ── Login ──────────────────────────────────────────────────────────────────────
 def cmd_login(args):
-    """SMS login and save token."""
-    base_url = (args.base_url or os.environ.get("SHIFU_BASE_URL", "")).rstrip("/")
+    """SMS login and save token (non-interactive two-step flow)."""
+    # Resolve base_url: --base-url > --region mapping > env
+    base_url = args.base_url
+    if not base_url and args.region:
+        base_url = REGION_URLS.get(args.region)
     if not base_url:
-        print("Error: --base-url is required for login")
+        base_url = os.environ.get("SHIFU_BASE_URL", "")
+    base_url = base_url.rstrip("/")
+    if not base_url:
+        print("Error: --region or --base-url is required for login")
         sys.exit(1)
 
     phone = args.phone
@@ -122,52 +133,56 @@ def cmd_login(args):
         print("Error: --phone is required for login")
         sys.exit(1)
 
-    # Step 1: Send SMS
-    print(f"Sending SMS code to {phone}...")
-    resp = requests.post(
-        f"{base_url}/api/user/send_sms_code",
-        json={"mobile": phone},
-        headers={"Content-Type": "application/json"},
-        timeout=30,
-    )
-    if not resp.ok:
-        print(f"Failed to send SMS (HTTP {resp.status_code}): {resp.text[:200]}")
-        sys.exit(1)
-    data = resp.json()
-    if data.get("code") != 0:
-        print(f"Failed to send SMS: {data}")
-        sys.exit(1)
-    print("SMS code sent. Check your phone.")
+    sms_code = args.sms_code
 
-    # Step 2: Get code from user
-    sms_code = input("Enter SMS code: ").strip()
-    if not sms_code:
-        print("No code entered.")
-        sys.exit(1)
+    if sms_code:
+        # Step 2: Verify code and save token
+        print("Verifying code...")
+        resp = requests.post(
+            f"{base_url}/api/user/verify_sms_code",
+            json={"mobile": phone, "sms_code": sms_code},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        if not resp.ok:
+            print(f"Verification failed (HTTP {resp.status_code}): {resp.text[:200]}")
+            sys.exit(1)
+        data = resp.json()
+        if data.get("code") != 0:
+            print(f"Verification failed: {data}")
+            sys.exit(1)
 
-    # Step 3: Verify
-    print("Verifying code...")
-    resp = requests.post(
-        f"{base_url}/api/user/verify_sms_code",
-        json={"mobile": phone, "sms_code": sms_code},
-        headers={"Content-Type": "application/json"},
-        timeout=30,
-    )
-    if not resp.ok:
-        print(f"Verification failed (HTTP {resp.status_code}): {resp.text[:200]}")
-        sys.exit(1)
-    data = resp.json()
-    if data.get("code") != 0:
-        print(f"Verification failed: {data}")
-        sys.exit(1)
+        token = data.get("data")
+        if not token:
+            print(f"No token in response: {data}")
+            sys.exit(1)
+        # API may return token as a dict (e.g. {"token": "..."}) or a plain string
+        if isinstance(token, dict):
+            token = token.get("token", "")
+        if not token:
+            print(f"No token string found in response data: {data}")
+            sys.exit(1)
 
-    token = data.get("data")
-    if not token:
-        print(f"No token in response: {data}")
-        sys.exit(1)
-
-    save_env(token, base_url)
-    print(f"Login successful! Token saved to {ENV_FILE}")
+        save_env(token, base_url)
+        print(f"Login successful! Token saved to {ENV_FILE}")
+    else:
+        # Step 1: Send SMS code only, then exit
+        print(f"Sending SMS code to {phone}...")
+        resp = requests.post(
+            f"{base_url}/api/user/send_sms_code",
+            json={"mobile": phone},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        if not resp.ok:
+            print(f"Failed to send SMS (HTTP {resp.status_code}): {resp.text[:200]}")
+            sys.exit(1)
+        data = resp.json()
+        if data.get("code") != 0:
+            print(f"Failed to send SMS: {data}")
+            sys.exit(1)
+        print(f"SMS code sent to {phone}. "
+              f"Run again with --sms-code <code> to complete login.")
 
 
 # ── List ───────────────────────────────────────────────────────────────────────
@@ -967,6 +982,10 @@ def build_parser():
     p = sub.add_parser("login", parents=[parent_parser],
                        help="SMS login and save token")
     p.add_argument("--phone", required=True, help="Phone number for SMS login")
+    p.add_argument("--sms-code", default=None,
+                   help="SMS verification code (skip interactive input)")
+    p.add_argument("--region", choices=["cn", "global"], default=None,
+                   help="Region: cn (中国大陆) or global (非中国大陆)")
 
     # ── list ──
     sub.add_parser("list", parents=[parent_parser], help="List all courses")

--- a/skills/ai-shifu-course-manager/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-manager/scripts/shifu-cli.py
@@ -115,8 +115,33 @@ def fmt_time(ts):
 
 
 # ── Login ──────────────────────────────────────────────────────────────────────
+def _login_post(base_url, path, payload, error_prefix):
+    """POST to a user-auth endpoint and return parsed JSON, exit on failure."""
+    resp = requests.post(
+        f"{base_url}{path}",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    if not resp.ok:
+        print(f"{error_prefix} (HTTP {resp.status_code}): {resp.text[:200]}")
+        sys.exit(1)
+    data = resp.json()
+    if data.get("code") != 0:
+        print(f"{error_prefix}: {data}")
+        sys.exit(1)
+    return data
+
+
 def cmd_login(args):
     """SMS login and save token (non-interactive two-step flow)."""
+    # Global region does not support SMS login via CLI
+    if args.region == "global":
+        print("Error: CLI login is not supported for the global region.")
+        print("Please log in manually at https://app.ai-shifu.com,")
+        print("then set SHIFU_TOKEN and SHIFU_BASE_URL in .env or use --token.")
+        sys.exit(1)
+
     # Resolve base_url: --base-url > --region mapping > env
     base_url = args.base_url
     if not base_url and args.region:
@@ -134,23 +159,13 @@ def cmd_login(args):
         sys.exit(1)
 
     sms_code = args.sms_code
+    masked = phone[:3] + "****" + phone[-4:] if len(phone) >= 7 else phone
 
     if sms_code:
         # Step 2: Verify code and save token
         print("Verifying code...")
-        resp = requests.post(
-            f"{base_url}/api/user/verify_sms_code",
-            json={"mobile": phone, "sms_code": sms_code},
-            headers={"Content-Type": "application/json"},
-            timeout=30,
-        )
-        if not resp.ok:
-            print(f"Verification failed (HTTP {resp.status_code}): {resp.text[:200]}")
-            sys.exit(1)
-        data = resp.json()
-        if data.get("code") != 0:
-            print(f"Verification failed: {data}")
-            sys.exit(1)
+        data = _login_post(base_url, "/api/user/verify_sms_code",
+                           {"mobile": phone, "sms_code": sms_code}, "Verification failed")
 
         token = data.get("data")
         if not token:
@@ -167,21 +182,10 @@ def cmd_login(args):
         print(f"Login successful! Token saved to {ENV_FILE}")
     else:
         # Step 1: Send SMS code only, then exit
-        print(f"Sending SMS code to {phone}...")
-        resp = requests.post(
-            f"{base_url}/api/user/send_sms_code",
-            json={"mobile": phone},
-            headers={"Content-Type": "application/json"},
-            timeout=30,
-        )
-        if not resp.ok:
-            print(f"Failed to send SMS (HTTP {resp.status_code}): {resp.text[:200]}")
-            sys.exit(1)
-        data = resp.json()
-        if data.get("code") != 0:
-            print(f"Failed to send SMS: {data}")
-            sys.exit(1)
-        print(f"SMS code sent to {phone}. "
+        print(f"Sending SMS code to {masked}...")
+        _login_post(base_url, "/api/user/send_sms_code",
+                    {"mobile": phone}, "Failed to send SMS")
+        print(f"SMS code sent to {masked}. "
               f"Run again with --sms-code <code> to complete login.")
 
 


### PR DESCRIPTION
## Summary
- Refactored `shifu-cli.py` login from interactive `input()` mode to a non-interactive two-step CLI flow (`--region` + `--sms-code` flags), making it compatible with agent-driven workflows
- Fixed a bug where token saving failed because the API returns token as a dict, not a plain string
- Updated `SKILL.md` to reflect the new login flow and parameter usage

## Test plan
- [x] Verified login flow end-to-end: send SMS code → receive code → complete login → token saved
- [ ] Test with `--region global` for non-CN users
- [ ] Verify other CLI commands still work with saved token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region selection (cn/global) for location-based endpoints
  * Two-step SMS verification login flow with non-interactive option (--sms-code) and --region flag
  * Automatic persistence of token and base URL to .env; env alternatives (SHIFU_BASE_URL, SHIFU_TOKEN)

* **Documentation**
  * Updated CLI-centric login docs with region-aware examples, token persistence guidance, and explicit CLI usage guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->