### PR TITLE
[codex] add AGENTS.md compatibility rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@
 
 ## Skill Content Rule
 
-- In the body of any skill document, do not use the abbreviation `MDF`.
-- Always write `MarkdownFlow` in full instead of `MDF`.
+- Do not use the abbreviation `MDF` anywhere in a skill document (including frontmatter); always write `MarkdownFlow` in full.
 
 ## Compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Instructions
+
+## Skill Content Rule
+
+- In the body of any skill document, do not use the abbreviation `MDF`.
+- Always write `MarkdownFlow` in full instead of `MDF`.
+
+## Compatibility
+
+- `CLAUDE.md` must stay aligned with this file.
+- If both files exist, treat this file as the source of truth and mirror the same rule in `CLAUDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,3 @@
 ## Skill Content Rule
 
 - Do not use the abbreviation `MDF` anywhere in a skill document (including frontmatter); always write `MarkdownFlow` in full.
-
-## Compatibility
-
-- `CLAUDE.md` must stay aligned with this file.
-- If both files exist, treat this file as the source of truth and mirror the same rule in `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- add root-level `AGENTS.md` with a repository rule for skill content
- make `CLAUDE.md` a symlink to `AGENTS.md` so Claude-compatible tooling reads the same instruction file

## Why

- keep the instruction in one place and avoid drift between agent-specific files
- require skill bodies to spell out `MarkdownFlow` instead of using the `MDF` abbreviation

## Validation

- verified `CLAUDE.md` resolves to `AGENTS.md` with `ls -l`
- verified the diff only contains the new instruction file and symlink


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->