### PR TITLE
fix: close unclosed parenthesis and remove .env.example

### DIFF
--- a/skills/ai-shifu-course-creator/.env.example
+++ b/skills/ai-shifu-course-creator/.env.example
@@ -1,6 +1,0 @@
-# AI-Shifu Deployer Configuration
-# Copy this file to .env and fill in values
-# The .env file is gitignored and will not be committed
-
-SHIFU_TOKEN=
-SHIFU_BASE_URL=

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -533,7 +533,7 @@ def _import_flat(base_url, token, json_file, shifu_bid):
         "tts_pitch": 0,
         "tts_emotion": "",
         "use_learner_language": False,
-    }
+    })
     for attempt in range(1, 4):
         result = api_safe(base_url, token, "post", f"/shifus/{shifu_bid}/detail",
                           json=detail_payload)


### PR DESCRIPTION
## Summary
- Fixed syntax error in `shifu-cli.py`: `detail_payload.update({...}` was missing closing `)`, causing the entire CLI to fail
- Removed `.env.example` as it is no longer needed

## Test plan
- [ ] Run `python3 shifu-cli.py login --phone <phone> --region cn` to verify CLI no longer crashes
- [ ] Run `python3 shifu-cli.py list` to verify import flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)