### PR TITLE
[codex] require conventional commit messages in agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Repository Instructions
 
+## Git Commit Rule
+
+- Git commit messages must use Conventional Commits style, such as `feat:` and `fix:`.
+
 ## Skill Content Rule
 
 - Do not use the abbreviation `MDF` anywhere in a skill document (including frontmatter); always write `MarkdownFlow` in full.


### PR DESCRIPTION
## Summary

- add an AGENTS.md rule requiring Conventional Commits style messages such as `feat:` and `fix:`

## Why

- make the repository commit message expectation explicit for contributors and agents

## Validation

- verified the AGENTS.md diff contains only the new git commit rule


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository Git commit message conventions requiring Conventional Commits style format (e.g., `feat:`, `fix:`) for consistent commit history management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->