### PR TITLE
fix: clarify MarkdownFlow interaction prompt placement

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -59,6 +59,7 @@ Disallowed patterns:
 
 For MarkdownFlow interactions, keep the question/prompt **outside** the syntax line.
 The interaction line must contain **only option labels** or a short `...` input placeholder.
+The `?[]` interaction syntax must be on its own line. Never put prompt text and `?[]` on the same line.
 
 Do not place a learner-facing question after `%{{var}}` inside `?[%{{var}} ...]`. Anything after `%{{var}}` is parsed as selectable content, so a question there becomes part of the interaction instead of the prompt.
 
@@ -70,6 +71,7 @@ Bad:
 `?[%{{topic}} Please pick a topic: A | B | C]`
 `?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]`
 `?[%{{example}} What is one situation where you want to apply this idea this week? ...Describe your situation]`
+`Ask the learner: Which option best matches your situation? ?[%{{choice}} Option A | Option B | Option C]`
 
 Good:
 `Ask the learner to pick a topic.`
@@ -537,6 +539,7 @@ Common syntax mistakes to avoid:
    - Incorrect: `?[%{{var}} Option A | Option B | Other, please specify...]`
    - Incorrect: `?[%{{var}} Question prompt? Option A | Option B | Option C]`
    - Incorrect: `?[%{{var}} Full learner-facing question? ...Short placeholder]`
+   - Incorrect: `Ask the learner the question prompt. ?[%{{var}} Option A | Option B | Option C]`
    - Correct: `Ask the learner the full question.`
    - Correct: `?[%{{var}} ...Short placeholder]`
    - Correct: `?[%{{var}} Option A | Option B | ...Other, please specify]`
@@ -576,6 +579,7 @@ Can normalize:
 - Each lesson includes at least one deepening interaction (calibration, boundary check, or misconception correction).
 - Interaction prompts must be concrete and directly answerable.
 - Learner-facing questions must appear before the interaction line, not inside `?[%{{var}} ...]`.
+- `?[]` interaction syntax must be on a standalone line.
 - For input interactions, the pre-interaction question must be more specific than the short `...` placeholder.
 - `*_viewpoint_check` interactions must branch by option and drive different next steps.
 - Avoid repetitive interaction semantics across lessons unless comparison intent is explicit.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-shifu-course-creator
-description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing MarkdownFlow lesson scripts. Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Trigger on any mention of AI-Shifu, AI师傅, or MarkdownFlow course scripting.
+description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing MarkdownFlow (MDF) lesson scripts. Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Trigger on any mention of AI-Shifu, AI师傅, or MarkdownFlow course scripting.
 ---
 
 # Course Creator

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -58,19 +58,26 @@ Disallowed patterns:
 ### 2) Interaction syntax: prompt outside, options inside
 
 For MarkdownFlow interactions, keep the question/prompt **outside** the syntax line.
-The interaction line must contain **only option labels** (and the `...` input marker when needed).
+The interaction line must contain **only option labels** or a short `...` input placeholder.
 
 Do not place a learner-facing question after `%{{var}}` inside `?[]`. Anything after `%{{var}}` is parsed as selectable content, so a question there becomes part of the interaction instead of the prompt.
+
+For input interactions, write both:
+- A specific, learner-facing question before the interaction line.
+- A shorter input placeholder after `...` inside the interaction line.
 
 Bad:
 `?[%{{topic}} Please pick a topic: A | B | C]`
 `?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]`
+`?[%{{example}} What is one situation where you want to apply this idea this week? ...Describe your situation]`
 
 Good:
 `Ask the learner to pick a topic.`
 `?[%{{topic}} A | B | C]`
 `Ask the learner: Which option best matches your situation?`
 `?[%{{choice}} Option A | Option B | Option C | ...Other]`
+`Ask the learner: What is one specific situation where you want to apply this idea this week?`
+`?[%{{example}} ...Brief situation]`
 
 ### 3) Mandatory anchoring + downstream effect
 
@@ -519,9 +526,9 @@ Authoring principle:
    - Never lock full lesson bodies inside deterministic blocks.
    - For fixed images, use one deterministic line per image.
    - After each interaction, restate learner selection and reflect it in downstream content.
-   - For input prompts, include example phrasing to reduce blank responses.
+   - For input interactions, put the full learner-facing question before the interaction line and use only a short placeholder after `...`.
    - Treat `...` as a structural input marker, not as decorative punctuation.
