### PR TITLE
feat: add creator course analysis report skill

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -1,8 +1,9 @@
 # Skill Index
 
-Total skills: **2**
+Total skills: **3**
 
 | Skill | One-liner | Category | Maturity |
 |---|---|---|---|
 | [ai-shifu-course-creator](./skills/ai-shifu-course-creator/SKILL.md) | Convert raw course material into optimized MarkdownFlow teaching scripts and deploy them as live AI-Shifu courses. | course-authoring | beta |
 | [course-direction-advisor](./skills/course-direction-advisor/SKILL.md) | Advise on market-fit course directions from source materials with competitor analysis and GO/HOLD/REWORK/NO-GO decisions. | content-preprocessing | beta |
+| [creator-course-analysis-report](./skills/creator-course-analysis-report/SKILL.md) | Build creator-facing course analysis reports from metrics, learner progress, follow-up details, ratings, and order signals. | course-analytics | beta |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Reusable AI-Shifu skills for course production, from topic selection to deployme
 
 - `ai-shifu-course-creator`: convert raw course material into optimized MarkdownFlow teaching scripts and deploy them as live AI-Shifu courses through a five-phase pipeline (segmentation, orchestration, generation, optimization, deployment).
 - `course-direction-advisor`: turn source materials into evidence-bound, market-fit course-topic decisions with competitor analysis, pricing guidance, and GO/HOLD/REWORK/NO-GO recommendations.
+- `creator-course-analysis-report`: turn creator-facing course metrics, learner progress, follow-up details, ratings, and order signals into structured analysis reports with conclusions and next-step recommendations.
 
 The course-creator skill includes runnable examples under `skills/ai-shifu-course-creator/examples/`.
 
@@ -17,12 +18,13 @@ The course-creator skill includes runnable examples under `skills/ai-shifu-cours
 skills/
   ai-shifu-course-creator/
   course-direction-advisor/
+  creator-course-analysis-report/
 ```
 
 ## Usage
 
 The skill keeps `SKILL.md` as the behavior source of truth.
-Core skill metadata lives in `skills/ai-shifu-course-creator/skill.yaml`.
+Each skill keeps `SKILL.md` as the behavior source of truth, with optional UI metadata in `agents/openai.yaml` when present.
 
 ## Course Authoring & Deployment Paths
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ skills/
 
 ## Usage
 
-The skill keeps `SKILL.md` as the behavior source of truth.
 Each skill keeps `SKILL.md` as the behavior source of truth, with optional UI metadata in `agents/openai.yaml` when present.
 
 ## Course Authoring & Deployment Paths

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,7 @@
 
 - `ai-shifu-course-creator`：通过五阶段流水线（分段、编排、生成、优化、部署）将原始课程素材转换为优化后的可运行 MarkdownFlow 授课脚本，并部署为 AI 师傅平台上的在线课程。
 - `course-direction-advisor`：将素材转化为基于证据的、市场适配的课程选题决策，包含竞品分析、定价建议和 GO/HOLD/REWORK/NO-GO 推荐。
+- `creator-course-analysis-report`：将创作者视角的课程指标、学员学习进度、追问明细、评分与订单信号整合为结构化分析报告，并给出结论与后续建议。
 
 course-creator skill 有可运行示例，位于 `skills/ai-shifu-course-creator/examples/`。
 
@@ -17,12 +18,13 @@ course-creator skill 有可运行示例，位于 `skills/ai-shifu-course-creator
 skills/
   ai-shifu-course-creator/
   course-direction-advisor/
+  creator-course-analysis-report/
 ```
 
 ## 使用说明
 
 skill 以 `SKILL.md` 作为行为定义。
-机器可读元数据位于 `skills/ai-shifu-course-creator/skill.yaml`。
+每个 skill 以 `SKILL.md` 作为行为定义；如存在 `agents/openai.yaml`，则用于补充 UI 元数据。
 
 ## 课程生产与部署路径
 

