### PR TITLE
ai-shifu-course-creator: clarify MDF scripts as directive teaching scripts

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -37,9 +37,48 @@ See `references/input-contract.md` for recommended object shapes.
 
 ## Output Boundary
 
-- Final outputs are learner-facing teaching content only.
+- Final outputs are **MarkdownFlow teaching scripts**.
+- The script must be **directive/instructional** (i.e., it tells the model how to teach), not a polished, directly learner-addressed “final lecture/manuscript”.
+- Avoid author-side meta labels such as “Knowledge Block 1/2/3”, “Lesson Objective”, or “Deliverable”. Keep those as implicit structure, not visible narration.
 - Authoring rules, pipeline notes, and process instructions stay in skill docs and references, not in lesson outputs.
 - Internal design notes may appear only in HTML comments when needed.
+
+## MarkdownFlow Authoring Hard Rules (Must Follow)
+
+### 1) Script style: directive, not manuscript
+
+Write in imperative, model-guiding language. Preferred patterns:
+- “Explain to the learner …”
+- “Ask the learner to …”
+- “Have the learner choose …”
+- “After collecting {{var}}, restate the choice and branch …”
+
+Disallowed patterns:
+- Long, polished prose written as if it is the final learner-facing lecture.
+- Author/lesson-plan meta narration (e.g., “Knowledge Block …”, “In this lesson you will …”, “Deliverable: …”).
+
+### 2) Interaction syntax: prompt outside, options inside
+
+For MarkdownFlow interactions, keep the question/prompt **outside** the syntax line.
+The interaction line must contain **only options** (and minimal inline hints when strictly necessary).
+
+Bad:
+`?[%{{topic}} Please pick a topic: A | B | C]`
+
+Good:
+`Ask the learner to pick a topic.`
+`?[%{{topic}} A | B | C]`
+
+### 3) Mandatory anchoring + downstream effect
+
+After every interaction, the script must:
+1. Restate the selection explicitly: `The learner's current choice is {{var}}.`
+2. Use {{var}} to create a visible downstream effect (branching explanation, examples, practice difficulty, feedback).
+
+### 4) Visuals: describe, do not inline source markup
+
+- Do not embed raw SVG/HTML source code inside lesson MDF files.
+- When a visual is needed, write a natural-language instruction: “Show an image that …” and pair it with a brief explanation of what the visual is meant to convey.
 
 ## Pipeline Overview
 
@@ -161,7 +200,7 @@ All gates must pass:
 - Do not wrap full lessons in deterministic blocks (`=== ===` or `!=== !===`).
 - Deterministic blocks are reserved for legally or operationally fixed statements only.
 - If an image must remain unchanged, use single-line deterministic syntax per image.
-- Use `---` between instructional blocks to keep pacing readable.
+
 - Every variable collection step must produce immediate feedback and downstream effect.
 - Core knowledge points require visual + textual explanation together.
 - Consecutive variable collection cannot exceed three variables.
@@ -314,7 +353,7 @@ See `references/optimization-methodology.md`.
 
 ### High-Standard Constraints
 
-- Separate knowledge blocks with `---`.
+
 - Include a lesson cover visual by default.
 - Keep max interactions per lesson at five (recommended three to four).
 - Place interactions at decision points, not only at lesson start.
@@ -483,7 +522,7 @@ See `references/markdownflow-spec.md` for the quick reference.
    - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
 3. Segments:
-   - Use `---` between segments.
+   - Segment separators are not required.
    - Each segment should serve one clear instructional objective.
 
 4. Deterministic output:

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -72,7 +72,7 @@ Good:
 ### 3) Mandatory anchoring + downstream effect
 
 After every interaction, the script must:
-1. Restate the selection explicitly: `The learner's current choice is {{var}}.`
+1. Restate the selection explicitly as an instruction (not as polished narration), e.g.: `Restate the learner's current choice as {{var}}.`
 2. Use {{var}} to create a visible downstream effect (branching explanation, examples, practice difficulty, feedback).
 
 ### 4) Visuals: describe, do not inline source markup
