### PR TITLE
docs: rename MDF references to MarkdownFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use when you want the fastest route from raw material to a live deployed course.
 3. Run Phase 5 to build, import, and publish to the AI-Shifu platform.
 
 Expected artifacts:
+
 - Structured segmentation
 - Lesson-by-lesson MarkdownFlow scripts
 - Course index and global variable table
@@ -43,16 +44,17 @@ Expected artifacts:
 
 ### Path B: Author Only
 
-Use when you need optimized MDF scripts without deploying. Sub-paths:
+Use when you need optimized MarkdownFlow scripts without deploying. Sub-paths:
+
 - **Segment only**: Phase 1 for semantic segments and manual review.
 - **Generate only**: Phase 3 on pre-existing segments.
 - **Optimize only**: Phase 4 to audit and improve existing scripts.
 
 ### Path C: Deploy Only
 
-Use when you have pre-existing MDF files ready to deploy:
+Use when you have pre-existing MarkdownFlow files ready to deploy:
 
-1. Organize MDF files in a course directory.
+1. Organize MarkdownFlow files in a course directory.
 2. Run `build --course-dir ./course-a/` to generate the import file.
 3. Run `import --new --json-file ./course-a/shifu-import.json` to create the course.
 4. Run `publish <shifu_bid>` to make it live.
@@ -78,6 +80,7 @@ Skills are language-flexible for course generation. From a user perspective:
 - If you need bilingual output, set `bilingual_output: true`.
 
 Recommended controls for predictable language output:
+
 - `target_language` (for example `zh-CN`, `fr-FR`, `ja-JP`)
 - `bilingual_output` (`true|false`)
 - `term_policy` (`preserve|translate|mixed`)
@@ -85,4 +88,4 @@ Recommended controls for predictable language output:
 
 ## AI-Shifu
 
-This suite is part of AI-Shifu's course authoring workflow: https://ai-shifu.com
+This suite is part of AI-Shifu's course authoring workflow: <https://ai-shifu.com>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@ skill 以 `SKILL.md` 作为行为定义。
 3. 运行 Phase 5 构建、导入并发布到 AI 师傅平台。
 
 预期产物：
+
 - 结构化分段
 - 分课节 MarkdownFlow 脚本
 - 课程索引与全局变量表
@@ -43,16 +44,17 @@ skill 以 `SKILL.md` 作为行为定义。
 
 ### 路径 B：仅创作
 
-适合只需要优化后 MDF 脚本而不部署的场景。子路径：
+适合只需要优化后 MarkdownFlow 脚本而不部署的场景。子路径：
+
 - **仅分段**：Phase 1 生成语义分段供人工审核。
 - **仅生成**：Phase 3 基于已有分段生成课节脚本。
 - **仅优化**：Phase 4 审计并改进现有脚本。
 
 ### 路径 C：仅部署
 
-适合已有 MDF 文件需要部署的场景：
+适合已有 MarkdownFlow 文件需要部署的场景：
 
-1. 将 MDF 文件组织到课程目录中。
+1. 将 MarkdownFlow 文件组织到课程目录中。
 2. 运行 `build --course-dir ./course-a/` 生成导入文件。
 3. 运行 `import --new --json-file ./course-a/shifu-import.json` 创建课程。
 4. 运行 `publish <shifu_bid>` 发布上线。
@@ -78,6 +80,7 @@ python3 scripts/validate_skill_quality.py
 - 需要双语输出时，设置 `bilingual_output: true`。
 
 建议使用以下控制项提升可预期性：
+
 - `target_language`（例如 `zh-CN`、`fr-FR`、`ja-JP`）
 - `bilingual_output`（`true|false`）
 - `term_policy`（`preserve|translate|mixed`）
@@ -85,4 +88,4 @@ python3 scripts/validate_skill_quality.py
 
 ## AI 师傅
 
-本技能套件是 AI 师傅课程创作工作流的一部分：https://ai-shifu.com
+本技能套件是 AI 师傅课程创作工作流的一部分：<https://ai-shifu.com>

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -61,14 +61,14 @@ Run all five phases from raw material to a live deployed course.
 
 ### Path B: Author Only
 
