### PR TITLE
[codex] add lesson preview URL guidance

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -416,6 +416,7 @@ build --course-dir ./course-a/                          # Build shifu-import.jso
 import --new --json-file ./course-a/shifu-import.json   # Import as new course
 publish <shifu_bid>                                      # Make course live
 show <shifu_bid>                                         # Verify course structure
+show <shifu_bid> <outline_bid>                           # Read a specific lesson
 ```
 
 See `references/cli-reference.md` for the complete command reference and `references/import-json-format.md` for the JSON schema.
@@ -453,8 +454,9 @@ archive <shifu_bid>
 
 After any deployment or management operation, verify the result:
 1. Admin console: `https://app.ai-shifu.cn/shifu/<shifu_bid>` (cn) or `https://app.ai-shifu.com/shifu/<shifu_bid>` (global)
-2. Preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true`
-3. Check each lesson's MarkdownFlow content, variable collection, and interaction logic.
+2. Course preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true` (cn) or `https://app.ai-shifu.com/c/<shifu_bid>?preview=true` (global)
+3. Lesson preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>` (cn) or `https://app.ai-shifu.com/c/<shifu_bid>?preview=true&lessonid=<outline_bid>` (global)
+4. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's MarkdownFlow content, variable collection, and interaction logic.
 
 ### Phase 5 Validation
 

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -65,7 +65,8 @@ python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 Platform URLs:
 
 - Admin: `https://app.ai-shifu.cn/shifu/abc123-def456`
-- Preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`
+- Course preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`
+- Lesson preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true&lessonid=<outline_bid>`
 
 ## Acceptance Notes
 

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -54,7 +54,7 @@ history <shifu_bid> <outline_bid>             # MarkdownFlow revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
-Use `show <shifu_bid>` to get lesson `outline_bid` values when you need a lesson-specific preview URL such as `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>`.
+Use `show <shifu_bid>` to get lesson `outline_bid` values for lesson-specific preview URLs, such as `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>` (cn) or `https://app.ai-shifu.com/c/<shifu_bid>?preview=true&lessonid=<outline_bid>` (global).
 
 ## Create Commands
 

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -54,6 +54,8 @@ history <shifu_bid> <outline_bid>             # MarkdownFlow revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
+Use `show <shifu_bid>` to get lesson `outline_bid` values when you need a lesson-specific preview URL such as `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>`.
+
 ## Create Commands
 
 ```bash

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -111,4 +111,5 @@ Validation:
 
 Verification URLs:
 - Admin console:
-- Preview:
+- Course preview:
+- Lesson preview:


### PR DESCRIPTION
## What changed
- documented `show <shifu_bid> <outline_bid>` as the lesson-level inspection command
- added course preview and lesson preview URL patterns, including `lessonid=<outline_bid>`
- updated the end-to-end deploy example and deployment report template to include lesson preview links

## Why
The skill already supported lesson-level preview URLs conceptually, but the docs did not explain how to reach a specific lesson after deployment. This makes the verification and debugging flow explicit.

## Impact
Users can now:
- locate a lesson `outline_bid` via `show <shifu_bid>`
- open a course-level preview or jump directly to a specific lesson preview
- report deployment results with both course and lesson preview links

## Validation
- reviewed the diff for the four documentation files
- confirmed the updated docs consistently reference `lessonid=<outline_bid>` and the lesson preview flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CLI usage note to preview a specific lesson in addition to course structure.
  * Replaced a single preview link with region-specific course and lesson preview URLs (lesson preview includes lessonid query).
  * Clarified how to obtain lesson identifiers and updated deployment verification and report templates to use the new preview URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->