### PR TITLE
fix: clarify AI-Shifu SMS code length

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -15,7 +15,7 @@ Run login once — the token persists in `{skillDir}/.env` for subsequent comman
 login --phone 13800138000 --region cn
 
 # Step 2: Complete login with the code
-login --phone 13800138000 --region cn --sms-code 123456
+login --phone 13800138000 --region cn --sms-code 1234
 ```
 
 Region options: `cn` (maps to `https://app.ai-shifu.cn`) or `global` (maps to `https://app.ai-shifu.com`). You can also use `--base-url` to override the URL directly.
@@ -37,9 +37,9 @@ When no valid token is available, guide the user through login:
 4. Ask for their registered phone number.
 5. Send SMS code:
    `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region cn`
-6. Ask the user for the verification code they received.
+6. Ask the user for the 4-digit verification code they received.
 7. Complete login:
-   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region cn --sms-code <code>`
+   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --region cn --sms-code <4-digit-code>`
 8. Token is automatically saved — proceed with the requested operation.
 
 Always use CLI commands. Never make raw HTTP/API calls directly.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -952,7 +952,7 @@ def build_parser():
                        help="SMS login and save token")
     p.add_argument("--phone", required=True, help="Phone number for SMS login")
     p.add_argument("--sms-code", default=None,
-                   help="4-digit SMS verification code (skip interactive input)")
+                   help="4-digit SMS verification code")
     p.add_argument("--region", choices=["cn", "global"], default=None,
                    help="Region: cn (中国大陆) or global (非中国大陆)")
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -186,7 +186,7 @@ def cmd_login(args):
         _login_post(base_url, "/api/user/send_sms_code",
                     {"mobile": phone}, "Failed to send SMS")
         print(f"SMS code sent to {masked}. "
-              f"Run again with --sms-code <code> to complete login.")
+              f"Run again with --sms-code <4-digit-code> to complete login.")
 
 
 # ── List ───────────────────────────────────────────────────────────────────────
@@ -952,7 +952,7 @@ def build_parser():
                        help="SMS login and save token")
     p.add_argument("--phone", required=True, help="Phone number for SMS login")
     p.add_argument("--sms-code", default=None,
-                   help="SMS verification code (skip interactive input)")
+                   help="4-digit SMS verification code (skip interactive input)")
     p.add_argument("--region", choices=["cn", "global"], default=None,
                    help="Region: cn (中国大陆) or global (非中国大陆)")
 


### PR DESCRIPTION
## Summary

- Update AI-Shifu course creator CLI docs to show a 4-digit SMS verification code.
- Update the login command output and argparse help text to describe the SMS code as 4 digits.

## Why

The actual AI-Shifu SMS verification code is 4 digits, but the docs previously used a 6-digit example and the CLI prompts did not state the expected length.

## Validation

- git diff --cached --check
- python3 scripts/validate_skill_quality.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference documentation and login flow messaging to clarify that SMS verification codes are 4 digits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->