--- a/skills/creator-course-analysis-report/SKILL.md
+++ b/skills/creator-course-analysis-report/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: creator-course-analysis-report
+description: Build creator-facing course analysis reports from course metrics, learner progress, chapter coverage, follow-up details, satisfaction signals, and revenue or order data. Use when Codex needs to diagnose how a course is performing for a creator, explain learner drop-off or pain points, compare chapters or cohorts, summarize follow-up patterns, or turn analytics exports into a structured report with conclusions and next-step recommendations.
+---
+
+# Creator Course Analysis Report
+
+Turn creator-facing course, learner, and business data into a reusable analysis report that explains what is happening, why it is likely happening, and what the creator should do next.
+
+## Core Output
+
+Produce a report, not just a metric dump. The default deliverable should include:
+- summary
+- core metrics
+- learning progress and coverage
+- learner personas and common pain points
+- follow-up analysis
+- rating and satisfaction signals
+- stage judgment
+- recommended actions
+- one-line conclusion
+- metric notes / caveats
+
+Use `assets/report-template.md` as the default skeleton.
+Use `assets/export-manifest-template.md` when the task includes standalone detail outputs.
+
+## Live Helper
+
+This skill includes a local helper script for live AI-Shifu lookup:
+
+- `scripts/creator-analysis-cli.py`
+
+Use it when the current environment has:
+
+- `SHIFU_BASE_URL`
+- `SHIFU_TOKEN`
+
+available either in this skill's `.env`, via CLI args, or via the fallback `.env` from `ai-shifu-course-creator`.
+
+Typical commands:
+
+```bash
+python scripts/creator-analysis-cli.py login --region cn --phone <phone>
+python scripts/creator-analysis-cli.py login --region cn --phone <phone> --sms-code <code>
+python scripts/creator-analysis-cli.py entry
+python scripts/creator-analysis-cli.py context <shifu_bid>
+python scripts/creator-analysis-cli.py export <shifu_bid> learner_progress
+python scripts/creator-analysis-cli.py export <shifu_bid> follow_up_detail
+python scripts/creator-analysis-cli.py bundle <shifu_bid>
+```
+
+## Output Modes
+
+Choose one of these modes based on the user request.
+
+### `report-only`
+- output only the creator-facing report
+
+### `report-with-appendix`
+- output the creator-facing report
+- add a compact appendix with representative follow-up or learner examples
+
+### `report-with-exports`
+- output the creator-facing report
+- optionally include a compact appendix
+- also output standalone detail tables such as CSV or Markdown tables
+
+When the user provides CSV files or explicitly asks for detailed data output, prefer `report-with-exports`.
+
+
+## Access Preconditions
+
+Before using live creator-facing course data, apply these checks:
+- confirm the user is authenticated
+- confirm owner check passes for the requested course in the current version
+- confirm uploaded CSV, screenshots, or offline tables belong to the same course
+
+If these checks do not pass, do not continue as if access is valid. See `references/access-and-scope-checks.md`.
+
+## Input Expectations
+
+Accept any mix of:
+- dashboard screenshots
+- analytics exports
+- SQL results
+- CSV or spreadsheet summaries
+- chapter-level or learner-level tables
+- follow-up detail samples
+- rating samples or comments
+- creator notes about course goal, audience, price, or current concern
+
+If critical data is missing, continue with a partial report and mark the missing fields explicitly. For AI-Shifu-specific work, first check `references/ai-shifu-current-surface.md` so the report does not assume a dashboard capability that the current product does not yet expose.
+
+## Direct Invocation Flow
+
+When the user invokes this skill directly for AI-Shifu creator analysis, prefer the following conversation flow.
+
+### If the user provides only a course id or `shifu_bid`
+
+1. Treat this as a live-course lookup request.
+2. Confirm or assume the current environment can provide authenticated user context.
+3. Run the current version's owner-only access checks before analysis.
+4. If live analysis context is available, default to `report-only`.
+5. If live export endpoints are also available and the user asks for detail rows, switch to `report-with-exports`.
+
+Do not ask the user to prepare CSV files first when live lookup is sufficient for the requested report.
+
+### If the user provides a course id plus screenshots
+
+1. Use live lookup for the core report.
+2. Use screenshots only as supporting evidence.
+3. If screenshots do not clearly match the requested course, stop and ask for clarification instead of blending evidence.
+
+### If the user provides CSV files or exported tables
+
+1. Prefer `report-with-exports`.
+2. Preserve source fields whenever possible.
+3. Add derived fields only as extra columns, not replacements.
+
+### If live lookup is unavailable
+
+1. Downgrade to offline-only analysis.
+2. State clearly that login / owner verification could not be confirmed in this run.
+3. Continue only with the evidence the user actually provided.
+
+### If login is missing or the token is expired
+
+Prefer a human-style recovery flow instead of immediately asking the user for a raw token.
+
+Recommended interaction order:
+
+1. say that live lookup needs a fresh login
+2. offer to help the user log in now
+3. ask for the phone number
+4. send the SMS code
+5. ask the user to provide the received code
+6. verify the code, save the token silently, and continue the live lookup
+
+For China-mainland environments, prefer using:
+
+```bash
+python scripts/creator-analysis-cli.py login --region cn --phone <phone>
+python scripts/creator-analysis-cli.py login --region cn --phone <phone> --sms-code <code>
+```
+
+This should feel like a guided login flow, not a configuration task. Only fall back to manual token input when the environment does not support SMS login, such as the global region.
+
+### First-turn behavior
+
+If the user says something like:
+
+- `Analyze course shifu_bid=...`
+- `Use creator-course-analysis-report for this course`
+- `Give me a creator report for course ...`
+
+then the skill should:
+
+1. identify the course id
+2. choose live-course analysis when possible
+3. decide whether the default output should be `report-only` or `report-with-exports`
+4. proceed with the smallest number of clarification questions needed to keep the run accurate
+
+If live lookup fails only because auth is stale, the next question should be about login recovery, not about CSV upload.
+
+## Analysis Order
+
+Follow this order unless the user asks for a narrower task.
+
+1. Identify the analysis object.
+- single course, multiple courses, time window, cohort, or chapter slice
+- creator goal: revenue, completion, engagement, satisfaction, or diagnosis
+
+2. Normalize the evidence boundary.
+- separate observed facts from interpretation
+- do not infer unavailable metrics
+- if screenshots are partial, mark the report as partial
+- when working on AI-Shifu data, distinguish current live dashboard metrics from extra offline evidence such as follow-up detail exports or learner tables
+
+3. Read the course at three layers.
+- business layer: exposure, orders, paid learners, revenue, coupon or campaign effects
+- learner layer: started learners, active learners, completion, depth, return behavior
+- content layer: chapter reach, chapter completion, follow-up hotspots, low-score hotspots
+
+4. Explain the learning path.
+- where learners enter
+- where they continue
+- where they stall
+- where they drop
+- which chapters create repeated confusion or repeated value
+
+5. Interpret follow-ups carefully.
+- high follow-up volume is not automatically bad
+- distinguish “healthy engagement” from “blocked understanding”
+- use follow-up detail samples to identify repeated concepts, ambiguous phrasing, missing examples, or pacing issues
+
+6. Read learner variables or qualitative fields when available.
+- cluster repeated inputs into themes instead of listing raw text only
+- use those themes to explain learner persona, pressure, and pain points
+- keep qualitative evidence supportive, not magically definitive
+
+7. Write a stage judgment.
+- early validation
+- growth with structural bottlenecks
+- mature but locally weak
+- strong sales but weak learning retention
+- strong learning signal but weak conversion
+
+8. End with action recommendations.
+- prioritize actions by impact and effort
+- prefer content, structure, onboarding, pricing, or promotion recommendations that are directly supported by the evidence
+
+## Required Reporting Discipline
+
+Always separate these four layers in the write-up:
+- `Observation`: what the data directly shows
+- `Interpretation`: the most likely explanation
+- `Confidence`: high / medium / low based on evidence completeness
+- `Suggested action`: what the creator should do next
+
+Do not blur assumptions into facts.
+
+## Interpretation Rules
+
+- Compare chapters before judging the whole course.
+- Use learner progress plus follow-up detail together; do not rely on only one.
+- Treat rating signals as supporting evidence, not the whole conclusion.
+- If business data and learning data conflict, call out the conflict explicitly.
+- Distinguish count-based metrics from user-based metrics.
+- Distinguish total follow-ups from follow-up learners and follow-up rate.
+- Prefer ratios and distributions over raw totals when course sizes differ.
+- If the course is newly launched or sample size is low, state that conclusions are directional.
+- In AI-Shifu, treat `avg_learning_duration_seconds` as an approximate learning span unless the user provides a more precise duration source.
+
+## Report Modes
+
+### Full report
+
+Use the full template when enough data exists across metrics, learner behavior, and chapter or follow-up signals.
+
+### Diagnosis memo
+
+Use a shorter memo when the user asks a narrow question such as:
+- why completion is low
+- why a chapter has many follow-ups
+- whether the course should optimize content or conversion first
+
+### Comparison note
+
+Use a comparison structure when the user asks to compare:
+- two courses
+- two time periods
+- two learner cohorts
+- before and after a course change or promotion
+
+## Reusable References
+
+Read only the references needed for the task.
+
+- `references/ai-shifu-current-surface.md`: what the current AI-Shifu creator dashboard actually exposes
+- `references/ai-shifu-metric-notes.md`: current project-specific metric meanings and confidence levels
+- `references/report-style-patterns.md`: how to write the report in the creator-report style shown by the reference analysis
+- `references/variable-theme-analysis.md`: how to turn learner variables or structured text fields into persona and pain-point diagnosis
+- `references/conclusion-and-notes.md`: how to write reusable one-line conclusions and explicit metric notes
+- `references/detail-export-modes.md`: when to output only the report, add an appendix, or emit standalone exports
+- `references/detail-output-specs.md`: standard shapes for follow-up and learner-progress detail outputs
+- `references/access-and-scope-checks.md`: login check, owner check, and evidence match rules for the current version
+- `references/report-structure.md`: section-by-section writing guide
+- `references/metric-dictionary.md`: creator-facing metric definitions and cautions
+- `references/learner-analysis.md`: how to read progress, coverage, depth, and rhythm
+- `references/follow-up-analysis.md`: how to read follow-up counts, details, and hotspots
+- `references/stage-judgement.md`: how to classify the course stage and choose actions
+
+## Output Language
+
+Write the final report in the user's requested language. If the user does not specify a language, match the language of the request.
+
+### Default language rule
+
+- if the conversation is in Chinese, output the report in Chinese
+- if the conversation is in English, output the report in English
+- do not ask an extra language question unless the user explicitly asks for bilingual output or the target audience is unclear
+
+### Bilingual output rule
+
+If the user explicitly asks for bilingual delivery, output two separate files instead of mixing languages in one file.
+
+Recommended pattern:
+
+- one Chinese report file
+- one English report file
+
+Prefer:
+
+- `creator-course-report.zh-CN.md`
+- `creator-course-report.en-US.md`
+
+If appendix files are also needed, keep them separate too:
+
+- `creator-course-report-appendix.zh-CN.md`
+- `creator-course-report-appendix.en-US.md`
+
+If an export manifest is needed, keep that separate as well:
+
+- `export-manifest.zh-CN.md`
+- `export-manifest.en-US.md`
+
+### Export language rule
+
+- keep raw detail export fields as close to source fields as possible
+- do not translate source-column meaning inline if that would make the export unstable
+- when bilingual delivery is requested, prefer translating the report files while keeping raw exports source-stable unless the user explicitly asks for translated export headers
+
+## Detail Output Discipline
+
+- Keep the main report readable; do not paste large raw tables into the main body.
+- Preserve original CSV fields whenever possible in standalone exports.
+- Add derived columns as extra fields rather than replacing source fields.
+- If the user asks for “this kind of detail data”, output both the report and the detail file spec when appropriate.
+- When selecting appendix examples, prefer representative rows that support the report conclusion.
+
+## Failure and Gap Handling
+
+When data is incomplete:
+- say what is missing
+- downgrade confidence
+- keep the report useful with directional findings
+- recommend the next data pull needed to firm up the conclusion
+
+When access checks fail:
+- stop live-course analysis
+- state whether the failure is login, owner, or evidence-match related
+- do not behave as if the current user is authorized for that course
+
+Do not fabricate chapter-level, learner-level, or revenue-level findings that the provided data cannot support.

--- a/skills/creator-course-analysis-report/SKILL.md
+++ b/skills/creator-course-analysis-report/SKILL.md
@@ -95,6 +95,26 @@ If critical data is missing, continue with a partial report and mark the missing
 
 When the user invokes this skill directly for AI-Shifu creator analysis, prefer the following conversation flow.
 
+### Default guided flow
+
+Unless the user already provided a valid course id and explicitly asked for a narrow export, prefer this default guided workflow:
+
+1. Briefly explain what the skill does.
+2. Check whether a valid login is already available.
+3. If login is missing or expired, guide the user through phone + SMS-code login.
+4. After login succeeds, list the current account's available courses.
+5. Ask which course the user wants to analyze.
+6. Run the owner check for that selected course.
+7. Ask whether to export:
+   - report only
+   - report + learner data table + follow-up data table
+8. Fetch only the data needed for the selected output mode.
+9. Generate the report or report-plus-tables in the interaction language.
+
+Keep the interaction concise, direct, and task-oriented. Match the steady product-assistant tone used by other AI-Shifu skills: explain the current step, state the next action, and avoid overly chatty or playful phrasing.
+
+See `references/conversation-flow.md` for the recommended wording pattern and the exact decision points.
+
 ### If the user provides only a course id or `shifu_bid`
 
 1. Treat this as a live-course lookup request.
@@ -161,6 +181,40 @@ then the skill should:
 4. proceed with the smallest number of clarification questions needed to keep the run accurate
 
 If live lookup fails only because auth is stale, the next question should be about login recovery, not about CSV upload.
+
+### Course selection after login
+
+After a successful live login, do not immediately ask the user to type a course id from memory unless there is only one possible course. Prefer this order:
+
+1. call the entry/list surface
+2. show the courses owned by the current account
+3. let the user choose by course name or `shifu_bid`
+4. if there are too many courses, show the top slice and still accept a direct `shifu_bid`
+
+When listing courses, keep the list lightweight. Prefer:
+
+- course name
+- `shifu_bid`
+- learner count when available
+- order count when available
+
+If the entry surface returns no course, say so clearly instead of pretending the account has analysis-ready content.
+
+### Output mode selection
+
+For live guided use, prefer exactly two user-facing choices:
+
+1. report only
+2. report + learner data table + follow-up data table
+
+Do not force the user to understand internal mode labels such as `report-only` or `report-with-exports`. Translate those internal modes into plain product language in the interaction.
+
+Map them as follows:
+
+- `report only` -> `report-only`
+- `report + learner data table + follow-up data table` -> `report-with-exports`
+
+If the user asks for only one detail table, honor that narrower request instead of forcing the bundled export.
 
 ## Analysis Order
 