-   - For pure input, place `...` directly before the prompt text: `?[%{{var}} ...Prompt text]`.
+   - For pure input, place `...` directly before a short input placeholder: `?[%{{var}} ...Short placeholder]`.
    - For select + input, place `...` at the start of the option that opens free text: `...Other, please specify`.
    - Never place `...` at the end of prompt text or option labels.
 
@@ -529,7 +536,9 @@ Common syntax mistakes to avoid:
    - Incorrect: `?[%{{var}} Prompt text...]`
    - Incorrect: `?[%{{var}} Option A | Option B | Other, please specify...]`
    - Incorrect: `?[%{{var}} Question prompt? Option A | Option B | Option C]`
-   - Correct: `?[%{{var}} ...Prompt text]`
+   - Incorrect: `?[%{{var}} Full learner-facing question? ...Short placeholder]`
+   - Correct: `Ask the learner the full question.`
+   - Correct: `?[%{{var}} ...Short placeholder]`
    - Correct: `?[%{{var}} Option A | Option B | ...Other, please specify]`
    - Correct: `Ask the learner the question prompt.`
    - Correct: `?[%{{var}} Option A | Option B | Option C]`
@@ -566,6 +575,7 @@ Can normalize:
 - Each lesson includes at least one deepening interaction (calibration, boundary check, or misconception correction).
 - Interaction prompts must be concrete and directly answerable.
 - Learner-facing questions must appear before the interaction line, not inside `?[%{{var}} ...]`.
+- For input interactions, the pre-interaction question must be more specific than the short `...` placeholder.
 - `*_viewpoint_check` interactions must branch by option and drive different next steps.
 - Avoid repetitive interaction semantics across lessons unless comparison intent is explicit.
 - Every interaction variable must create visible downstream impact.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -540,8 +540,9 @@ Common syntax mistakes to avoid:
    - Correct: `Ask the learner the full question.`
    - Correct: `?[%{{var}} ...Short placeholder]`
    - Correct: `?[%{{var}} Option A | Option B | ...Other, please specify]`
-   - Correct: `Ask the learner the question prompt.`
-   - Correct: `?[%{{var}} Option A | Option B | Option C]`
+   - Correct: Prompt text followed by the interaction line, e.g.:
+     Ask the learner the question prompt.
+     ?[%{{var}} Option A | Option B | Option C]
 
 ## Shared Constraints
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -60,7 +60,7 @@ Disallowed patterns:
 For MarkdownFlow interactions, keep the question/prompt **outside** the syntax line.
 The interaction line must contain **only option labels** or a short `...` input placeholder.
 
-Do not place a learner-facing question after `%{{var}}` inside `?[]`. Anything after `%{{var}}` is parsed as selectable content, so a question there becomes part of the interaction instead of the prompt.
+Do not place a learner-facing question after `%{{var}}` inside `?[%{{var}} ...]`. Anything after `%{{var}}` is parsed as selectable content, so a question there becomes part of the interaction instead of the prompt.
 
 For input interactions, write both:
 - A specific, learner-facing question before the interaction line.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-shifu-course-creator
-description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing MarkdownFlow (MDF) lesson scripts. Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Trigger on any mention of AI-Shifu, AI师傅, or MarkdownFlow course scripting.
+description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing MarkdownFlow lesson scripts. Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Trigger on any mention of AI-Shifu, AI师傅, or MarkdownFlow course scripting.
 ---
 
 # Course Creator
@@ -58,14 +58,19 @@ Disallowed patterns:
 ### 2) Interaction syntax: prompt outside, options inside
 
 For MarkdownFlow interactions, keep the question/prompt **outside** the syntax line.
-The interaction line must contain **only options** (and minimal inline hints when strictly necessary).
+The interaction line must contain **only option labels** (and the `...` input marker when needed).
+
+Do not place a learner-facing question after `%{{var}}` inside `?[]`. Anything after `%{{var}}` is parsed as selectable content, so a question there becomes part of the interaction instead of the prompt.
 
 Bad:
 `?[%{{topic}} Please pick a topic: A | B | C]`
+`?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]`
 
 Good:
 `Ask the learner to pick a topic.`
 `?[%{{topic}} A | B | C]`
