### PR TITLE
feat: support first-upload course/chapter lesson flow

### DIFF
--- a/skills/ai-shifu-course-manager/SKILL.md
+++ b/skills/ai-shifu-course-manager/SKILL.md
@@ -63,7 +63,9 @@ export <shifu_bid> [-o file.json]             # Export course as JSON
 
 ```bash
 create --name "Title" [--description "Desc"]                              # Create empty course
-add-lesson <shifu_bid> --name "Name" --mdf-file lesson.md [--parent-bid]  # Add single lesson
+add-chapter <shifu_bid> --name "Chapter Name"                              # Create top-level chapter
+add-lesson <shifu_bid> --name "Name" --mdf-file lesson.md --parent-bid <chapter_bid>
+                                                                          # Add lesson under a chapter
 ```
 
 ### Update Commands
@@ -125,6 +127,16 @@ Do not run the CLI's interactive `input()` mode. Instead, handle the login conve
 
 ### Common Workflows
 
+**First upload of a lesson script (no course/chapter exists yet):**
+```bash
+create --name "Course Title" --description "..."            # Create the course first
+add-chapter <shifu_bid> --name "Chapter 1"                   # Always create a chapter
+add-lesson <shifu_bid> --name "Lesson 1" --mdf-file lesson.md --parent-bid <chapter_bid>
+show <shifu_bid>                                              # Verify chapter → lesson structure
+```
+
+Rule: when the user first asks to upload a lesson script, do not write into a random existing placeholder node. Create the course, create a new chapter, then create the lesson under that chapter and upload the MDF/lesson script into that newly created lesson.
+
 **View and update a single lesson:**
 ```bash
 list                                              # Find the course BID
@@ -174,7 +186,7 @@ publish <shifu_bid>
 Key fields:
 - `llm_system_prompt`: Course-level AI role definition (from system-prompt.md)
 - `type: 401`: Regular lesson node
-- `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MDF content)
+- `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MDF content). For manual CLI creation, first create a chapter and then pass that chapter BID as `--parent-bid` when creating the lesson.
 - `content`: The MDF prompt content (this is the core teaching material)
 - `ask_enabled_status: 5101`: Enables learner questions
 

--- a/skills/ai-shifu-course-manager/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-manager/scripts/shifu-cli.py
@@ -363,6 +363,18 @@ def cmd_update_meta(args):
     print(f"Updated metadata for {shifu_bid}")
 
 
+# ── Add Chapter ────────────────────────────────────────────────────────────────
+def cmd_add_chapter(args):
+    """Add a new top-level chapter to a course."""
+    base_url, token = resolve_auth(args)
+    shifu_bid = args.shifu_bid
+
+    result = api(base_url, token, "put", f"/shifus/{shifu_bid}/outlines",
+                 json={"name": args.name})
+    outline_bid = result.get("bid") or result.get("outline_item_bid")
+    print(f"Created chapter: {outline_bid} ({args.name})")
+
+
 # ── Add Lesson ─────────────────────────────────────────────────────────────────
 def cmd_add_lesson(args):
     """Add a new lesson to a course."""
@@ -377,7 +389,8 @@ def cmd_add_lesson(args):
     result = api(base_url, token, "put", f"/shifus/{shifu_bid}/outlines",
                  json=outline_payload)
     outline_bid = result.get("bid") or result.get("outline_item_bid")
-    print(f"Created lesson: {outline_bid} ({args.name})")
+    parent_label = f" under {args.parent_bid}" if args.parent_bid else ""
+    print(f"Created lesson: {outline_bid} ({args.name}){parent_label}")
 
     # Write MDF content if provided
     if args.mdf_file:
@@ -1005,6 +1018,12 @@ def build_parser():
     p.add_argument("--system-prompt-file", default=None,
                    help="File containing system prompt")
 
+    # ── add-chapter ──
+    p = sub.add_parser("add-chapter", parents=[parent_parser],
+                       help="Add a new top-level chapter")
+    p.add_argument("shifu_bid", help="Course BID")
+    p.add_argument("--name", required=True, help="Chapter name")
+
     # ── add-lesson ──
     p = sub.add_parser("add-lesson", parents=[parent_parser],
                        help="Add a new lesson")
@@ -1012,7 +1031,7 @@ def build_parser():
     p.add_argument("--name", required=True, help="Lesson name")
     p.add_argument("--mdf-file", default=None, help="MDF content file")
     p.add_argument("--parent-bid", default=None,
-                   help="Parent outline BID (for nested structure)")
+                   help="Parent outline BID (chapter outline BID for nested structure)")
 
     # ── update-lesson ──
     p = sub.add_parser("update-lesson", parents=[parent_parser],
@@ -1099,6 +1118,7 @@ def main():
         "export": cmd_export,
         "create": cmd_create,
         "update-meta": cmd_update_meta,
+        "add-chapter": cmd_add_chapter,
         "add-lesson": cmd_add_lesson,
         "update-lesson": cmd_update_lesson,
         "rename-lesson": cmd_rename_lesson,


### PR DESCRIPTION
## 总结
-将明确的“add-chapter”命令添加到shifu-cli
-将首次上传工作流程记录为创建课程->创建章节->创建课程->上传课程脚本
-澄清代理不应在首次上传时重复使用随机占位符节点
##测试
-python3 -m py_编译技能/ai-shifu-course-manager/scripts/shifu-cli.py

##为什么
用户报告说，首次上传课程需要创建脚本课程技能，创建新的章节，然后将课程脚本放入新的课程创建中，假设不是现有的大纲是可写的。

<!--这是自动生成的评论：coderabbit.ai的发布说明-->

## CodeRabbit的摘要

* **新功能**
*添加了在课程中创建顶级章节的命令。
*更新了add-lesson命令，要求通过--parent-bid参数指定父章节。

* **文件**
*为课程、章节和课程创建添加了全面的工作流程。
*增强的CLI帮助文本，以提高命令清晰度。

<!--自动生成评论结束：coderabbit.ai的发布说明-->