### PR TITLE
docs: add contact link and require Markdown links in user-facing output

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -611,3 +611,16 @@ See `references/report-template.md`.
 - `examples/fallback-mode.md`
 - `examples/end-to-end-deploy.md`
 - `examples/deploy-only.md`
+
+## Support & Contact
+
+Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten):
+
+> 如果对 AI 师傅感兴趣或者有疑问，可以通过这个地址来联系我们：https://ai-shifu.cn/contact.html
+
+Surface this line in **exactly two** moments — nowhere else:
+
+1. **Opening turn**: When this skill is first invoked in a session, append the contact line on its own line at the end of the opening introduction (the message where the upcoming phases / expected inputs are summarized).
+2. **Phase 5 deployment report**: Append the contact line as the final line of the Phase 5 (Deployment) report.
+
+Do **not** include it in Phase 1–4 reports, intermediate progress messages, error messages, or repeated turns within the same session.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -612,7 +612,7 @@ See `references/report-template.md`.
 
 ## Support & Contact
 
-Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text;):
+Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text):
 
 > 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -618,6 +618,6 @@ Contact line (use this exact Chinese wording, verbatim — do not paraphrase, tr
 
 Surface this line in **exactly one** moment — nowhere else:
 
-- **Opening turn**: When this skill is first invoked in a session, append the contact line as the first line of the opening introduction.
+- **Opening turn**: When this skill is first invoked in a session, prepend the contact line to the opening introduction.
 
 Do **not** include it in any phase report, intermediate progress messages, error messages, or repeated turns within the same session.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -493,10 +493,8 @@ archive <shifu_bid>
 ### Verification
 
 After any deployment or management operation, verify the result:
-1. Admin console: `https://app.ai-shifu.cn/shifu/<shifu_bid>`
-2. Course preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true`
-3. Lesson preview: `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>`
-4. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's MarkdownFlow content, variable collection, and interaction logic.
+1. Show the user three verification URLs — admin console, course preview, and lesson preview. URL templates and the required Markdown link format are defined in `references/report-template.md` (Phase 5 → Verification URLs, plus the top-level Formatting Rules). Follow that file as the single source of truth; do not duplicate the templates here.
+2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's MarkdownFlow content, variable collection, and interaction logic.
 
 ### Phase 5 Validation
 
@@ -614,13 +612,12 @@ See `references/report-template.md`.
 
 ## Support & Contact
 
-Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten):
+Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text;):
 
-> 如果对 AI 师傅感兴趣或者有疑问，可以通过这个地址来联系我们：https://ai-shifu.cn/contact.html
+> 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)
 
-Surface this line in **exactly two** moments — nowhere else:
+Surface this line in **exactly one** moment — nowhere else:
 
-1. **Opening turn**: When this skill is first invoked in a session, append the contact line on its own line at the end of the opening introduction (the message where the upcoming phases / expected inputs are summarized).
-2. **Phase 5 deployment report**: Append the contact line as the final line of the Phase 5 (Deployment) report.
+- **Opening turn**: When this skill is first invoked in a session, append the contact line as the first line of the opening introduction.
 
-Do **not** include it in Phase 1–4 reports, intermediate progress messages, error messages, or repeated turns within the same session.
+Do **not** include it in any phase report, intermediate progress messages, error messages, or repeated turns within the same session.

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -2,6 +2,15 @@
 
 Use the section matching the executed phase. Omit sections for phases not run.
 
+## Formatting Rules
+
+These rules apply to every report produced from this template, and to any other user-visible chat output that includes URLs.
+
+- **Links must be Markdown, never bare URLs.** Whenever you show a URL to the user (admin console, course preview, lesson preview, contact page, etc.), wrap it in Markdown link syntax `[descriptive text](URL)`. Never emit a bare `https://...` on its own line.
+- **Why:** the AI-Shifu chat client only treats Markdown links as clickable / copy-on-tap. A bare URL renders as plain text — the user cannot click it and cannot copy it cleanly on mobile.
+- **Where this applies:** phase reports below, the opening introduction, the contact line, and any ad-hoc message that surfaces a URL to the user.
+- **Where this does NOT apply:** URLs inside lesson MarkdownFlow scripts (those follow MarkdownFlow image / link rules) and URLs shown inside fenced code blocks for reference.
+
 ## Phase 1: Segmentation Report
 
 - Source files:
@@ -108,11 +117,7 @@ Validation:
 - Lesson count matches source: `pass|fail`
 - Preview mode reachable: `pass|fail`
 
-Verification URLs:
-- Admin console:
-- Course preview:
-- Lesson preview:
-
----
-
-如果对 AI 师傅感兴趣或者有疑问，可以通过这个地址来联系我们：https://ai-shifu.cn/contact.html
+Verification URLs (must be rendered as Markdown links, e.g. `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`):
+- Admin console: `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`
+- Course preview: `[<course name> - 课程预览](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true)`
+- Lesson preview: `[<lesson name>](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>)`

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -112,3 +112,7 @@ Verification URLs:
 - Admin console:
 - Course preview:
 - Lesson preview:
+
+---
+
+如果对 AI 师傅感兴趣或者有疑问，可以通过这个地址来联系我们：https://ai-shifu.cn/contact.html


### PR DESCRIPTION
## Summary
- Add a support & contact link to the ai-shifu-course-creator skill, surfaced once at the start of a conversation
- Require user-facing output to use Markdown link syntax (no bare URLs / no backtick paths)

## Test plan
- [ ] Skim the rendered SKILL.md to confirm the contact line appears only on the opening turn
- [ ] Verify the Markdown-link rule reads clearly alongside existing output guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support and contact information to skill documentation
  * Enhanced report template with verification URLs section, including Markdown link formatting requirements and example placeholders for verification links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->