+`Ask the learner: Which option best matches your situation?`
+`?[%{{choice}} Option A | Option B | Option C | ...Other]`
 
 ### 3) Mandatory anchoring + downstream effect
 
@@ -523,8 +528,11 @@ Authoring principle:
 Common syntax mistakes to avoid:
    - Incorrect: `?[%{{var}} Prompt text...]`
    - Incorrect: `?[%{{var}} Option A | Option B | Other, please specify...]`
+   - Incorrect: `?[%{{var}} Question prompt? Option A | Option B | Option C]`
    - Correct: `?[%{{var}} ...Prompt text]`
    - Correct: `?[%{{var}} Option A | Option B | ...Other, please specify]`
+   - Correct: `Ask the learner the question prompt.`
+   - Correct: `?[%{{var}} Option A | Option B | Option C]`
 
 ## Shared Constraints
 
@@ -557,6 +565,7 @@ Can normalize:
 
 - Each lesson includes at least one deepening interaction (calibration, boundary check, or misconception correction).
 - Interaction prompts must be concrete and directly answerable.
+- Learner-facing questions must appear before the interaction line, not inside `?[%{{var}} ...]`.
 - `*_viewpoint_check` interactions must branch by option and drive different next steps.
 - Avoid repetitive interaction semantics across lessons unless comparison intent is explicit.
 - Every interaction variable must create visible downstream impact.

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -51,8 +51,6 @@ Incorrect:
 ### Input Marker Examples
 
 - Correct:
-
-  ```markdown
   Ask the learner: What is one goal you want this lesson to help you achieve in your current work?
   ?[%{{learner_goal}} ...One-sentence goal]
 - Correct: `?[%{{difficulty_type}} Concept unclear | Need practice | ...Other, please specify]`

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -19,25 +19,30 @@
 - Put the learner-facing question or prompt in the script text immediately before the interaction line.
 - Put only option labels inside select interactions.
 - Do not place the question after `%{{var}}`; it will become part of the selectable interaction content.
+- For input interactions, include both the full question before the interaction line and a shorter placeholder after `...`.
 
 Correct:
 
 ```markdown
 Ask the learner: Which option best matches your situation?
 ?[%{{choice}} Option A | Option B | Option C | ...Other]
+
+Ask the learner: What is one specific situation where you want to apply this idea this week?
+?[%{{example}} ...Brief situation]
 ```
 
 Incorrect:
 
 ```markdown
 ?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]
+?[%{{example}} What is one situation where you want to apply this idea this week? ...Describe your situation]
 ```
 
 ### Input Marker Rules
 
 - `...` is an input marker, not punctuation.
-- `...` must appear immediately before the free-text prompt or free-text option label.
-- For pure input, use `?[%{{var}} ...Prompt text]`.
+- `...` must appear immediately before the short free-text placeholder or free-text option label.
+- For pure input, use `?[%{{var}} ...Short placeholder]` after a fuller learner-facing question.
 - For select + input, put `...` at the start of the option that opens text entry, such as `...Other, please specify`.
 - Do not move `...` to the end of the prompt text.
 - Do not write `?[%{{var}} Prompt text...]`.
@@ -45,7 +50,8 @@ Incorrect:
 
 ### Input Marker Examples
 
-- Correct: `?[%{{learner_goal}} ...Describe your goal in one sentence]`
+- Correct: `Ask the learner: What is one goal you want this lesson to help you achieve in your current work?`
+- Correct: `?[%{{learner_goal}} ...One-sentence goal]`
 - Correct: `?[%{{difficulty_type}} Concept unclear | Need practice | ...Other, please specify]`
 - Incorrect: `?[%{{learner_goal}} Describe your goal in one sentence...]`
 - Incorrect: `?[%{{difficulty_type}} Concept unclear | Need practice | Other, please specify...]`

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -50,8 +50,11 @@ Incorrect:
 
 ### Input Marker Examples
 
-- Correct: `Ask the learner: What is one goal you want this lesson to help you achieve in your current work?`
-- Correct: `?[%{{learner_goal}} ...One-sentence goal]`
+- Correct:
+
+  ```markdown
+  Ask the learner: What is one goal you want this lesson to help you achieve in your current work?
+  ?[%{{learner_goal}} ...One-sentence goal]
 - Correct: `?[%{{difficulty_type}} Concept unclear | Need practice | ...Other, please specify]`
 - Incorrect: `?[%{{learner_goal}} Describe your goal in one sentence...]`
 - Incorrect: `?[%{{difficulty_type}} Concept unclear | Need practice | Other, please specify...]`

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -17,8 +17,8 @@
 ### Prompt Placement Rules
 
 - Put the learner-facing question or prompt in the script text immediately before the interaction line.