@@ -306,8 +360,10 @@ If an export manifest is needed, keep that separate as well:
 
 ### Export language rule
 
-- keep raw detail export fields as close to source fields as possible
-- do not translate source-column meaning inline if that would make the export unstable
+- report body language follows the interaction language unless the user explicitly requests another language
+- detail-table headers and surrounding explanatory text should follow the interaction language as well
+- keep raw detail cell values as close to source values as possible
+- do not translate source text fields such as learner nicknames, follow-up content, or answer content unless the user explicitly asks for translated raw content
 - when bilingual delivery is requested, prefer translating the report files while keeping raw exports source-stable unless the user explicitly asks for translated export headers
 
 ## Detail Output Discipline

--- a/skills/creator-course-analysis-report/agents/openai.yaml
+++ b/skills/creator-course-analysis-report/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Creator Course Analysis Report"
+  short_description: "Creator-facing course report skill"
+  default_prompt: "Use $creator-course-analysis-report to turn creator-facing course data, learner progress, follow-up details, ratings, and business metrics into a structured analysis report with conclusions and next-step recommendations."

--- a/skills/creator-course-analysis-report/assets/export-manifest-template.md
+++ b/skills/creator-course-analysis-report/assets/export-manifest-template.md
@@ -7,7 +7,7 @@
 - `creator-analysis-report.md`
 
 ## Optional appendix sections included
-- 
+-
 
 ## Detail exports included
 - `follow-up-details.csv`

--- a/skills/creator-course-analysis-report/assets/export-manifest-template.md
+++ b/skills/creator-course-analysis-report/assets/export-manifest-template.md
@@ -1,0 +1,22 @@
+# Export Manifest
+
+## Requested output mode
+- report-only / report-with-appendix / report-with-exports:
+
+## Main deliverables
+- `creator-analysis-report.md`
+
+## Optional appendix sections included
+- 
+
+## Detail exports included
+- `follow-up-details.csv`
+- `learner-progress-details.csv`
+- `follow-up-details-enriched.csv`
+- `learner-progress-details-enriched.csv`
+- `learner-theme-clusters.md`
+
+## Notes
+- Which outputs preserve raw source fields:
+- Which outputs add derived columns:
+- Which outputs are filtered subsets vs full exports:

--- a/skills/creator-course-analysis-report/assets/report-template.md
+++ b/skills/creator-course-analysis-report/assets/report-template.md
@@ -7,9 +7,9 @@
 - Confidence boundary:
 
 ## 1. Summary
-- 
-- 
-- 
+-
+-
+-
 
 ## 2. Core Metrics
 - Orders / Paid learners / Revenue:
@@ -53,9 +53,9 @@
 - What is still not stable:
 
 ## 8. Recommended Actions
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## 9. One-Line Conclusion
 - Current state:

--- a/skills/creator-course-analysis-report/assets/report-template.md
+++ b/skills/creator-course-analysis-report/assets/report-template.md
@@ -1,0 +1,78 @@
+# {Course Name} Creator Analysis Report
+
+## 0. Evidence Scope
+- Data sources used:
+- Current live dashboard fields used:
+- Extra offline tables / screenshots used:
+- Confidence boundary:
+
+## 1. Summary
+- 
+- 
+- 
+
+## 2. Core Metrics
+- Orders / Paid learners / Revenue:
+- Started learners / Active learners / Completed learners:
+- Completion rate:
+- Follow-up learners / Follow-up count / Follow-up rate:
+- Rating count / Average rating:
+
+## 3. Learning Progress and Coverage
+### 3.1 Learner depth
+
+### 3.2 Chapter coverage
+
+### 3.3 Learning rhythm
+
+## 4. Learner Personas and Common Pain Points
+### 4.1 Repeated learner themes
+
+### 4.2 Common pain points
+
+### 4.3 Interpretation
+
+
+## 5. Follow-Up Analysis
+### 5.1 Hotspot chapters
+
+### 5.2 Repeated follow-up themes
+
+### 5.3 Diagnosis
+
+## 6. Rating and Satisfaction Signals
+- Rating count:
+- Average rating:
+- Sample caveat:
+
+
+## 7. Stage Judgment
+- Primary stage:
+- Why:
+- What is already validated:
+- What is still not stable:
+
+## 8. Recommended Actions
+1. 
+2. 
+3. 
+
+## 9. One-Line Conclusion
+- Current state:
+
+## 10. Metric Notes / Caveats
+- Denominator notes:
+- Counting rules:
+- Current live dashboard vs offline evidence:
+- Missing evidence:
+- Confidence caveat:
+
+## Appendix A. Representative Follow-Up Examples
+- Chapter:
+- Learner question:
+- Why it matters:
+
+## Appendix B. Representative Learner Progress Rows
+- Learner:
+- Progress signal:
+- Why it matters:

--- a/skills/creator-course-analysis-report/references/access-and-scope-checks.md
+++ b/skills/creator-course-analysis-report/references/access-and-scope-checks.md
@@ -1,0 +1,58 @@
+# Access and Scope Checks
+
+Use this reference before analyzing creator-facing course data.
+
+## Current permission model
+
+For the current version of this skill, use the strictest simple rule:
+- login check
+- owner check
+- evidence match check
+
+Do not broaden this to collaborator or broader creator access unless the skill is explicitly updated later.
+
+## 1. Login check
+
+Before reading course analytics or using course-private data:
+- confirm the user is authenticated
+- if there is no authenticated user context, stop and ask for authenticated context or treat the task as offline-only analysis with no live course lookup
+
+## 2. Owner check
+
+For the current version:
+- when the user asks to analyze a specific course by course id or `shifu_bid`, confirm that the current user is the owner of that course
+- if owner status cannot be confirmed, do not continue as if access is valid
+- if owner status is false, stop and explain that the current version only supports owner-level analysis
+
+This is intentionally narrower than future collaborator-based access.
+
+## 3. Evidence match check
+
+When the user provides CSV, screenshots, exported tables, or offline analysis files:
+- confirm that the evidence belongs to the same requested course
+- check course name, course id, report title, chapter set, or other identifying markers when available
+- if the evidence appears to belong to another course, stop and ask for clarification instead of blending mismatched evidence
+
+## Allowed modes
+
+### Live-course analysis
+Require all three:
+- authenticated user
+- owner check passes
+- evidence matches the course when offline files are mixed in
+
+### Offline-only analysis
+If the user only wants a draft analysis of manually provided files and does not ask for live system lookup:
+- login check may be unavailable in practice
+- owner check may be unverifiable in practice
+- in that case, clearly mark the report as offline-only and unverified against live ownership
+
+However, if the surrounding product flow is supposed to be creator-private, prefer authenticated owner-confirmed usage.
+
+## Failure behavior
+
+If any of the three checks fail:
+- do not proceed as though the course is authorized
+- do not infer hidden course data
+- clearly state which check failed
+- ask for corrected course identity or corrected evidence when necessary

--- a/skills/creator-course-analysis-report/references/ai-shifu-current-surface.md
+++ b/skills/creator-course-analysis-report/references/ai-shifu-current-surface.md
@@ -1,0 +1,74 @@
+# AI-Shifu Current Surface
+
+This file describes the current creator-facing analytics surface that already exists in AI-Shifu.
+
+## Current creator dashboard routes
+
+Current live routes are:
+- `/api/dashboard/entry`
+- `/api/dashboard/shifus/<shifu_bid>/detail`
+
+Current frontend pages are:
+- `src/cook-web/src/app/admin/dashboard/page.tsx`
+- `src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx`
+
+## What the current entry page exposes
+
+### Entry summary
+- `course_count`
+- `learner_count`
+- `order_count`
+- `order_amount`
+
+### Per-course row
+- `shifu_bid`
+- `shifu_name`
+- `learner_count`
+- `order_count`
+- `order_amount`
+- `last_active_at`
+- `last_active_at_display`
+
+## What the current course detail page exposes
+
+### Basic info
+- `course_name`
+- `created_at`
+- `chapter_count`
+- `learner_count`
+
+### Detail metrics
+- `order_count`
+- `order_amount`
+- `completed_learner_count`
+- `completion_rate`
+- `active_learner_count_last_7_days`
+- `total_follow_up_count`
+- `avg_follow_up_count_per_learner`
+- `avg_learning_duration_seconds`
+
+## Important current limitations
+
+- The current creator dashboard does **not** yet expose live learner drill-down rows.
+- The current creator dashboard does **not** yet expose follow-up detail lists in the live UI.
+- The current dashboard charts are still placeholders in the current frontend page.
+- If the user asks for learner-level pain points or follow-up detail analysis, expect to need extra inputs such as screenshots, exports, SQL results, or manually prepared tables.
+
+## Best use of this skill right now
+
+Use this skill in two modes:
+- `dashboard-supported mode`: when the creator only needs report sections supported by current dashboard metrics
+- `extended evidence mode`: when the creator also provides learner detail, chapter detail, follow-up samples, rating samples, or offline analysis tables
+
+When only current dashboard metrics are available, keep the report high-level and do not invent chapter-level or learner-level findings.
+
+## What can still be analyzed from offline report inputs
+
+Even though the live dashboard is currently limited, this skill can still analyze deeper creator questions when the user supplies extra evidence such as:
+- learner variable exports
+- chapter coverage tables
+- follow-up detail samples
+- ratings or qualitative feedback
+- manually prepared analysis notes
+
+That means the skill can still produce sections such as learner personas, repeated pain points, or follow-up topic clusters, but only when the evidence is explicitly provided.

