### PR TITLE
fix: clarify MarkdownFlow input marker syntax

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -362,7 +362,6 @@ See `references/optimization-methodology.md`.
 - Spread global variable collection across lessons.
 - Do not recollect the same variable unless marked as staged comparison.
 - Treat semantic duplicates as duplicates even if variable names differ.
-- Use stable input syntax: `?[%{{var}}...prompt]`.
 - Keep ending structure lesson-appropriate; interactive endings are optional.
 - Every core concept needs visual-plus-text explanation.
 - Avoid internal authoring terms in learner-facing copy.
@@ -509,39 +508,23 @@ After any deployment or management operation, verify the result:
 
 See `references/markdownflow-spec.md` for the quick reference.
 
-1. Variables:
-   - Use `{{var_name}}` for references.
-   - Variable names cannot contain spaces.
-   - Undefined variables default to `"UNKNOWN"`.
-
-2. Interactions:
-   - Single-select: `?[%{{var}} Option A | Option B | Option C]`
-   - Multi-select: `?[%{{var}} Option A || Option B || Option C]`
-   - Input: `?[%{{var}} ... enter your answer]`
-   - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
-
-3. Segments:
-   - Segment separators are not required.
-   - Each segment should serve one clear instructional objective.
-
-4. Deterministic output:
-   - Single-line fixed text: `===fixed text===`
-   - Multi-line fixed text:
-   ```md
-   !===
-   Line 1
-   Line 2
-   !===
-   ```
-
-5. Authoring principle:
+Authoring principle:
    - Script text should guide generation behavior.
    - Do not output full polished learner prose as fixed text.
    - Never lock full lesson bodies inside deterministic blocks.
    - For fixed images, use one deterministic line per image.
    - After each interaction, restate learner selection and reflect it in downstream content.
    - For input prompts, include example phrasing to reduce blank responses.
-   - Use stable input syntax: `?[%{{var}}...prompt]`.
+   - Treat `...` as a structural input marker, not as decorative punctuation.
+   - For pure input, place `...` directly before the prompt text: `?[%{{var}} ...Prompt text]`.
+   - For select + input, place `...` at the start of the option that opens free text: `...Other, please specify`.
+   - Never place `...` at the end of prompt text or option labels.
+
+Common syntax mistakes to avoid:
+   - Incorrect: `?[%{{var}} Prompt text...]`
+   - Incorrect: `?[%{{var}} Option A | Option B | Other, please specify...]`
+   - Correct: `?[%{{var}} ...Prompt text]`
+   - Correct: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
 ## Shared Constraints
 

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -4,26 +4,39 @@
 
 - Reference syntax: `{{var_name}}`
 - No spaces in variable names
-- Undefined variables resolve to `"UNKNOWN"`
+- Undefined variables resolve to `UNKNOWN`
 
 ## Interactions
 
 - Single-select: `?[%{{var}} Option A | Option B | Option C]`
 - Multi-select: `?[%{{var}} Option A || Option B || Option C]`
-- Input: `?[%{{var}} ... enter your answer]`
-- Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
+- Input: `?[%{{var}} ...Enter your answer]`
+- Single-select + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
+- Multi-select + input: `?[%{{var}} Option A || Option B || ...Other, please specify]`
 
-## Structure
+### Input Marker Rules
 
-- Use `---` between instructional segments.
-- Keep one objective per segment.
+- `...` is an input marker, not punctuation.
+- `...` must appear immediately before the free-text prompt or free-text option label.
+- For pure input, use `?[%{{var}} ...Prompt text]`.
+- For select + input, put `...` at the start of the option that opens text entry, such as `...Other, please specify`.
+- Do not move `...` to the end of the prompt text.
+- Do not write `?[%{{var}} Prompt text...]`.
+- Do not write `?[%{{var}} Option A | Option B | Other, please specify...]`.
+
+### Input Marker Examples
+
+- Correct: `?[%{{learner_goal}} ...Describe your goal in one sentence]`
+- Correct: `?[%{{difficulty_type}} Concept unclear | Need practice | ...Other, please specify]`
+- Incorrect: `?[%{{learner_goal}} Describe your goal in one sentence...]`
+- Incorrect: `?[%{{difficulty_type}} Concept unclear | Need practice | Other, please specify...]`
 
 ## Deterministic Output
 
 - Single-line fixed text: `===fixed text===`
 - Multi-line fixed text:
 
-```md
+```markdown
 !===
 Line 1
 Line 2

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -33,8 +33,8 @@
 
 ## Structure
 
-- Use `---` between instructional segments when segmentation is needed.
-- Keep one clear instructional objective per segment.
+- Use `---` between instructional segments.
+- Keep one objective per segment.
 
 ## Deterministic Output
 

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -31,6 +31,11 @@
 - Incorrect: `?[%{{learner_goal}} Describe your goal in one sentence...]`
 - Incorrect: `?[%{{difficulty_type}} Concept unclear | Need practice | Other, please specify...]`
 
+## Structure
+
+- Use `---` between instructional segments when segmentation is needed.
+- Keep one clear instructional objective per segment.
+
 ## Deterministic Output
 
 - Single-line fixed text: `===fixed text===`


### PR DESCRIPTION
## Summary
- clarify that three dots act as a structural input marker in MarkdownFlow
- add positive and negative examples for open input and select-plus-input patterns
- reinforce the rule in the main skill instructions to reduce model drift

## Testing
- not run (docs-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified input-marker placement rules with an authoring-principle for pure input and select+input patterns
  * Added a short guide of common syntax mistakes with explicit incorrect/correct examples
  * Expanded interaction examples to include single- and multi-select plus input forms
  * Changed undefined-variable representation for clearer handling
  * Adjusted deterministic output labeling and refined segmentation/objective guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->