### PR TITLE
fix: clarify visual placeholder guidance

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -76,7 +76,9 @@ After every interaction, the script must:
 ### 4) Visuals: describe, do not inline source markup
 
 - Do not embed raw SVG/HTML source code inside lesson MarkdownFlow files.
-- When a visual is needed, write a natural-language instruction: “Show an image that …” and pair it with a brief explanation of what the visual is meant to convey.
+- Unless the user explicitly asks for SVG, HTML, Mermaid, PlantUML, Graphviz, or other diagram source/markup, do not proactively generate visual source code or diagram markup.
+- Default behavior: when a visual is needed, write a natural-language instruction such as “Show an image that …” and pair it with a brief explanation of what the visual is meant to convey.
+- If the user asks for a visual but does not specify the format, prefer natural-language image/diagram placeholders over executable or embeddable diagram code.
 
 ## Pipeline Overview
 


### PR DESCRIPTION
## Summary
- clarify that visual source and diagram markup should not be generated unless explicitly requested
- make natural-language visual placeholders the default for unspecified visual requests
- keep the guidance focused on MarkdownFlow lesson authoring behavior

## Testing
- not run (documentation-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated visual-authoring guidance to prioritize natural-language diagram descriptions over auto-generated diagram markup by default. Explicit requests for specific diagram formats are now required to generate executable diagram source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->