--- a/skills/creator-course-analysis-report/references/ai-shifu-metric-notes.md
+++ b/skills/creator-course-analysis-report/references/ai-shifu-metric-notes.md
@@ -1,0 +1,99 @@
+# AI-Shifu Metric Notes
+
+This file records the current project-specific metric meanings inferred from code and product specs.
+
+## Course scope
+
+Creator dashboard data is course-scoped by `shifu_bid`.
+Entry-level totals are restricted to courses visible to the current creator or collaborator.
+
+## Learner set
+
+### Current learner_count meaning
+In current AI-Shifu dashboard logic, learner-related counts are not purely “progress learners only”.
+
+The learner set includes:
+- users with at least one non-reset `LearnProgressRecord` for the course
+- users with a successful manual-import order for the course (`payment_channel == "manual"`)
+
+This means `learner_count` can include imported or manually opened learners even if their in-course progress is limited.
+
+## Order metrics
+
+### `order_count`
+- counts successful, non-deleted course orders
+- detail page uses all successful orders for the course
+- entry page uses date-range filtered successful orders when a time filter is applied
+
+### `order_amount`
+- sum of `paid_price` for successful, non-deleted orders
+- use as actual paid amount, not list price
+
+## Completion metrics
+
+### `chapter_count`
+- current detail page uses visible leaf outline count from published outline items
+- hidden outlines are excluded
+- the visible leaf count acts as the required lesson count baseline
+
+### `completed_learner_count`
+A learner is considered completed when the learner has completion coverage across all visible leaf outlines under current dashboard logic.
+
+Use caution:
+- this is outline-level completion, not deeper block-level mastery
+- it is suitable for creator reporting, but should not be described as fine-grained mastery
+
+### `completion_rate`
+- current implementation is `completed_learner_count / learner_count`
+- always state that denominator is the dashboard learner set
+
+## Activity metrics
+
+### `active_learner_count_last_7_days`
+- distinct learners with non-reset progress records updated in the last 7 days
+- this is recent in-course activity, not broader site activity
+
+### `last_active_at`
+- current entry page uses the latest progress `updated_at` as course last-active proxy
+- use it as learning activity signal, not revenue activity signal
+
+## Follow-up metrics
+
+### `total_follow_up_count`
+- counts student follow-up ask blocks only
+- source is `LearnGeneratedBlock`
+- filter is effectively `type = MDASK` and `role = student`
+- it is a question count, not an answer count and not a distinct learner count
+
+### `avg_follow_up_count_per_learner`
+- current implementation is `total_follow_up_count / learner_count`
+- describe carefully as an average over the current dashboard learner set
+
+## Learning duration
+
+### `avg_learning_duration_seconds`
+- current implementation approximates per-learner duration as:
+  - `max(updated_at) - min(created_at)` across that learner's non-reset progress records in the course
+- dashboard then averages those learner durations across the learner set
+
+Use caution:
+- this is an approximation of learning span, not actual active watch time or active reading time
+- call it “average learning span” or explain the approximation when precision matters
+
+## Data-confidence guidance
+
+### High confidence
+- order_count
+- order_amount
+- learner_count
+- total_follow_up_count
+
+### Medium confidence
+- completion_rate
+- completed_learner_count
+- active_learner_count_last_7_days
+
+### Lower-confidence / approximation-based
+- avg_learning_duration_seconds
+- any chapter-level diagnosis inferred without direct chapter tables
+- any learner persona conclusion inferred without learner-level drill-down inputs

--- a/skills/creator-course-analysis-report/references/conclusion-and-notes.md
+++ b/skills/creator-course-analysis-report/references/conclusion-and-notes.md
@@ -1,0 +1,76 @@
+# Conclusion and Metric Notes
+
+Use this reference for the final two sections of the creator report: the one-line conclusion and the metric notes.
+
+## One-Line Conclusion Style
+
+The one-line conclusion should be short enough to paste into:
+- a creator sync note
+- a review meeting note
+- a product or teaching update
+- a management summary
+
+It should usually contain three parts:
+- current stage or current overall condition
+- one confirmed strength
+- one main limit or next priority
+
+## Recommended formula
+
+Use a sentence close to this structure:
+- `This course is currently in {stage}; it already shows {main strength}, but {main limitation}, so the next priority is {action focus}.`
+
+Chinese-style equivalent:
+- `当前课程处于{阶段}，已经体现出{主要优势}，但{主要限制}仍然存在，下一步应优先{动作重点}。`
+
+## Good conclusion characteristics
+
+- includes one stable business or learning judgment
+- does not try to repeat every metric
+- avoids dramatic certainty when the sample is small
+- names the next action direction instead of ending as a passive summary
+
+## Stage phrasing patterns
+
+Useful phrasing patterns:
+- early validation stage
+- broad early reach but shallow depth
+- engagement signal exists but deep completion is still developing
+- conversion signal exists but learning retention is the current bottleneck
+- learning value is confirmed, but commercial conversion still needs work
+
+## Metric Notes Style
+
+This section should protect report reuse.
+It should explain:
+- how key denominators were defined
+- whether metrics come from live dashboard fields or extra offline evidence
+- where the data is approximate, partial, or sample-sensitive
+
+## Minimum metric notes checklist
+
+Always try to state:
+- learner denominator
+- completion denominator
+- follow-up counting rule
+- rating counting rule
+- whether chapter coverage is based on published visible leaf outlines
+- whether learning duration is an approximation
+- what evidence was not available
+
+## AI-Shifu-specific note style
+
+For AI-Shifu reports, the notes section should explicitly distinguish:
+- current live dashboard metrics
+- extra offline evidence such as screenshots, learner variable exports, follow-up samples, or manual analysis tables
+
+If the report mixes both, say so clearly.
+
+## Confidence labels
+
+Use simple confidence labels when the report is likely to be reused:
+- high confidence
+- medium confidence
+- directional only
+
+If sample size is still small, use `directional only` or `medium confidence` instead of giving overly hard conclusions.

--- a/skills/creator-course-analysis-report/references/conversation-flow.md
+++ b/skills/creator-course-analysis-report/references/conversation-flow.md
@@ -1,0 +1,126 @@
+# Conversation Flow
+
+Use this reference when the skill is operating as a live creator-analysis assistant instead of an offline report writer.
+
+## Tone and style
+
+Keep the style aligned with other AI-Shifu skills:
+
+- concise
+- direct
+- professional
+- task-oriented
+
+Good patterns:
+
+- "I can generate a creator course analysis report for your courses."
+- "Please enter your phone number."
+- "Login succeeded. I am loading your courses."
+- "Please choose the course to analyze."
+- "Please choose the export mode."
+
+Avoid:
+
+- overly playful or cute phrasing
+- long greetings
+- repeated reassurance without new information
+- exposing raw token/config language unless recovery requires it
+
+## Recommended guided flow
+
+### Step 1: explain capability
+
+Start with one short capability statement.
+
+Recommended pattern:
+
+- "I can generate a creator course analysis report, and I can also export learner and follow-up detail tables if you need them."
+
+### Step 2: recover login if needed
+
+If there is no valid login:
+
+1. ask for phone number
+2. send SMS code
+3. ask for SMS code
+4. verify and continue silently
+
+Recommended wording:
+
+- "A login is required first. Please enter your phone number."
+- "The SMS code has been sent. Please enter the code."
+- "Login succeeded. I am loading your courses."
+
+### Step 3: list available courses
+
+After login succeeds, list the courses under the current account before asking for a course id from memory.
+
+Recommended wording:
+
+- "I found these courses under the current account. Please choose the course to analyze. You can reply with the course name or course ID."
+
+Preferred list fields:
+
+- course name
+- `shifu_bid`
+- learner count
+- order count
+
+### Step 4: owner check
+
+Before analysis, verify that the selected course belongs to the logged-in account.
+
+Recommended success wording:
+
+- "The course ownership check passed."
+
+Recommended failure wording:
+
+- "The current account does not have access to this course, so I cannot continue with the analysis."
+
+Do not continue as if access were valid when the owner check fails.
+
+### Step 5: ask for export mode
+
+Prefer exactly two default choices:
+
+1. report only
+2. report + learner data table + follow-up data table
+
+Recommended wording:
+
+- "Please choose the export mode: 1) report only, or 2) report plus learner and follow-up data tables."
+
+If the user asks for only one detail table, honor that narrower request.
+
+### Step 6: generate outputs
+
+If the user chooses report only:
+
+- generate the creator-facing report
+
+If the user chooses report + tables:
+
+- generate the creator-facing report
+- generate the learner data table
+- generate the follow-up data table
+
+Recommended completion wording:
+
+- "The analysis report is ready."
+- "The analysis report and detail tables are ready."
+
+## Language behavior
+
+- if the interaction is in Chinese, write the report and table headers in Chinese
+- if the interaction is in English, write the report and table headers in English
+- do not ask a separate language question unless the user requests another target language or bilingual delivery
+- preserve raw source text fields in their original language unless the user explicitly asks for translated raw content
+
+## Fallback behavior
+
+If live lookup fails:
+
+- state whether the problem is login, owner check, or unavailable data
+- continue with offline evidence only when the user already provided offline evidence
+- do not pretend live analysis succeeded