-Run Phase 1–4 to produce optimized MDF scripts without deploying. Sub-paths:
+Run Phase 1–4 to produce optimized MarkdownFlow scripts without deploying. Sub-paths:
 - **Segment only**: Phase 1 alone for structured segments and manual review.
 - **Generate only**: Phase 3 alone on pre-existing segments to produce lesson scripts.
 - **Optimize only**: Phase 4 alone to audit and improve existing MarkdownFlow scripts.
 
 ### Path C: Deploy Only
 
-Run Phase 5 alone to deploy pre-existing MDF files to the AI-Shifu platform.
+Run Phase 5 alone to deploy pre-existing MarkdownFlow files to the AI-Shifu platform.
 
 ### Path D: Manage Existing
 
@@ -383,7 +383,7 @@ See `references/review-checklist.md`.
 
 ## Phase 5: Deployment
 
-Deploy optimized MDF lesson scripts to the AI-Shifu platform as live courses.
+Deploy optimized MarkdownFlow lesson scripts to the AI-Shifu platform as live courses.
 
 ### Prerequisites
 
@@ -403,7 +403,7 @@ Always use CLI commands. Never make raw HTTP/API calls directly.
 
 ### Course Directory
 
-MDF lesson scripts must be organized in a course directory before deployment. See `references/course-directory-spec.md` for the full specification.
+MarkdownFlow lesson scripts must be organized in a course directory before deployment. See `references/course-directory-spec.md` for the full specification.
 
 When continuing from Phase 4 (Path A), write optimized scripts into the course directory structure automatically.
 
@@ -430,7 +430,7 @@ See `references/cli-reference.md` for the complete command reference and `refere
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
-1. Ensure course directory is ready with MDF files.
+1. Ensure course directory is ready with MarkdownFlow files.
 2. Run `build`, `import`, `publish` as above.
 
 ### Common Management
@@ -454,7 +454,7 @@ archive <shifu_bid>
 After any deployment or management operation, verify the result:
 1. Admin console: `https://app.ai-shifu.cn/shifu/<shifu_bid>` (cn) or `https://app.ai-shifu.com/shifu/<shifu_bid>` (global)
 2. Preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true`
-3. Check each lesson's MDF content, variable collection, and interaction logic.
+3. Check each lesson's MarkdownFlow content, variable collection, and interaction logic.
 
 ### Phase 5 Validation
 

--- a/skills/ai-shifu-course-creator/examples/deploy-only.md
+++ b/skills/ai-shifu-course-creator/examples/deploy-only.md
@@ -1,10 +1,10 @@
 # Deploy Only Example (Phase 5)
 
-Deploy pre-existing MDF files without running the authoring pipeline.
+Deploy pre-existing MarkdownFlow files without running the authoring pipeline.
 
 ## Prerequisites
 
-A course directory with MDF lesson files already prepared:
+A course directory with MarkdownFlow lesson files already prepared:
 
 ```
 my-course/
@@ -51,5 +51,5 @@ python3 {skillDir}/scripts/shifu-cli.py archive xyz789
 ## Acceptance Notes
 
 - Phase 5 executed independently (Path C).
-- Course deployed from pre-existing MDF files.
+- Course deployed from pre-existing MarkdownFlow files.
 - Management commands used for ongoing operations (Path D).

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -22,7 +22,7 @@
 
 ## Phase 1–4 (Author)
 
-Produces optimized MDF lesson scripts (see `pipeline-full.md` for detailed output).
+Produces optimized MarkdownFlow lesson scripts (see `pipeline-full.md` for detailed output).
 
 ## Phase 5 Output (Deployment)
 