@@ -192,7 +192,7 @@ All gates must pass:
 - Each lesson resolves one core question.
 - Each lesson contains at least one valid MarkdownFlow interaction, max five interactions total.
 - Each lesson includes a minimum teaching loop: setup, explanation, interaction, close.
-- Lesson language is learner-facing, not pipeline narration.
+- Lesson language must be **instructional/directive** (model-guiding), not pipeline narration.
 - Each lesson includes at least one deepening interaction (calibration, boundary check, or counterintuitive prompt).
 - Action tasks are either immediately executable or explicitly linked to later modules.
 - Variable naming is consistent and traceable.
@@ -250,7 +250,7 @@ Generate runnable MarkdownFlow scripts for each lesson.
 
 Use these defaults unless lesson content requires a justified variation:
 
-1. Learner-facing language only.
+1. Instructional/directive language only (a teaching script, not a final manuscript).
 2. Variable collection is distributed, not front-loaded.
 3. Build evidence chain from observation to mechanism to conclusion.
 4. Use visual-first explanation for abstract concepts, then textual interpretation.
@@ -295,10 +295,9 @@ Optional modules:
 
 ### Visual-Text Coordination
 
-- Include an SVG cover in each lesson by default.
-- Every core concept must include at least one visual-plus-explanation pair.
-- Visuals compress structure; text explains mechanism, limits, and pitfalls.
-- Replace unstable source images with generated SVG/HTML visuals when needed.
+- If a visual is needed, describe it in natural language (e.g., "Show an image that …").
+- Pair every visual instruction with a brief explanation of what the visual is meant to convey.
+- Do not inline raw SVG/HTML markup in MDF lesson files.
 
 ### Interaction Design
 

--- a/skills/ai-shifu-course-creator/references/output-contract.md
+++ b/skills/ai-shifu-course-creator/references/output-contract.md
@@ -4,7 +4,7 @@
 
 1. `lesson_mdf_scripts`
 - One MarkdownFlow file per lesson.
-- Learner-facing language only.
+- Instructional/directive teaching-script language only (model-guiding), not a final learner manuscript.
 
 2. `course_index`
 - `lesson_id`

--- a/skills/ai-shifu-course-creator/references/output-contract.md
+++ b/skills/ai-shifu-course-creator/references/output-contract.md
@@ -56,7 +56,7 @@ Each item:
     {
       "lesson_id": "L01",
       "lesson_title": "Core Loop Setup",
-      "mdf_script": "## Objective\n...\n?[%{{learner_goal}} Option A | Option B]\n---\n...",
+      "mdf_script": "## Objective\n...\n?[%{{learner_goal}} Option A | Option B]\n...",
       "used_variables": ["learner_goal"],
       "depends_on_lessons": []
     }


### PR DESCRIPTION
### Why
MarkdownFlow authoring failures were repeatedly traced to ambiguous guidance around "learner-facing" output. In practice, authors may accidentally write a polished lecture manuscript (instead of a directive teaching script), embed question prompts inside the interaction syntax line, or add lesson-plan meta narration (e.g., "Knowledge Block", "Deliverable"). These patterns reduce runtime stability and increase syntax errors.

### What
This PR clarifies and hardens the authoring contract in `skills/ai-shifu-course-creator/SKILL.md`:
- Define outputs as **directive MarkdownFlow teaching scripts** (model-guiding), not final learner manuscripts.
- Disallow author-side meta narration labels (e.g., Knowledge Block / Lesson Objective / Deliverable).
- Enforce interaction formatting: **prompt outside, options inside** (includes bad/good examples).
- Require post-interaction anchoring + visible downstream effect: restate `{{var}}` and branch explanation/examples/practice/feedback accordingly.
- Visual guidance: **describe visuals**; do not inline raw SVG/HTML source markup in lesson MDF files.
- Remove any requirement to use `---` as a pacing/segmentation mechanism.

### Scope
Documentation-only change: `skills/ai-shifu-course-creator/SKILL.md`

### Validation
- Ran `python3 scripts/validate_skill_quality.py` (pass).