--- a/skills/creator-course-analysis-report/references/detail-export-modes.md
+++ b/skills/creator-course-analysis-report/references/detail-export-modes.md
@@ -1,0 +1,96 @@
+# Detail Export Modes
+
+Use this reference when the user wants not only a creator-facing report, but also reusable detail tables.
+
+## Default principle
+
+Do not dump large raw tables into the main report body.
+
+Preferred output layering:
+- main report: conclusions and recommendations
+- appendix: selected supporting examples
+- separate detail files: full or filtered detail tables
+
+## Supported output modes
+
+### 1. `report-only`
+Use when the user wants a fast creator-facing readout.
+
+Output:
+- one report only
+
+Recommended file:
+- `creator-analysis-report.md`
+
+### 2. `report-with-appendix`
+Use when the user wants a readable report plus a compact evidence section.
+
+Output:
+- main report
+- appendix with selected follow-up examples or selected learner progress rows
+
+Recommended file:
+- `creator-analysis-report.md`
+
+Appendix rules:
+- include only representative or high-value examples
+- do not paste hundreds of raw rows
+- favor samples that explain the conclusion
+
+### 3. `report-with-exports`
+Use when the user wants both the report and reusable structured detail outputs.
+
+Output:
+- main report
+- optional appendix with selected evidence
+- one or more standalone detail files
+
+Recommended files:
+- `creator-analysis-report.md`
+- `follow-up-details.csv`
+- `learner-progress-details.csv`
+- optional: `learner-theme-clusters.md`
+
+This is the preferred mode when the user supplies CSV files or explicitly asks for detailed data output.
+
+## What belongs in the main report vs exports
+
+### Keep in the main report
+- summary findings
+- grouped metrics
+- top hotspots
+- recurring learner themes
+- representative examples
+- recommendations
+
+### Move to exports
+- full follow-up rows
+- full learner progress rows
+- large chapter coverage tables
+- repeated raw learner variable rows
+- anything too long for a report reader to scan comfortably
+
+## Export strategies
+
+### Full export
+Use when the user explicitly asks for all detail rows.
+
+### Filtered export
+Use when only a subset is needed, for example:
+- high-follow-up learners
+- hotspot chapters
+- low-depth learners
+- high-value representative follow-ups
+
+### Enriched export
+Use when it is helpful to add derived columns while preserving the original fields.
+Examples:
+- `theme_cluster`
+- `question_type`
+- `learner_depth_bucket`
+- `risk_flag`
+- `is_representative_example`
+
+## Important rule
+
+Preserve the original input fields whenever possible. Add derived columns as extra fields, not replacements, unless the user asks for a transformed-only output.

--- a/skills/creator-course-analysis-report/references/detail-output-specs.md
+++ b/skills/creator-course-analysis-report/references/detail-output-specs.md
@@ -1,0 +1,94 @@
+# Detail Output Specs
+
+Use these output specs when the user supplies AI-Shifu creator-analysis CSV inputs or asks for detail tables.
+
+## 1. Follow-up detail output
+
+### Typical source shape
+Common source columns include:
+- learner phone
+- follow-up chapter
+- learner question
+- AI answer
+
+### Standard output goal
+Produce one of:
+- a preserved raw copy
+- a filtered subset
+- an enriched export with derived columns
+
+### Recommended output fields
+Preserve original fields first, then optionally add:
+- `theme_cluster`
+- `question_type`
+- `chapter_hotspot_flag`
+- `is_representative_example`
+- `analysis_note`
+
+### Question type examples
+- concept clarification
+- application mapping
+- terminology clarification
+- KPI / metric understanding
+- report or communication framing
+- action design
+
+## 2. Learner progress detail output
+
+### Typical source shape
+Common source columns include:
+- learner phone
+- nickname
+- learner id
+- chapter sequence
+- chapter title
+- chapter id
+- chapter type code
+- learning status code
+- progress position
+- chapter first learning time
+- chapter latest learning time
+- chapter follow-up count
+- learner total follow-up count
+- learner learned chapter count
+- learner first learning time
+- learner latest learning time
+
+### Standard output goal
+Produce one of:
+- a preserved raw copy
+- a grouped or filtered subset
+- an enriched export with diagnostic columns
+
+### Recommended derived fields
+- `learner_depth_bucket`
+- `engagement_flag`
+- `dropoff_risk_flag`
+- `chapter_hotspot_flag`
+- `analysis_note`
+
+### Learner depth bucket examples
+- started-only
+- shallow
+- mid-depth
+- deep
+- near-complete
+
+## 3. Appendix selection rule
+
+When generating appendix examples for the report:
+- pick rows that explain the report conclusion
+- prefer repeated patterns over one-off oddities
+- include enough raw wording to stay credible
+- keep the appendix much shorter than the full export
+
+## 4. File naming rule
+
+Use names that are stable and readable.
+Examples:
+- `creator-analysis-report.md`
+- `follow-up-details.csv`
+- `follow-up-details-enriched.csv`
+- `learner-progress-details.csv`
+- `learner-progress-details-enriched.csv`
+- `learner-theme-clusters.md`

--- a/skills/creator-course-analysis-report/references/follow-up-analysis.md
+++ b/skills/creator-course-analysis-report/references/follow-up-analysis.md
@@ -1,0 +1,44 @@
+# Follow-Up Analysis
+
+Use follow-up data to detect both healthy engagement and blocked understanding.
+
+## Read Follow-Ups in Three Layers
+
+### Volume layer
+Look at:
+- total follow-up count
+- follow-up learners
+- follow-up rate
+- hotspot chapters or lessons
+
+### Detail layer
+Read detail samples for repeated themes such as:
+- concept not understood
+- missing example
+- unclear terminology
+- task instruction ambiguity
+- learner trying to apply the idea to their own case
+
+### Interpretation layer
+Classify the signal:
+- `healthy engagement`: learners are extending, applying, or comparing ideas
+- `blocked understanding`: learners repeatedly ask for basic clarification or step recovery
+- `instruction gap`: learners are confused about what to do next
+- `expectation gap`: learners expected a different scope or difficulty
+
+## Important Cautions
+- high follow-up volume can indicate strong learner participation, not only confusion
+- low follow-up volume can indicate either clarity or disengagement; cross-check with progress
+- use chapter coverage plus follow-up detail together before concluding
+
+## Useful Output Pattern
+For each major hotspot, write:
+- chapter / lesson
+- observed signal
+- likely reason
+- confidence level
+- recommended content action
+
+## AI-Shifu-specific reminder
+- Current live AI-Shifu creator dashboard exposes total follow-up count and average follow-up count per learner, but not the full follow-up detail list in the current live UI.
+- For chapter-level hotspot analysis or repeated-theme diagnosis, require screenshots, exports, SQL results, or manually extracted follow-up samples.

--- a/skills/creator-course-analysis-report/references/learner-analysis.md
+++ b/skills/creator-course-analysis-report/references/learner-analysis.md
@@ -1,0 +1,52 @@
+# Learner Analysis
+
+Use learner behavior to explain where the course creates value and where it loses momentum.
+
+## What to Look For
+
+### Learning depth
+Ask:
+- how many learners only start
+- how many reach the middle
+- how many reach the end
+- whether depth loss is early, mid-course, or late
+
+### Chapter coverage
+Ask:
+- which chapters have strong reach
+- where the biggest drop occurs
+- whether the drop is gradual or cliff-like
+
+### Learning rhythm
+Ask:
+- do learners continue over multiple sessions
+- is activity clustered only at the beginning
+- do learners return after the first day or first week
+
+## Common Patterns
+
+### Strong start, weak continuation
+Likely causes:
+- expectations and course reality are mismatched
+- early promise is attractive but the middle becomes heavy
+- onboarding is weak
+
+### Stable reach, weak completion
+Likely causes:
+- learners consume but do not finish tasks
+- later chapters feel repetitive or less rewarding
+- completion signal is weak or too delayed
+
+### One sharp drop chapter
+Likely causes:
+- concept jump is too large
+- example support is too weak
+- pacing changes abruptly
+
+## Reporting Rule
+
+When describing a learner bottleneck, link it to a specific chapter, stage, or behavior pattern whenever possible.
+
+## AI-Shifu-specific reminder
+- Current live AI-Shifu creator dashboard exposes overall learner_count, completed_learner_count, completion_rate, active_learner_count_last_7_days, and average learning duration approximation.
+- It does not yet expose full learner drill-down in the current live surface, so learner personas and chapter-specific progression judgments require extra evidence.