@@ -63,11 +63,12 @@ python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 ```
 
 Platform URLs:
+
 - Admin: `https://app.ai-shifu.cn/shifu/abc123-def456`
 - Preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`
 
 ## Acceptance Notes
 
 - All five phases executed end-to-end.
-- MDF files written to course directory, built, imported, and published.
+- MarkdownFlow files written to course directory, built, imported, and published.
 - Course is live and accessible via platform URL.

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -21,6 +21,7 @@ login --phone 13800138000 --region cn --sms-code 123456
 Region options: `cn` (maps to `https://app.ai-shifu.cn`) or `global` (maps to `https://app.ai-shifu.com`). You can also use `--base-url` to override the URL directly.
 
 Alternatively, set environment variables or CLI flags:
+
 - `--base-url` or `SHIFU_BASE_URL` in `.env`
 - `--token` or `SHIFU_TOKEN` in `.env`
 
@@ -48,8 +49,8 @@ Always use CLI commands. Never make raw HTTP/API calls directly.
 ```bash
 list                                          # List all courses
 show <shifu_bid>                              # Show course details + outline tree
-show <shifu_bid> <outline_bid>                # Read a lesson's MDF content
-history <shifu_bid> <outline_bid>             # MDF revision history
+show <shifu_bid> <outline_bid>                # Read a lesson's MarkdownFlow content
+history <shifu_bid> <outline_bid>             # MarkdownFlow revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
@@ -93,12 +94,13 @@ import --new --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
 build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--chapter-name "..."]
 ```
 
-The `build` command works entirely offline — it reads local MDF files and produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step.
+The `build` command works entirely offline — it reads local MarkdownFlow files and produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step.
 
 Build behavior:
+
 - **Course title** resolution order: `--title` CLI arg -> first heading in `README.md` -> directory name
 - **Chapter structure**: if `structure.json` exists, generates multi-chapter structure per its definition; otherwise creates a single chapter (named via `--chapter-name` or defaults to course title) containing all `lesson-*.md` files in sorted order
-- **Lesson title** resolution order: `title` field in `structure.json` -> `lesson_title: ...` line in MDF content -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
+- **Lesson title** resolution order: `title` field in `structure.json` -> `lesson_title: ...` line in MarkdownFlow content -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
 
 ## State Management
 

--- a/skills/ai-shifu-course-creator/references/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/course-directory-spec.md
@@ -9,7 +9,7 @@
   shifu-import.json    # Generated import file (output of build)
   structure.json       # Chapter structure (optional, for multi-chapter courses)
   lessons/
-    lesson-01.md       # MDF lesson file
+    lesson-01.md       # MarkdownFlow lesson file
     lesson-02.md
     ...
 ```
@@ -22,7 +22,7 @@ When `structure.json` is not present, `build` auto-discovers only `lesson-*.md` 
 
 Defines the AI engine's role, teaching style, and interaction rules at the course level. The `build` command reads this file and populates `shifu.llm_system_prompt` automatically.
 
-Note: MDF files do not support HTML comments (`<!-- -->`). The parser discards them entirely, so the AI engine never sees them. Write instructions as plain text directly in the MDF content.
+Note: MarkdownFlow files do not support HTML comments (`<!-- -->`). The parser discards them entirely, so the AI engine never sees them. Write instructions as plain text directly in the MarkdownFlow content.
 
 ## structure.json
 
@@ -45,7 +45,8 @@ Schema:
 ```
 
 Field reference:
+
 - `chapters[].title` (required): Chapter display name
 - `chapters[].lessons[]` (required): Array of lesson objects
 - `chapters[].lessons[].file` (required): Filename in the `lessons/` directory (must exist)
-- `chapters[].lessons[].title` (optional): Lesson display name. If omitted, auto-extracted from MDF content (`lesson_title: ...` line) or derived from filename
+- `chapters[].lessons[].title` (optional): Lesson display name. If omitted, auto-extracted from MarkdownFlow content (`lesson_title: ...` line) or derived from filename

--- a/skills/ai-shifu-course-creator/references/import-json-format.md
+++ b/skills/ai-shifu-course-creator/references/import-json-format.md
@@ -25,7 +25,7 @@ The `build` command generates a `shifu-import.json` file that can be imported to
       "type": 401,
       "parent_bid": "",
       "position": "0",
