### PR TITLE
docs: update CLI reference for removed import flags

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -86,6 +86,7 @@ import <shifu_bid> --json-file course.json
 import --new --json-file course.json
 
 # One-step build + import from course directory
+import <shifu_bid> --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
 import --new --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
 
 # Local build only (offline, generates shifu-import.json)

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -85,15 +85,14 @@ delete-lesson <shifu_bid> <outline_bid>
 import <shifu_bid> --json-file course.json
 import --new --json-file course.json
 
-# Nested import (chapter -> lesson structure)
-import <shifu_bid> --structure structure.json --lessons-dir ./lessons/
-import --new --structure structure.json --lessons-dir ./lessons/
+# One-step build + import from course directory
+import --new --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
 
-# Local build (offline, generates shifu-import.json)
+# Local build only (offline, generates shifu-import.json)
 build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--chapter-name "..."]
 ```
 
-The `build` command works entirely offline — it reads local MDF files and produces `shifu-import.json` without any network calls.
+The `build` command works entirely offline — it reads local MDF files and produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step.
 
 Build behavior:
 - **Course title** resolution order: `--title` CLI arg -> first heading in `README.md` -> directory name


### PR DESCRIPTION
## Summary
- Replace deprecated `--structure`/`--lessons-dir` examples with new `--course-dir` usage in CLI reference docs
- Follow-up to #10 which removed these flags from the parser

## Test plan
- [ ] Verify `cli-reference.md` accurately reflects current `import` subcommand options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * One-step import workflow via new `--course-dir` option combining build and import operations.
  * Improved course and lesson title resolution logic with explicit priority ordering.

* **Documentation**
  * Comprehensive CLI reference updates detailing build behavior, title resolution order, and chapter/lesson structure generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->