--- a/skills/creator-course-analysis-report/references/metric-dictionary.md
+++ b/skills/creator-course-analysis-report/references/metric-dictionary.md
@@ -1,0 +1,43 @@
+# Metric Dictionary
+
+Define terms carefully before comparing courses or periods.
+
+## Business Metrics
+- `orders`: total order count; may differ from distinct paying learners
+- `paid_learners`: distinct learners who completed payment or valid entitlement activation, depending on the dataset
+- `revenue`: actual collected amount when available; do not mix with list price
+- `conversion_rate`: always state the denominator, such as visitor-to-paid or started-to-paid
+
+## Learner Metrics
+- `started_learners`: learners who actually began learning
+- `active_learners`: learners with recent or meaningful learning activity; define the time window
+- `completed_learners`: learners who reached the course completion rule
+- `completion_rate`: always state whether based on paid learners, started learners, or active learners
+
+## Progress Metrics
+- `learning_depth`: how far learners progress into the course
+- `chapter_coverage`: reach rate for each chapter or lesson
+- `chapter_completion`: completion rate per chapter or lesson
+- `learning_rhythm`: time-based pattern of continued learning, return visits, or pacing
+
+## Follow-Up Metrics
+- `follow_up_count`: total follow-up ask records
+- `follow_up_learners`: distinct learners who asked at least one follow-up
+- `follow_up_rate`: always state the denominator
+- `avg_follow_ups_per_learner`: distinguish from total follow-up count
+- `follow_up_hotspot`: chapter or lesson with unusually high follow-up volume or density
+
+## Rating Metrics
+- `rating_count`: number of rating events, not unique viewers
+- `average_rating`: use with sample size; low volume weakens confidence
+- `low_score_signal`: low-score concentration in specific chapters, cohorts, or complaint types
+
+## Comparison Cautions
+- never compare raw totals across very different course sizes without ratios
+- never compare conversion rates with different denominators
+- never interpret a small-sample average rating as a stable quality judgment
+- never treat high follow-up volume as automatically negative
+
+## AI-Shifu-specific reminder
+- In AI-Shifu creator dashboard work, prefer the project-specific definitions in `ai-shifu-metric-notes.md` when they differ from generic reporting language.
+- If the user gives only dashboard screenshots, avoid pretending you have follow-up learner counts, chapter-level completion, or learner personas unless that evidence is actually present.

--- a/skills/creator-course-analysis-report/references/report-structure.md
+++ b/skills/creator-course-analysis-report/references/report-structure.md
@@ -1,0 +1,67 @@
+# Report Structure
+
+Use this as the default report order.
+
+## 1. Summary
+- 3-6 bullets only
+- answer: how the course is doing, the biggest bottleneck, the biggest strength, and the next action
+
+## 2. Core Metrics
+Include only metrics actually available.
+Typical candidates:
+- orders / paid learners / revenue
+- started learners / active learners / completed learners
+- completion rate
+- rating count / average rating
+- follow-up learners / follow-up count / follow-up rate
+
+## 3. Learning Progress and Coverage
+Explain:
+- learner depth distribution
+- chapter reach or coverage
+- completion bottlenecks
+- learning rhythm over time
+
+## 4. Learner Personas and Common Pain Points
+Summarize repeated traits from learner behavior or qualitative inputs.
+Examples:
+- strong intent but low persistence
+- willing to ask but blocked by abstraction
+- engaged early but weak mid-course continuation
+
+## 5. Follow-up Analysis
+Cover:
+- which chapters attract the most follow-ups
+- whether follow-ups reflect engagement or confusion
+- common repeated topics from follow-up details
+- whether follow-ups cluster around concept, application, or task ambiguity
+
+## 6. Rating and Satisfaction Signals
+Cover:
+- rating count and average
+- whether low ratings concentrate in specific chapters or learner segments
+- whether ratings support or contradict follow-up and progress data
+
+## 7. Stage Judgment
+Choose one primary stage and briefly justify it.
+Examples:
+- early validation
+- growth with structural bottlenecks
+- content-value confirmed but conversion weak
+- conversion strong but retention weak
+
+## 8. Recommended Actions
+Keep this actionable.
+Order by impact first.
+Typical action buckets:
+- content rewrite
+- chapter restructuring
+- add examples or exercises
+- improve onboarding or expectation setting
+- adjust pricing, coupon, or campaign use
+
+## 9. One-Line Conclusion
+Write a single sentence that can be reused in a creator update or review meeting.
+
+## 10. Metric Notes / Caveats
+List any metric limitations, partial data, or interpretation boundaries.

--- a/skills/creator-course-analysis-report/references/report-style-patterns.md
+++ b/skills/creator-course-analysis-report/references/report-style-patterns.md
@@ -19,7 +19,7 @@ Use this tone:
 ## Section writing pattern
 
 ### 1. Summary
-Use 3-5 bullets.
+Use 3-6 bullets.
 Each bullet should usually contain:
 - one direct data point
 - one implication
@@ -137,7 +137,27 @@ Typical stage framing:
 - promising start but still shallow learning depth
 - engagement signal exists but not enough evidence for a mature conclusion
 
-### 8. One-line conclusion
+### 8. Recommended Actions
+This section should be practical and ordered by impact first.
+
+Preferred pattern:
+- action
+- why this action matters now
+- what evidence supports it
+
+Good action buckets:
+- rewrite or simplify a bottleneck chapter
+- add examples or applied walkthroughs
+- improve chapter transitions or pacing
+- strengthen onboarding or expectation setting
+- adjust pricing, coupon use, or campaign packaging when business data supports it
+
+Avoid vague actions such as:
+- "keep observing"
+- "improve the course experience"
+- "do more promotion"
+
+### 9. One-line conclusion
 Write one sentence that can be pasted directly into a creator sync, review note, or management update.
 It should include:
 - current course state
@@ -145,5 +165,5 @@ It should include:
 - one main limit
 - one next-step direction when possible
 
-### 9. Metric notes
+### 10. Metric notes
 Always state denominator and metric boundary when the report may be reused outside the original analysis context. In the reference report style, this section is explicit and operational rather than decorative.

--- a/skills/creator-course-analysis-report/references/report-style-patterns.md
+++ b/skills/creator-course-analysis-report/references/report-style-patterns.md
@@ -1,0 +1,149 @@
+# Report Style Patterns
+
+This file captures the writing and diagnosis style shown in the reference creator report screenshot.
+
+## Overall style
+
+The report is not a cold metric sheet. It mixes:
+- factual bullets
+- grouped metric evidence
+- short interpretation paragraphs
+- explicit caveats about sample size and metric boundaries
+
+Use this tone:
+- factual first
+- interpretation second
+- recommendation last
+- avoid dramatic certainty when the sample is still small
+
+## Section writing pattern
+
+### 1. Summary
+Use 3-5 bullets.
+Each bullet should usually contain:
+- one direct data point
+- one implication
+
+Good pattern:
+- current scale / latest activity / reach
+- current depth / where learning is still shallow
+- current strengths from follow-up or rating signals
+- current caution about sample size
+
+### 2. Core metrics
+Use compact bullets, not a paragraph.
+Typical creator-facing fields:
+- learner count
+- chapter coverage total
+- active chapter count
+- average learning depth
+- first learning date / latest learning date
+- follow-up count / follow-up learners
+- rating count / average rating
+
+If a metric is not available, omit it instead of inventing it.
+
+### 3. Learning progress and coverage
+Write this as three sub-sections.
+
+#### 3.1 Learner depth
+Prefer bucket-style reporting.
+Typical bucket examples:
+- at least 1 chapter
+- at least 3 chapters
+- at least 5 chapters
+- at least 10 chapters
+- average completed or reached chapters per learner
+
+Then add one short interpretation paragraph.
+Focus on:
+- wide early reach vs narrow deep completion
+- whether the course has entered only shallow exploration or real sustained learning
+
+#### 3.2 Chapter coverage
+List chapters in descending or meaningful order with:
+- chapter id or title
+- learner count
+- learner share
+
+Then add `Key observations`.
+Focus on:
+- which opening chapters have near-full reach
+- where the first sharp drop begins
+- which themes create continuation vs friction
+
+#### 3.3 Learning rhythm
+Use date-clustered activity bullets.
+Examples:
+- a few peak learning dates
+- bursts after release or promotion
+- whether learning is continuous or concentrated in a few windows
+
+Then add one interpretation sentence about rhythm quality.
+
+### 4. Learner personas and common pain points
+This section can be built from learner variables, survey fields, or tagged themes.
+
+Preferred pattern:
+- show top repeated themes by field
+- examples: `strategy_pain_point`, `weakest_link`, `meeting_status`
+- list theme text plus count
+- add one short interpretation paragraph after each field or at the end
+
+The job here is not to restate the variable values. The job is to explain what kind of learners this course is attracting and where they are blocked.
+
+### 5. Follow-up analysis
+Always separate:
+- follow-up count
+- follow-up learners
+- follow-up time window
+- follow-up topic clusters
+- representative questions
+
+Then explain whether the questions show:
+- healthy engagement
+- blocked understanding
+- terminology ambiguity
+- application difficulty
+- expectation mismatch
+
+When possible, provide repeated topic clusters such as:
+- concept clarification
+- mapping to the learner's real business context
+- KPI alignment
+- report-writing or communication framing
+
+### 6. Rating and satisfaction signals
+Keep this short unless there is a lot of evidence.
+Use:
+- rating count
+- average rating
+- distribution or sample highlights when available
+
+Then add a caution if the sample is still small.
+
+### 7. Stage judgment
+This section should read like a business diagnosis, not a metric restatement. In the reference report style, stage judgment is usually a short set of bullets plus a compact explanatory paragraph.
+
+Good judgment inputs:
+- reach is broad or narrow
+- depth is shallow or sustained
+- follow-up is active or sparse
+- rating is early or stable
+- chapter drop-off has or has not formed a clear bottleneck
+
+Typical stage framing:
+- early validation with broad early reach
+- promising start but still shallow learning depth
+- engagement signal exists but not enough evidence for a mature conclusion
+
+### 8. One-line conclusion
+Write one sentence that can be pasted directly into a creator sync, review note, or management update.
+It should include:
+- current course state
+- one main strength
+- one main limit
+- one next-step direction when possible
+
+### 9. Metric notes
+Always state denominator and metric boundary when the report may be reused outside the original analysis context. In the reference report style, this section is explicit and operational rather than decorative.

