### PR TITLE
fix: include admin login context in SMS verification

### DIFF
--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -165,7 +165,7 @@ def cmd_login(args):
         # Step 2: Verify code and save token
         print("Verifying code...")
         data = _login_post(base_url, "/api/user/verify_sms_code",
-                           {"mobile": phone, "sms_code": sms_code}, "Verification failed")
+                           {"mobile": phone, "sms_code": sms_code, "login_context": "admin"}, "Verification failed")
 
         token = data.get("data")
         if not token:


### PR DESCRIPTION
## Summary
- include `login_context: "admin"` when sending SMS login codes in the AI-Shifu CLI
- include `login_context: "admin"` when verifying SMS login codes in the AI-Shifu CLI

## Tests
- `python3 -m py_compile skills/ai-shifu-course-creator/scripts/shifu-cli.py`
- `git diff --check`