-      "content": "<MDF content>"
+      "content": "<MarkdownFlow content>"
     }
   ],
   "structure": { "bid": "<shifu_bid>", "type": "shifu", "children": [] }
@@ -36,6 +36,6 @@ The `build` command generates a `shifu-import.json` file that can be imported to
 
 - `llm_system_prompt`: Course-level AI role definition (from `system-prompt.md`)
 - `type: 401`: Regular lesson node
-- `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MDF content). Use `add-chapter` to create chapters, then pass the chapter BID as `--parent-bid` when creating lessons
-- `content`: The MDF prompt content (this is the core teaching material)
+- `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MarkdownFlow content). Use `add-chapter` to create chapters, then pass the chapter BID as `--parent-bid` when creating lessons
+- `content`: The MarkdownFlow prompt content (this is the core teaching material)
 - `ask_enabled_status: 5101`: Enables learner questions

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -228,17 +228,14 @@ def cmd_show(args):
         # Show MarkdownFlow content for a specific lesson
         result = api(base_url, token, "get",
                      f"/shifus/{shifu_bid}/outlines/{outline_bid}/mdflow")
-        content = result.get("data", "") if isinstance(
-            result, dict) else result
-        revision = result.get("revision", "") if isinstance(
-            result, dict) else ""
+        content = result.get("data", "") if isinstance(result, dict) else result
+        revision = result.get("revision", "") if isinstance(result, dict) else ""
         if revision:
             print(f"# Revision: {revision}\n")
         print(content)
     else:
         # Show course detail + outline tree
-        detail = api_safe(base_url, token, "get",
-                          f"/shifus/{shifu_bid}/detail")
+        detail = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/detail")
         if detail:
             print(f"Course: {detail.get('name', '')}")
             print(f"BID:    {shifu_bid}")
@@ -364,7 +361,7 @@ def cmd_update_meta(args):
     payload = {
         "name": args.name if args.name is not None else current.get("name", ""),
         "description": args.description if args.description is not None
-        else current.get("description", ""),
+                       else current.get("description", ""),
         "avatar": current.get("avatar", ""),
         "keywords": keywords,
         "model": current.get("model", ""),
@@ -397,10 +394,8 @@ def cmd_add_chapter(args):
                  json={"name": args.name})
     outline_bid = result.get("bid") or result.get("outline_item_bid")
     if not outline_bid:
-        print(f"Error: chapter created but response did not include a BID",
-              file=sys.stderr)
-        print(
-            f"  Response: {json.dumps(result, ensure_ascii=False)}", file=sys.stderr)
+        print(f"Error: chapter created but response did not include a BID", file=sys.stderr)
+        print(f"  Response: {json.dumps(result, ensure_ascii=False)}", file=sys.stderr)
         sys.exit(1)
     print(f"Created chapter: {outline_bid} ({args.name})")
 
@@ -546,8 +541,7 @@ def _import_flat(base_url, token, json_file, shifu_bid):
             print("  Updated shifu detail")
             break
         if attempt < 3:
-            print(
-                f"  Warning: failed to update shifu detail (attempt {attempt}/3), retrying...")
+            print(f"  Warning: failed to update shifu detail (attempt {attempt}/3), retrying...")
             time.sleep(1)
         else:
             print("Error: failed to update shifu detail after 3 attempts")
@@ -562,18 +556,15 @@ def _import_flat(base_url, token, json_file, shifu_bid):
                     result = api_safe(base_url, token, "delete",
                                       f"/shifus/{shifu_bid}/outlines/{child['bid']}")
                     if result is None:
-                        print(
-                            f"Error: failed to delete child outline: {child['bid']}")
+                        print(f"Error: failed to delete child outline: {child['bid']}")
                         sys.exit(1)
             if item.get("bid"):
                 result = api_safe(base_url, token, "delete",
                                   f"/shifus/{shifu_bid}/outlines/{item['bid']}")
                 if result is None:
-                    print(
-                        f"Error: failed to delete outline: {item.get('name', item['bid'])}")
+                    print(f"Error: failed to delete outline: {item.get('name', item['bid'])}")
                     sys.exit(1)