-- Put only option labels inside select interactions.
-- Do not place the question after `%{{var}}`; it will become part of the selectable interaction content.
+- Inside the interaction line, include only interaction content: option labels for select interactions, and input markers/placeholders such as `...Other` or `...Brief situation` where applicable.
+- Do not place learner-facing question text after `%{{var}}`; it will become part of the interaction content.
 - For input interactions, include both the full question before the interaction line and a shorter placeholder after `...`.
 
 Correct:

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -14,6 +14,25 @@
 - Single-select + input: `?[%{{var}} Option A | Option B | ...Other, please specify]`
 - Multi-select + input: `?[%{{var}} Option A || Option B || ...Other, please specify]`
 
+### Prompt Placement Rules
+
+- Put the learner-facing question or prompt in the script text immediately before the interaction line.
+- Put only option labels inside select interactions.
+- Do not place the question after `%{{var}}`; it will become part of the selectable interaction content.
+
+Correct:
+
+```markdown
+Ask the learner: Which option best matches your situation?
+?[%{{choice}} Option A | Option B | Option C | ...Other]
+```
+
+Incorrect:
+
+```markdown
+?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]
+```
+
 ### Input Marker Rules
 
 - `...` is an input marker, not punctuation.

--- a/skills/ai-shifu-course-creator/references/markdownflow-spec.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow-spec.md
@@ -17,6 +17,7 @@
 ### Prompt Placement Rules
 
 - Put the learner-facing question or prompt in the script text immediately before the interaction line.
+- Put each `?[]` interaction on its own line.
 - Inside the interaction line, include only interaction content: option labels for select interactions, and input markers/placeholders such as `...Other` or `...Brief situation` where applicable.
 - Do not place learner-facing question text after `%{{var}}`; it will become part of the interaction content.
 - For input interactions, include both the full question before the interaction line and a shorter placeholder after `...`.
@@ -36,6 +37,7 @@ Incorrect:
 ```markdown
 ?[%{{choice}} Which option best matches your situation? Option A | Option B | Option C | ...Other]
 ?[%{{example}} What is one situation where you want to apply this idea this week? ...Describe your situation]
+Ask the learner: Which option best matches your situation? ?[%{{choice}} Option A | Option B | Option C]
 ```
 
 ### Input Marker Rules

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -8,7 +8,7 @@
 ## Interaction Quality
 
 - Interactions are concrete and answerable.
-- Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[]`.
+- Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[%{{var}} ...]`.
 - Input interactions include a specific pre-interaction question plus a shorter `...` placeholder.
 - Branching paths are distinct where required.
 - Interaction results affect later content.

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -9,6 +9,7 @@
 
 - Interactions are concrete and answerable.
 - Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[]`.
+- Input interactions include a specific pre-interaction question plus a shorter `...` placeholder.
 - Branching paths are distinct where required.
 - Interaction results affect later content.
 

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -9,6 +9,7 @@
 
 - Interactions are concrete and answerable.
 - Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[%{{var}} ...]`.
+- Each `?[]` interaction appears on its own line.
 - Input interactions include a specific pre-interaction question plus a shorter `...` placeholder.
 - Branching paths are distinct where required.
 - Interaction results affect later content.

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -8,6 +8,7 @@
 ## Interaction Quality
 
 - Interactions are concrete and answerable.
+- Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[]`.
 - Branching paths are distinct where required.
 - Interaction results affect later content.
 


### PR DESCRIPTION
## Summary

- Clarify that learner-facing questions must be placed before MarkdownFlow interaction syntax.
- Require every `?[]` interaction to appear on its own line, separate from prompt text.
- Add generic English correct/incorrect examples showing that select interaction lines should contain only option labels and input markers.
- Clarify input interactions: the full learner-facing question goes before the interaction line, while the text after `...` is only a shorter input placeholder.
- Add the same prompt-placement checks to the MarkdownFlow quick spec and review checklist.

## Validation

- `python3 scripts/validate_skill_quality.py skills/ai-shifu-course-creator`