### PR TITLE
feat: remove MarkdownFlow structure section

### DIFF
--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -13,11 +13,6 @@
 - Input: `?[%{{var}} ... enter your answer]`
 - Button + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 
-## Structure
-
-- Use `---` between instructional segments.
-- Keep one objective per segment.
-
 ## Deterministic Output
 
 - Single-line fixed text: `===fixed text===`


### PR DESCRIPTION
## Summary
- remove the Structure section from the MarkdownFlow quick spec
- keep this PR scoped only to that documentation deletion

## Testing
- not run (docs-only changes)