-                print(
-                    f"  Deleted old outline: {item.get('name', item['bid'])}")
+                print(f"  Deleted old outline: {item.get('name', item['bid'])}")
 
     # Separate parents (chapters) and children (lessons) for two-pass creation
     parents = []
@@ -767,8 +758,7 @@ def _build_import_json(course_dir, title=None, description=None,
                     content = f.read()
 
                 item_bid = str(uuid.uuid4()).replace("-", "")
-                ls_title = ls_def.get(
-                    "title") or _extract_lesson_title(content, ls_file)
+                ls_title = ls_def.get("title") or _extract_lesson_title(content, ls_file)
 
                 outline_items.append({
                     "outline_item_bid": item_bid,
@@ -936,8 +926,7 @@ def cmd_archive(args):
 def cmd_unarchive(args):
     """Unarchive a course."""
     base_url, token = resolve_auth(args)
-    api(base_url, token, "post",
-        f"/shifus/{args.shifu_bid}/unarchive", json={})
+    api(base_url, token, "post", f"/shifus/{args.shifu_bid}/unarchive", json={})
     print(f"Unarchived: {args.shifu_bid}")
 
 
@@ -987,8 +976,7 @@ def build_parser():
     p = sub.add_parser("export", parents=[parent_parser],
                        help="Export course to JSON")
     p.add_argument("shifu_bid", help="Course BID")
-    p.add_argument("-o", "--output", default=None,
-                   help="Output file (stdout if omitted)")
+    p.add_argument("-o", "--output", default=None, help="Output file (stdout if omitted)")
 
     # ── create ──
     p = sub.add_parser("create", parents=[parent_parser],
@@ -1016,8 +1004,7 @@ def build_parser():
                        help="Add a new lesson under a chapter")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--name", required=True, help="Lesson name")
-    p.add_argument("--mdf-file", default=None,
-                   help="MarkdownFlow content file")
+    p.add_argument("--mdf-file", default=None, help="MarkdownFlow content file")
     p.add_argument("--parent-bid", required=True,
                    help="Parent chapter BID (use add-chapter to create one first)")
 
@@ -1026,8 +1013,7 @@ def build_parser():
                        help="Update lesson MarkdownFlow content")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("outline_bid", help="Outline BID")
-    p.add_argument("--mdf-file", required=True,
-                   help="MarkdownFlow content file")
+    p.add_argument("--mdf-file", required=True, help="MarkdownFlow content file")
 
     # ── rename-lesson ──
     p = sub.add_parser("rename-lesson", parents=[parent_parser],
@@ -1069,8 +1055,7 @@ def build_parser():
                    help="Chapter name (only with --course-dir)")
 
     # ── build ──
-    p = sub.add_parser(
-        "build", help="Build import JSON from local course directory")
+    p = sub.add_parser("build", help="Build import JSON from local course directory")
     p.add_argument("--course-dir", required=True, help="Course directory path")
     p.add_argument("-o", "--output", default=None,
                    help="Output file (default: <course-dir>/shifu-import.json)")
@@ -1078,8 +1063,7 @@ def build_parser():
     p.add_argument("--chapter-name", default=None,
                    help="Chapter name (default: same as course title)")
     p.add_argument("--description", default=None, help="Course description")
-    p.add_argument("--keywords", default=None,
-                   help="Keywords (comma-separated)")
+    p.add_argument("--keywords", default=None, help="Keywords (comma-separated)")
 
     # ── publish ──
     p = sub.add_parser("publish", parents=[parent_parser],

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -44,8 +44,7 @@ def save_env(token, base_url=None):
 
 def resolve_auth(args):
     """Resolve base_url and token from CLI args or .env, exit on failure."""
-    base_url = getattr(args, "base_url", None) or os.environ.get(
-        "SHIFU_BASE_URL")
+    base_url = getattr(args, "base_url", None) or os.environ.get("SHIFU_BASE_URL")
     if not base_url:
         print("Error: --base-url is required (or set SHIFU_BASE_URL in .env)")
         sys.exit(1)

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -44,7 +44,8 @@ def save_env(token, base_url=None):
 
 def resolve_auth(args):
     """Resolve base_url and token from CLI args or .env, exit on failure."""
-    base_url = getattr(args, "base_url", None) or os.environ.get("SHIFU_BASE_URL")
+    base_url = getattr(args, "base_url", None) or os.environ.get(
+        "SHIFU_BASE_URL")
     if not base_url:
         print("Error: --base-url is required (or set SHIFU_BASE_URL in .env)")
         sys.exit(1)
@@ -219,23 +220,26 @@ def cmd_list(args):
 
 # ── Show ───────────────────────────────────────────────────────────────────────
 def cmd_show(args):
-    """Show course detail / outline tree / MDF content."""
+    """Show course detail / outline tree / MarkdownFlow content."""
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
     outline_bid = args.outline_bid
 
     if outline_bid:
-        # Show MDF content for a specific lesson
+        # Show MarkdownFlow content for a specific lesson
         result = api(base_url, token, "get",
                      f"/shifus/{shifu_bid}/outlines/{outline_bid}/mdflow")
-        content = result.get("data", "") if isinstance(result, dict) else result
-        revision = result.get("revision", "") if isinstance(result, dict) else ""
+        content = result.get("data", "") if isinstance(
+            result, dict) else result
+        revision = result.get("revision", "") if isinstance(
+            result, dict) else ""
         if revision:
             print(f"# Revision: {revision}\n")
         print(content)
     else:
         # Show course detail + outline tree
-        detail = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/detail")
+        detail = api_safe(base_url, token, "get",
+                          f"/shifus/{shifu_bid}/detail")
         if detail:
             print(f"Course: {detail.get('name', '')}")
             print(f"BID:    {shifu_bid}")
@@ -268,7 +272,7 @@ def cmd_show(args):
 
 # ── History ────────────────────────────────────────────────────────────────────
 def cmd_history(args):
-    """Show MDF revision history for a lesson."""
+    """Show MarkdownFlow revision history for a lesson."""
     base_url, token = resolve_auth(args)
     result = api(base_url, token, "get",
                  f"/shifus/{args.shifu_bid}/outlines/{args.outline_bid}/mdflow/history")
@@ -361,7 +365,7 @@ def cmd_update_meta(args):
     payload = {
         "name": args.name if args.name is not None else current.get("name", ""),
         "description": args.description if args.description is not None
-                       else current.get("description", ""),
+        else current.get("description", ""),
         "avatar": current.get("avatar", ""),
         "keywords": keywords,
         "model": current.get("model", ""),
@@ -394,8 +398,10 @@ def cmd_add_chapter(args):
                  json={"name": args.name})
     outline_bid = result.get("bid") or result.get("outline_item_bid")
     if not outline_bid:
-        print(f"Error: chapter created but response did not include a BID", file=sys.stderr)
-        print(f"  Response: {json.dumps(result, ensure_ascii=False)}", file=sys.stderr)
+        print(f"Error: chapter created but response did not include a BID",
+              file=sys.stderr)
+        print(
+            f"  Response: {json.dumps(result, ensure_ascii=False)}", file=sys.stderr)
         sys.exit(1)
     print(f"Created chapter: {outline_bid} ({args.name})")
 
@@ -417,19 +423,19 @@ def cmd_add_lesson(args):
     parent_label = f" under {args.parent_bid}" if args.parent_bid else ""
     print(f"Created lesson: {outline_bid} ({args.name}){parent_label}")
 
-    # Write MDF content if provided
+    # Write MarkdownFlow content if provided
     if args.mdf_file:
         with open(args.mdf_file, "r", encoding="utf-8") as f:
             content = f.read()
         api(base_url, token, "post",
             f"/shifus/{shifu_bid}/outlines/{outline_bid}/mdflow",
             json={"data": content})
-        print(f"  MDF saved ({len(content)} chars)")
+        print(f"  MarkdownFlow saved ({len(content)} chars)")
 
 
 # ── Update Lesson ──────────────────────────────────────────────────────────────
 def cmd_update_lesson(args):
-    """Update MDF content for an existing lesson (with optimistic locking)."""
+    """Update MarkdownFlow content for an existing lesson (with optimistic locking)."""
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
     outline_bid = args.outline_bid
@@ -541,7 +547,8 @@ def _import_flat(base_url, token, json_file, shifu_bid):
             print("  Updated shifu detail")
             break
         if attempt < 3:
-            print(f"  Warning: failed to update shifu detail (attempt {attempt}/3), retrying...")
+            print(
+                f"  Warning: failed to update shifu detail (attempt {attempt}/3), retrying...")
             time.sleep(1)
         else:
             print("Error: failed to update shifu detail after 3 attempts")
@@ -556,15 +563,18 @@ def _import_flat(base_url, token, json_file, shifu_bid):
                     result = api_safe(base_url, token, "delete",
                                       f"/shifus/{shifu_bid}/outlines/{child['bid']}")
                     if result is None:
-                        print(f"Error: failed to delete child outline: {child['bid']}")
+                        print(
+                            f"Error: failed to delete child outline: {child['bid']}")
                         sys.exit(1)
             if item.get("bid"):
                 result = api_safe(base_url, token, "delete",
                                   f"/shifus/{shifu_bid}/outlines/{item['bid']}")
                 if result is None:
-                    print(f"Error: failed to delete outline: {item.get('name', item['bid'])}")
+                    print(
+                        f"Error: failed to delete outline: {item.get('name', item['bid'])}")
                     sys.exit(1)
-                print(f"  Deleted old outline: {item.get('name', item['bid'])}")
+                print(
+                    f"  Deleted old outline: {item.get('name', item['bid'])}")
 
     # Separate parents (chapters) and children (lessons) for two-pass creation
     parents = []
@@ -597,7 +607,7 @@ def _import_flat(base_url, token, json_file, shifu_bid):
             api(base_url, token, "post",
                 f"/shifus/{shifu_bid}/outlines/{new_bid}/mdflow",
                 json={"data": content})
-            print(f"    MDF saved ({len(content)} chars)")
+            print(f"    MarkdownFlow saved ({len(content)} chars)")
 
         created.append({"bid": new_bid, "title": title})
         time.sleep(0.3)
@@ -619,7 +629,7 @@ def _import_flat(base_url, token, json_file, shifu_bid):
             api(base_url, token, "post",
                 f"/shifus/{shifu_bid}/outlines/{new_bid}/mdflow",
                 json={"data": content})
-            print(f"    MDF saved ({len(content)} chars)")
+            print(f"    MarkdownFlow saved ({len(content)} chars)")
 
         created.append({"bid": new_bid, "title": title})
         time.sleep(0.3)
@@ -726,7 +736,7 @@ def _build_import_json(course_dir, title=None, description=None,
             ch_bid = str(uuid.uuid4()).replace("-", "")
             ch_title = ch_def["title"]
 
-            # Chapter item (container, no MDF content)
+            # Chapter item (container, no MarkdownFlow content)
             outline_items.append({
                 "outline_item_bid": ch_bid,
                 "title": ch_title,
@@ -758,7 +768,8 @@ def _build_import_json(course_dir, title=None, description=None,
                     content = f.read()
 
                 item_bid = str(uuid.uuid4()).replace("-", "")
-                ls_title = ls_def.get("title") or _extract_lesson_title(content, ls_file)
+                ls_title = ls_def.get(
+                    "title") or _extract_lesson_title(content, ls_file)
 
                 outline_items.append({
                     "outline_item_bid": item_bid,
@@ -793,7 +804,7 @@ def _build_import_json(course_dir, title=None, description=None,
         chapter_bid = str(uuid.uuid4()).replace("-", "")
         chapter_title = chapter_name or title
 
-        # Chapter item (container, no MDF content)
+        # Chapter item (container, no MarkdownFlow content)
         outline_items.append({
             "outline_item_bid": chapter_bid,
             "title": chapter_title,
@@ -926,7 +937,8 @@ def cmd_archive(args):
 def cmd_unarchive(args):
     """Unarchive a course."""
     base_url, token = resolve_auth(args)
-    api(base_url, token, "post", f"/shifus/{args.shifu_bid}/unarchive", json={})
+    api(base_url, token, "post",
+        f"/shifus/{args.shifu_bid}/unarchive", json={})
     print(f"Unarchived: {args.shifu_bid}")
 
 
@@ -961,14 +973,14 @@ def build_parser():
 
     # ── show ──
     p = sub.add_parser("show", parents=[parent_parser],
-                       help="Show course detail or lesson MDF content")
+                       help="Show course detail or lesson MarkdownFlow content")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("outline_bid", nargs="?", default=None,
                    help="Outline BID (omit to show tree)")
 
     # ── history ──
     p = sub.add_parser("history", parents=[parent_parser],
-                       help="Show MDF revision history")
+                       help="Show MarkdownFlow revision history")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("outline_bid", help="Outline BID")
 
@@ -976,7 +988,8 @@ def build_parser():
     p = sub.add_parser("export", parents=[parent_parser],
                        help="Export course to JSON")
     p.add_argument("shifu_bid", help="Course BID")
-    p.add_argument("-o", "--output", default=None, help="Output file (stdout if omitted)")
+    p.add_argument("-o", "--output", default=None,
+                   help="Output file (stdout if omitted)")
 
     # ── create ──
     p = sub.add_parser("create", parents=[parent_parser],
@@ -1004,16 +1017,18 @@ def build_parser():
                        help="Add a new lesson under a chapter")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--name", required=True, help="Lesson name")
-    p.add_argument("--mdf-file", default=None, help="MDF content file")
+    p.add_argument("--mdf-file", default=None,
+                   help="MarkdownFlow content file")
     p.add_argument("--parent-bid", required=True,
                    help="Parent chapter BID (use add-chapter to create one first)")
 
     # ── update-lesson ──
     p = sub.add_parser("update-lesson", parents=[parent_parser],
-                       help="Update lesson MDF content")
+                       help="Update lesson MarkdownFlow content")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("outline_bid", help="Outline BID")
-    p.add_argument("--mdf-file", required=True, help="MDF content file")
+    p.add_argument("--mdf-file", required=True,
+                   help="MarkdownFlow content file")
 
     # ── rename-lesson ──
     p = sub.add_parser("rename-lesson", parents=[parent_parser],
@@ -1055,7 +1070,8 @@ def build_parser():
                    help="Chapter name (only with --course-dir)")
 
     # ── build ──
-    p = sub.add_parser("build", help="Build import JSON from local course directory")
+    p = sub.add_parser(
+        "build", help="Build import JSON from local course directory")
     p.add_argument("--course-dir", required=True, help="Course directory path")
     p.add_argument("-o", "--output", default=None,
                    help="Output file (default: <course-dir>/shifu-import.json)")
@@ -1063,7 +1079,8 @@ def build_parser():
     p.add_argument("--chapter-name", default=None,
                    help="Chapter name (default: same as course title)")
     p.add_argument("--description", default=None, help="Course description")
-    p.add_argument("--keywords", default=None, help="Keywords (comma-separated)")
+    p.add_argument("--keywords", default=None,
+                   help="Keywords (comma-separated)")
 
     # ── publish ──
     p = sub.add_parser("publish", parents=[parent_parser],


### PR DESCRIPTION
## Summary
- rename user-facing MDF terminology to MarkdownFlow across docs and examples
- update CLI help text and status messages to use MarkdownFlow wording
- keep existing API paths and option names intact for compatibility

## Validation
- python3 -m py_compile skills/ai-shifu-course-creator/scripts/shifu-cli.py
- /tmp/ai-shifu-cli-venv/bin/python skills/ai-shifu-course-creator/scripts/shifu-cli.py --help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced "MDF" with "MarkdownFlow" across guides, examples, CLI and spec docs.
  * Improved Markdown spacing and readability in multiple docs.
  * Normalized hyperlink formatting.

* **CLI Updates**
  * Updated user-facing help text and output messages to use "MarkdownFlow" terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->