### PR TITLE
fix: use console SMS code endpoint

### DIFF
--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -138,7 +138,7 @@ def cmd_login(args):
     if sms_code:
         # Step 2: Verify code and save token
         print("Verifying code...")
-        data = _login_post(base_url, "/api/user/verify_sms_code",
+        data = _login_post(base_url, "/api/user/login_sms",
                            {"mobile": phone, "sms_code": sms_code, "login_context": "admin"}, "Verification failed")
 
         token = data.get("data")
@@ -157,7 +157,7 @@ def cmd_login(args):
     else:
         # Step 1: Send SMS code only, then exit
         print(f"Sending SMS code to {masked}...")
-        _login_post(base_url, "/api/user/send_sms_code",
+        _login_post(base_url, "/api/user/console_send_sms_code",
                     {"mobile": phone}, "Failed to send SMS")
         print(f"SMS code sent to {masked}. "
               f"Run again with --sms-code <4-digit-code> to complete login.")


### PR DESCRIPTION
## Summary

- Update the AI Shifu course creator CLI SMS login flow to use the console SMS-code endpoint for sending codes.
- Keep verification/login on the shared `/api/user/login_sms` endpoint.

## Why

The backend now separates SMS code delivery from SMS login. Console and skill callers should send codes through `/api/user/console_send_sms_code`, while all clients complete login through the single `/api/user/login_sms` endpoint.

## Validation

- `python3 -m py_compile skills/ai-shifu-course-creator/scripts/shifu-cli.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SMS login authentication flow to improve verification and code delivery processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->