--- a/skills/creator-course-analysis-report/references/stage-judgement.md
+++ b/skills/creator-course-analysis-report/references/stage-judgement.md
@@ -1,0 +1,67 @@
+# Stage Judgement
+
+Use stage labels to help creators decide the next move.
+
+## Suggested Stages
+
+### Early validation
+Use when:
+- sample size is still small
+- signals are directional, not stable
+- the main goal is to confirm audience-course fit
+
+Typical action:
+- avoid over-optimizing details
+- confirm the main promise, audience, and first bottleneck first
+
+### Growth with structural bottlenecks
+Use when:
+- learner or order volume exists
+- one or more chapters show clear drop-off or repeated confusion
+- the course has demand but delivery structure is leaking value
+
+Typical action:
+- prioritize chapter restructuring, examples, scaffolding, and onboarding
+
+### Conversion strong, retention weak
+Use when:
+- business entry is healthy
+- learning depth or completion is weak
+- satisfaction or follow-up detail suggests mid-course problems
+
+Typical action:
+- fix the learning path before pushing more acquisition
+
+### Learning value confirmed, conversion weak
+Use when:
+- active learners, completion, or satisfaction look solid
+- order or paid conversion is weak
+
+Typical action:
+- review positioning, pricing, landing promise, and offer packaging
+
+### Mature but locally weak
+Use when:
+- the overall course is stable
+- only a few chapters, cohorts, or time windows show weakness
+
+Typical action:
+- local optimization, not full rewrite
+
+## Rule
+Always justify the chosen stage with concrete evidence. If evidence is mixed, name the conflict instead of forcing certainty.
+
+## Screenshot-derived AI-Shifu pattern
+
+The reference report screenshot suggests an especially common AI-Shifu judgment pattern:
+- broad early reach exists
+- some follow-up activity and rating positivity already exist
+- deep chapter progression is still limited
+- clear structural bottlenecks are emerging but not yet fully stable
+
+In that case, prefer language like:
+- `early validation with promising engagement`
+- `broad early interest, but learning depth is still shallow`
+- `worth continuing to expand sample and optimize early-to-mid lesson support`
+
+Do not overstate this stage as mature success. The presence of follow-ups and positive ratings can confirm useful interest, but not yet full course-product fit.

--- a/skills/creator-course-analysis-report/references/variable-theme-analysis.md
+++ b/skills/creator-course-analysis-report/references/variable-theme-analysis.md
@@ -1,0 +1,60 @@
+# Variable Theme Analysis
+
+Use this reference when the creator report includes learner variables, learner tags, or structured free-text fields.
+
+## Goal
+
+Turn repeated learner inputs into creator-usable diagnosis.
+
+Do not stop at:
+- listing raw field values
+- reporting counts without interpretation
+
+Always answer:
+- what kind of learner is showing up
+- what repeated problem they are trying to solve
+- what this implies about course positioning or missing support
+
+## Recommended fields
+
+Example fields from the reference report style:
+- `strategy_pain_point`
+- `weakest_link`
+- `meeting_status`
+
+Equivalent fields are also acceptable if the naming differs.
+
+## Output pattern
+
+For each field:
+1. show the top repeated themes and counts
+2. cluster near-duplicate meanings when the wording is clearly equivalent
+3. interpret the common thread
+4. state the course implication
+
+## Interpretation examples
+
+### `strategy_pain_point`
+Possible meaning:
+- what strategic issue learners are under pressure to solve
+- whether the course is attracting learners with broad confusion or specific execution pain
+
+### `weakest_link`
+Possible meaning:
+- where learners perceive the main organizational or personal bottleneck
+- whether the course needs more practical examples, prioritization tools, or communication templates
+
+### `meeting_status`
+Possible meaning:
+- how urgent the learner's current communication or reporting context is
+- whether learners need more decision framing, stakeholder communication, or quick-win messaging
+
+## Clustering rule
+
+If several answers mean nearly the same thing, merge them into one theme and say that wording was normalized.
+Do not keep five separate bullets when they clearly point to the same pain point.
+
+## Caution
+
+Variable themes are useful for persona and pain-point analysis, but they are usually qualitative and sample-sensitive.
+Do not let them override stronger quantitative signals without saying so explicitly.

--- a/skills/creator-course-analysis-report/scripts/creator-analysis-cli.py
+++ b/skills/creator-course-analysis-report/scripts/creator-analysis-cli.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Live API helper for the creator-course-analysis-report skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+from dotenv import load_dotenv, set_key
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+ENV_FILE = SKILL_DIR / ".env"
+FALLBACK_ENV_FILE = (
+    Path.home()
+    / ".codex"
+    / "skills"
+    / "ai-shifu-course-creator"
+    / ".env"
+)
+REGION_URLS = {
+    "cn": "https://app.ai-shifu.cn",
+    "global": "https://app.ai-shifu.com",
+}
+DEFAULT_BASE_URL = REGION_URLS["cn"]
+EXPORT_TYPES = {"learner_progress", "follow_up_detail"}
+
+
+def load_env() -> None:
+    if FALLBACK_ENV_FILE.exists():
+        load_dotenv(dotenv_path=FALLBACK_ENV_FILE, override=False)
+    if ENV_FILE.exists():
+        load_dotenv(dotenv_path=ENV_FILE, override=True)
+
+
+def save_env(token: str | None = None, base_url: str | None = None) -> None:
+    if not ENV_FILE.exists():
+        ENV_FILE.parent.mkdir(parents=True, exist_ok=True)
+        ENV_FILE.touch(mode=0o600)
+    env_path = str(ENV_FILE)
+    if token:
+        set_key(env_path, "SHIFU_TOKEN", token)
+    if base_url:
+        set_key(env_path, "SHIFU_BASE_URL", base_url.rstrip("/"))
+    os.chmod(env_path, 0o600)
+
+
+def resolve_auth(args: argparse.Namespace) -> tuple[str, str]:
+    base_url = (getattr(args, "base_url", None) or os.environ.get("SHIFU_BASE_URL") or "").strip()
+    token = (getattr(args, "token", None) or os.environ.get("SHIFU_TOKEN") or "").strip()
+    if not base_url:
+        print(
+            "Error: missing base URL. Use --base-url, set SHIFU_BASE_URL in skill .env, "
+            "or reuse the ai-shifu-course-creator skill .env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not token:
+        print(
+            "Error: missing token. Run `login` first, use --token, set SHIFU_TOKEN "
+            "in skill .env, or reuse the ai-shifu-course-creator skill .env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return base_url.rstrip("/"), token
+
+
+def _login_post(base_url: str, path: str, payload: dict[str, Any], error_prefix: str) -> dict[str, Any]:
+    resp = requests.post(
+        f"{base_url}{path}",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    if not resp.ok:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "http_status": resp.status_code,
+                    "url": f"{base_url}{path}",
+                    "body": resp.text[:1000],
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data = resp.json()
+    if data.get("code") != 0:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "step": error_prefix,
+                    "response": data,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return data
+
+
+def api_request(
+    base_url: str,
+    token: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    url = f"{base_url}/api/dashboard{path}"
+    resp = requests.get(
+        url,
+        params=params,
+        headers={
+            "Cookie": f"token={token}",
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+    )
+    if not resp.ok:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "http_status": resp.status_code,
+                    "url": resp.url,
+                    "body": resp.text[:1000],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        sys.exit(1)
+
+    payload = resp.json()
+    if payload.get("code") != 0:
+        if payload.get("code") == 1005:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "code": 1005,
+                        "message": "Token Expired",
+                        "hint": "Run the `login` command again or update SHIFU_TOKEN.",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        sys.exit(1)
+    return payload.get("data")
+
+
+def cmd_login(args: argparse.Namespace) -> None:
+    region = (args.region or "").strip().lower()
+    base_url = (args.base_url or "").strip()
+    if not base_url:
+        base_url = REGION_URLS.get(region, "")
+    if not base_url and region in {"", "cn"}:
+        base_url = DEFAULT_BASE_URL
+    if not base_url:
+        base_url = os.environ.get("SHIFU_BASE_URL", "").strip()
+    base_url = base_url.rstrip("/")
+    if not base_url:
+        print(
+            "Error: provide --region cn/global or --base-url for login.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if region == "global":
+        print(
+            "Global region does not support SMS login in this helper. "
+            "Please log in manually and then save SHIFU_TOKEN / SHIFU_BASE_URL.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    phone = (args.phone or "").strip()
+    if not phone:
+        print("Error: --phone is required for login.", file=sys.stderr)
+        sys.exit(1)
+
+    sms_code = (args.sms_code or "").strip()
+    masked_phone = phone[:3] + "****" + phone[-4:] if len(phone) >= 7 else phone
+
+    if not sms_code:
+        _login_post(
+            base_url,
+            "/api/user/console_send_sms_code",
+            {"mobile": phone},
+            "console_send_sms_code",
+        )
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "step": "sms_sent",
+                    "message": f"SMS code sent to {masked_phone}",
+                    "next_command": (
+                        "python scripts/creator-analysis-cli.py "
+                        + (f"--base-url {args.base_url} " if args.base_url else "")
+                        + (f"--region {region} " if (not args.base_url and region) else "")
+                        + f"login --phone {phone} --sms-code <code>"
+                    ),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return
+
+    result = _login_post(
+        base_url,
+        "/api/user/login_sms",
+        {
+            "mobile": phone,
+            "sms_code": sms_code,
+            "login_context": "admin",
+        },
+        "login_sms",
+    )
+    token_data = result.get("data")
+    token = token_data.get("token", "") if isinstance(token_data, dict) else token_data
+    token = str(token or "").strip()
+    if not token:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "message": "Login succeeded but no token was returned.",
+                    "response": result,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Only save base_url if user explicitly provided --base-url;
+    # otherwise preserve whatever is already in .env (e.g. localhost).
+    if args.base_url:
+        save_env(token=token, base_url=base_url)
+    else:
+        save_env(token=token)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "step": "login_success",
+                "message": f"Login successful for {masked_phone}",
+                "saved_to": str(ENV_FILE),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+def cmd_config(args: argparse.Namespace) -> None:
+    if not args.token and not args.base_url:
+        print("Nothing to save. Provide --token and/or --base-url.", file=sys.stderr)
+        sys.exit(1)
+    save_env(token=args.token, base_url=args.base_url)
+    print(f"Saved config to {ENV_FILE}")
+
+
+def cmd_entry(args: argparse.Namespace) -> None:
+    base_url, token = resolve_auth(args)
+    data = api_request(
+        base_url,
+        token,
+        "/entry",
+        params={
+            "page_index": args.page_index,
+            "page_size": args.page_size,
+            **({"timezone": args.timezone} if args.timezone else {}),
+        },
+    )
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def cmd_context(args: argparse.Namespace) -> None:
+    base_url, token = resolve_auth(args)
+    data = api_request(
+        base_url,
+        token,
+        f"/shifus/{args.shifu_bid}/analysis-context",
+        params={k: v for k, v in {"timezone": args.timezone}.items() if v},
+    )
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    if args.export_type not in EXPORT_TYPES:
+        print(f"Unsupported export type: {args.export_type}", file=sys.stderr)
+        sys.exit(1)
+    base_url, token = resolve_auth(args)
+    data = api_request(
+        base_url,
+        token,
+        f"/shifus/{args.shifu_bid}/analysis-exports",
+        params={
+            "type": args.export_type,
+            "page_index": args.page_index,
+            "page_size": args.page_size,
+            **({"timezone": args.timezone} if args.timezone else {}),
+        },
+    )
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def cmd_bundle(args: argparse.Namespace) -> None:
+    base_url, token = resolve_auth(args)
+    timezone_params = {"timezone": args.timezone} if args.timezone else {}
+    context = api_request(
+        base_url,
+        token,
+        f"/shifus/{args.shifu_bid}/analysis-context",
+        params=timezone_params,
+    )
+    bundle: dict[str, Any] = {"context": context, "exports": {}}
+    for export_type in args.export_types:
+        if export_type not in EXPORT_TYPES:
+            print(f"Unsupported export type: {export_type}", file=sys.stderr)
+            sys.exit(1)
+        bundle["exports"][export_type] = api_request(
+            base_url,
+            token,
+            f"/shifus/{args.shifu_bid}/analysis-exports",
+            params={
+                "type": export_type,
+                "page_index": 1,
+                "page_size": args.page_size,
+                **timezone_params,
+            },
+        )
+    print(json.dumps(bundle, ensure_ascii=False, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Creator course analysis live API helper"
+    )
+    parser.add_argument("--base-url", default=None, help="Base app URL")
+    parser.add_argument("--token", default=None, help="Auth token")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    login_parser = subparsers.add_parser(
+        "login",
+        help="SMS login and save token/base-url to skill .env",
+    )
+    login_parser.add_argument(
+        "--region",
+        default="cn",
+        help="Region alias: cn or global",
+    )
+    login_parser.add_argument("--phone", default=None, help="Phone number")
+    login_parser.add_argument(
+        "--sms-code",
+        default=None,
+        help="SMS code for the second login step",
+    )
+    login_parser.set_defaults(func=cmd_login)
+
+    config_parser = subparsers.add_parser("config", help="Save token/base-url to skill .env")
+    config_parser.add_argument("--base-url", default=None, help="Base app URL")
+    config_parser.add_argument("--token", default=None, help="Auth token")
+    config_parser.set_defaults(func=cmd_config)
+
+    entry_parser = subparsers.add_parser("entry", help="Fetch creator dashboard entry")
+    entry_parser.add_argument("--page-index", type=int, default=1)
+    entry_parser.add_argument("--page-size", type=int, default=20)
+    entry_parser.add_argument("--timezone", default=None, help="Timezone name")
+    entry_parser.set_defaults(func=cmd_entry)
+
+    context_parser = subparsers.add_parser("context", help="Fetch analysis context")
+    context_parser.add_argument("shifu_bid", help="Course business id")
+    context_parser.add_argument("--timezone", default=None, help="Timezone name")
+    context_parser.set_defaults(func=cmd_context)
+
+    export_parser = subparsers.add_parser("export", help="Fetch one export type")
+    export_parser.add_argument("shifu_bid", help="Course business id")
+    export_parser.add_argument("export_type", help="learner_progress or follow_up_detail")
+    export_parser.add_argument("--page-index", type=int, default=1)
+    export_parser.add_argument("--page-size", type=int, default=100)
+    export_parser.add_argument("--timezone", default=None, help="Timezone name")
+    export_parser.set_defaults(func=cmd_export)
+
+    bundle_parser = subparsers.add_parser(
+        "bundle",
+        help="Fetch context plus one or more export types",
+    )
+    bundle_parser.add_argument("shifu_bid", help="Course business id")
+    bundle_parser.add_argument(
+        "--export-types",
+        nargs="*",
+        default=["learner_progress", "follow_up_detail"],
+        help="Export types to include",
+    )
+    bundle_parser.add_argument("--page-size", type=int, default=100)
+    bundle_parser.add_argument("--timezone", default=None, help="Timezone name")
+    bundle_parser.set_defaults(func=cmd_bundle)
+
+    return parser
+
+
+def main() -> None:
+    load_env()
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/creator-course-analysis-report/scripts/creator-analysis-cli.py
+++ b/skills/creator-course-analysis-report/scripts/creator-analysis-cli.py
@@ -137,7 +137,8 @@ def api_request(
                 },
                 ensure_ascii=False,
                 indent=2,
-            )
+            ),
+            file=sys.stderr,
         )
         sys.exit(1)
 
@@ -154,10 +155,11 @@ def api_request(
                     },
                     ensure_ascii=False,
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr)
         sys.exit(1)
     return payload.get("data")
 
@@ -324,6 +326,13 @@ def cmd_export(args: argparse.Namespace) -> None:
 
 def cmd_bundle(args: argparse.Namespace) -> None:
     base_url, token = resolve_auth(args)
+    invalid_types = [export_type for export_type in args.export_types if export_type not in EXPORT_TYPES]
+    if invalid_types:
+        print(
+            f"Unsupported export types: {', '.join(invalid_types)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     timezone_params = {"timezone": args.timezone} if args.timezone else {}
     context = api_request(
         base_url,
@@ -333,9 +342,6 @@ def cmd_bundle(args: argparse.Namespace) -> None:
     )
     bundle: dict[str, Any] = {"context": context, "exports": {}}
     for export_type in args.export_types:
-        if export_type not in EXPORT_TYPES:
-            print(f"Unsupported export type: {export_type}", file=sys.stderr)
-            sys.exit(1)
         bundle["exports"][export_type] = api_request(
             base_url,
             token,


### PR DESCRIPTION
## What
- add the new `creator-course-analysis-report` skill under `skills/`
- include report templates, references, live lookup helper script, and OpenAI UI metadata
- update `README.md`, `README.zh-CN.md`, and `INDEX.md` to list the new skill

## Validation
- `python3 scripts/validate_skill_quality.py`
- `python /Users/iris/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/iris/ai-shifu-skills/skills/creator-course-analysis-report`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Creator Course Analysis Report" skill to generate structured creator-facing analysis reports (summary, metrics, progress, personas, follow-ups, recommendations) with selectable output modes.

* **Documentation**
  * Added comprehensive multilingual docs, templates, style guides, access/scope rules, export/output specs, conversation flows, and a CLI helper for authenticated live-data retrieval and bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->