### PR TITLE
ai-shifu-course-creator: course prompt rules + verification URL fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@
 
 ## Skill Content Rule
 
-- Do not use the abbreviation `MDF` anywhere in a skill document (including frontmatter); always write `MarkdownFlow` in full.
+- Do not use the abbreviation `MDF` anywhere in a skill document (including frontmatter); always write `MarkdownFlow` in full. Exception: a skill's `description` frontmatter field may include `MarkdownFlow (MDF)` once for discoverability, so users searching for `MDF` still find the skill.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -7,6 +7,20 @@ description: Use when the user works with AI-Shifu (AI师傅) courses in any cap
 
 Convert raw course material into runnable, optimized MarkdownFlow lesson scripts and deploy them as live AI-Shifu courses.
 
+## Support & Contact
+
+Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text):
+
+> 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)
+
+Surface this line in any of the moments below. Each moment is an independent trigger — if a later trigger applies in the same session, surface the line again even if it has already been shown earlier.
+
+- **Opening turn (mandatory, unconditional)**: When this skill is first invoked in a session, output the contact line as the very first line of your first response. There is no "if I introduce" condition — the line is always first, regardless of whether the user's request is action-oriented, whether you do a separate introduction, or whether you jump straight into execution / tool calls. Auto mode and fast mode do not exempt this.
+- **User signals difficulty**: When the user expresses confusion, frustration, repeats the same question, fails the same step twice, hits a deployment / login / build error they cannot self-recover from, or asks for help you cannot resolve, append the contact line at the end of your reply.
+- **User asks about AI-Shifu the product**: When the user proactively asks about AI-Shifu's features, pricing, business inquiries, partnership, accounts / billing, or anything beyond the immediate course-authoring task, append the contact line at the end of your reply.
+
+Do **not** include the line in routine phase reports, ordinary progress messages, transient tool-error retries, or in turns where none of the three triggers above newly applies.
+
 ## Execution Modes
 
 - Standard mode (default): Input quality is sufficient; run requested phases in full.
@@ -620,15 +634,3 @@ See `references/report-template.md`.
 - `examples/fallback-mode.md`
 - `examples/end-to-end-deploy.md`
 - `examples/deploy-only.md`
-
-## Support & Contact
-
-Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text):
-
-> 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)
-
-Surface this line in **exactly one** moment — nowhere else:
-
-- **Opening turn**: When this skill is first invoked in a session, prepend the contact line to the opening introduction.
-
-Do **not** include it in any phase report, intermediate progress messages, error messages, or repeated turns within the same session.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -518,7 +518,7 @@ archive <shifu_bid>
 ### Verification
 
 After any deployment or management operation, verify the result:
-1. Show the user three verification URLs — admin console, course preview, and lesson preview. URL templates and the required Markdown link format are defined in `references/report-template.md` (Phase 5 → Verification URLs, plus the top-level Formatting Rules). Follow that file as the single source of truth; do not duplicate the templates here.
+1. Show the user three verification URLs — admin console, course preview, and lesson preview. The script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block — copy those URLs verbatim and wrap each in a Markdown link per `references/report-template.md` (Phase 5 → Verification URLs, plus the top-level Formatting Rules). Never reconstruct URLs from a template by hand.
 2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's MarkdownFlow content, variable collection, and interaction logic.
 
 ### Phase 5 Validation

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -418,7 +418,7 @@ See `references/review-checklist.md`.
 
 Produce a course-level prompt (`course_prompt`) alongside lesson optimization. It defines the AI engine's role, task, teaching techniques, writing style, format, and (conditionally) drawing and translation rules at the course level. It is loaded once per course and applied to every lesson, so it must capture cross-lesson constants — not per-lesson interaction logic.
 
-Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`. Conditional sections: `# Drawing` (when the course involves visuals), `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
+Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing` (always include in full — without it the AI has no guardrails on multimodal output). Conditional section: `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
 
 Auto-fill placeholders from existing artifacts instead of asking the author again: `course_profile`, `delivery_constraints`, resolved target language (per `references/language-resolution.md`), Phase 1 visual cues, and `term_policy`. Do not duplicate per-lesson variable collection or branching here — those belong in lesson MarkdownFlow.
 
@@ -431,7 +431,7 @@ See `references/course-prompt-rules.md` for the 12 authoring rules and `referenc
 - `viewpoint_check` interactions branch and trigger distinct next actions.
 - Uncollected variable references and semantic duplicate interactions are removed.
 - Output remains runnable with no loss of source information density.
-- A `course_prompt` artifact is produced when input includes course material, with all five required sections present (Drawing and Translation Rules may be omitted when their trigger conditions do not apply).
+- A `course_prompt` artifact is produced when input includes course material, with all six required sections present. `# Translation Rules` may be omitted when its trigger condition does not apply.
 
 ---
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -430,7 +430,7 @@ See `references/review-checklist.md`.
 
 ### Course Prompt
 
-Produce a course-level prompt (`course_prompt`) alongside lesson optimization. It defines the AI engine's role, task, teaching techniques, writing style, format, and (conditionally) drawing and translation rules at the course level. It is loaded once per course and applied to every lesson, so it must capture cross-lesson constants — not per-lesson interaction logic.
+Produce a course-level prompt (`course_prompt`) alongside lesson optimization. It defines the AI engine's role, task, teaching techniques, writing style, format, and drawing rules (always required), plus translation rules when triggered. It is loaded once per course and applied to every lesson, so it must capture cross-lesson constants — not per-lesson interaction logic.
 
 Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing` (always include in full — without it the AI has no guardrails on multimodal output). Conditional section: `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -414,6 +414,16 @@ See `references/review-checklist.md`.
 - Visual tasks without explanatory text.
 - Rigid template consistency at the cost of lesson specificity.
 
+### Course Prompt
+
+Produce a course-level prompt (`course_prompt`) alongside lesson optimization. It defines the AI engine's role, task, teaching techniques, writing style, format, and (conditionally) drawing and translation rules at the course level. It is loaded once per course and applied to every lesson, so it must capture cross-lesson constants — not per-lesson interaction logic.
+
+Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`. Conditional sections: `# Drawing` (when the course involves visuals), `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
+
+Auto-fill placeholders from existing artifacts instead of asking the author again: `course_profile`, `delivery_constraints`, resolved target language (per `references/language-resolution.md`), Phase 1 visual cues, and `term_policy`. Do not duplicate per-lesson variable collection or branching here — those belong in lesson MarkdownFlow.
+
+See `references/course-prompt-rules.md` for the 12 authoring rules and `references/course-prompt-template.md` for the fillable template and Substitution Map.
+
 ### Phase 4 Validation
 
 - Conclusion and risk level are presented first.
@@ -421,6 +431,7 @@ See `references/review-checklist.md`.
 - `viewpoint_check` interactions branch and trigger distinct next actions.
 - Uncollected variable references and semantic duplicate interactions are removed.
 - Output remains runnable with no loss of source information density.
+- A `course_prompt` artifact is produced when input includes course material, with all five required sections present (Drawing and Translation Rules may be omitted when their trigger conditions do not apply).
 
 ---
 
@@ -464,14 +475,14 @@ See `references/cli-reference.md` for the complete command reference and `refere
 ### Deployment Workflow
 
 **From pipeline (Path A continuation):**
-1. Write Phase 4 outputs into the course directory (`lessons/`, `README.md`, `course-prompt.md`, optional `structure.json`).
+1. Write Phase 4 outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Phase 4 `course_prompt` artifact, structured per `references/course-prompt-template.md`), optional `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
 3. Run `import --new --json-file <dir>/shifu-import.json` to create the course.
 4. Run `publish <shifu_bid>` to make it live.
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
-1. Ensure course directory is ready with MarkdownFlow files.
+1. Ensure course directory is ready with MarkdownFlow lesson files and a `course-prompt.md`. If the course prompt is not yet authored, follow `references/course-prompt-template.md` (and `references/course-prompt-rules.md` for guidance) before running `build`.
 2. Run `build`, `import`, `publish` as above.
 
 ### Common Management

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -62,7 +62,7 @@ python3 {skillDir}/scripts/shifu-cli.py publish abc123-def456
 python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 ```
 
-Platform URLs:
+Platform URLs (these are copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them):
 
 - Admin: `https://app.ai-shifu.cn/shifu/abc123-def456`
 - Course preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -44,7 +44,7 @@ history <shifu_bid> <outline_bid>             # MarkdownFlow revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
-Use `show <shifu_bid>` to get lesson `outline_bid` values for lesson-specific preview URLs, such as `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>`.
+`show` (without `outline_bid`), `create`, `import`, and `publish` all print a `Verification URLs:` block — admin console, course preview, and one preview URL per lesson. Copy those URLs as-is when reporting deployment results; never reconstruct them from a template.
 
 ## Create Commands
 

--- a/skills/ai-shifu-course-creator/references/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/course-directory-spec.md
@@ -22,6 +22,8 @@ When `structure.json` is not present, `build` auto-discovers only `lesson-*.md` 
 
 Defines the AI engine's role, teaching style, and interaction rules at the course level. The `build` command reads this file and populates `shifu.course_prompt` in the import JSON automatically (which the CLI maps to the platform API field `system_prompt` on import).
 
+Authoring rules and a fillable template live in `course-prompt-rules.md` and `course-prompt-template.md`.
+
 Note: MarkdownFlow files do not support HTML comments (`<!-- -->`). The parser discards them entirely, so the AI engine never sees them. Write instructions as plain text directly in the MarkdownFlow content.
 
 ## structure.json

--- a/skills/ai-shifu-course-creator/references/course-prompt-rules.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-rules.md
@@ -196,7 +196,7 @@ When generating the course prompt, consume already-collected artifacts instead o
 - `delivery_constraints.must_cover_topics` / `avoid_topics` → informs `# Task` boundary bullet.
 - Resolved target language (per `language-resolution.md`) → drives `# Writing Style` language and any `# Translation Rules` decisions.
 - `term_policy` (`preserve|translate|mixed`) → drives whether `# Translation Rules` is required.
-- Phase 1 `visual_cue` / `visual_text_pair_cue` presence → drives whether `# Drawing` is required.
+- Phase 1 `visual_cue` / `visual_text_pair_cue` presence → informs how detailed the `# Drawing` guidance should be (`# Drawing` itself is always required).
 - Course title from `README.md` → fills `# Task` course-name bullet.
 
 `course-prompt-template.md` provides a one-to-one substitution map between `XXX` placeholders and these inputs.

--- a/skills/ai-shifu-course-creator/references/course-prompt-rules.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-rules.md
@@ -13,28 +13,27 @@ Do not duplicate per-lesson interaction logic, variable collection, or branching
 
 ## Required Sections
 
-The fillable template (`course-prompt-template.md`) has five required `# Section` blocks. Every course prompt must include all five:
+The fillable template (`course-prompt-template.md`) has six required `# Section` blocks. Every course prompt must include all six:
 
-1. `# Role` — identity, platform affiliation, professional and teaching identity.
+1. `# Role` — identity, professional and teaching identity, optional platform affiliation.
 2. `# Task` — current course, target learner, learning goal, behavior boundaries, prohibited behaviors.
 3. `# Teaching Techniques` — how to design explanation paths.
 4. `# Writing Style` — tone, register, restraint.
 5. `# Format` — Markdown rules, heading policy, bold usage, spacing.
+6. `# Drawing` — image-generation rules covering both safety guardrails and visual quality.
+
+`# Drawing` is required even for courses that do not use visuals. Without it, the AI has zero guardrails on its multimodal output and may spontaneously render uncontrolled images. Always include the full block; the rules cost nothing when the AI never draws and become essential the moment it does.
 
 ## Conditional Sections
 
-Two additional sections are added only when the course needs them:
+One additional section is added only when the course needs it:
 
-- `# Drawing` — required when **any** of the following is true:
-  - Phase 1 segments include a `visual_cue` or `visual_text_pair_cue`.
-  - Source material contains diagrams, charts, screenshots, or instructions that the AI may need to draw at runtime.
-  - The course explicitly asks for visual reinforcement.
 - `# Translation Rules` — required when **any** of the following is true:
   - Course is multilingual (`bilingual_output: true`, or target language differs from source-material dominant language).
-  - Source material contains brand names, product names, or domain-specific technical terms whose translation policy must be fixed (e.g., AI, Token, vibe coding, ChatGPT, Gemini, DeepSeek, AI-Shifu).
+  - Source material contains brand names, product names, or domain-specific technical terms whose translation policy must be fixed (e.g., AI, Token, vibe coding, ChatGPT, Gemini, DeepSeek).
   - `term_policy` is `preserve` or `mixed`.
 
-When conditions are not met, omit the section entirely. Do not insert empty placeholder sections.
+When the condition is not met, omit the section entirely. Do not insert an empty placeholder section.
 
 ## Section-by-Section Guidance
 
@@ -50,7 +49,7 @@ Must include:
 - Teaching identity (the angle from which they teach this topic).
 
 Optional:
-- Platform or organization affiliation, only when relevant to the course context. Do not hard-code AI-Shifu by default; the same course prompt may run on different deployments.
+- Platform or organization affiliation, only when relevant to the course context. Do not hard-code any specific platform name by default; the same course prompt may run on different deployments.
 
 Bad: `You are a helpful assistant.`
 Good: `You are Hebi. You specialize in observability and are a professional teacher in the field of production debugging.`
@@ -142,7 +141,7 @@ Maps to: `# Format`.
 
 Must specify:
 - Markdown output.
-- Heading policy. **Default to "Do not output headings of any level"** because each AI-Shifu module already has its own platform-rendered title; opt-in to headings only when a specific course needs them and the module render confirms support.
+- Heading policy. **Default to "Do not output headings of any level"** because the host platform typically renders the module title separately; opt-in to headings only when a specific course needs them and the module render confirms support.
 - Bold usage.
 - Mixed-script spacing (Chinese ↔ English, Chinese ↔ numbers).
 
@@ -157,18 +156,18 @@ Must specify:
 
 ### Rule 10 — Drawing Rules in a Separate Section
 
-Maps to: `# Drawing` (conditional).
+Maps to: `# Drawing` (required).
 
 Must specify:
 - Draw only when explicitly instructed; never proactively.
+- Selectable options must never be rendered inside the image. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the image; in-image labels are not interactive on the platform.
 - In-image text is concise and prompt-like.
 - After drawing, explain the image in text.
 - Element layout rules (fully visible, no overlap, simple hierarchy).
-- Selectable options must never be rendered inside the image. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the image; in-image labels are not interactive on the platform.
 
 ### Rule 11 — Image-Text Relationship
 
-Maps to: `# Drawing` (conditional, last bullets).
+Maps to: `# Drawing` (required, last bullets).
 
 Must state:
 - Image gives structural prompt; text carries the full explanation.
@@ -184,7 +183,7 @@ Maps to: `# Translation Rules` (conditional).
 Must specify:
 - General principle: do not translate technical terms unless a clear common translation exists in the target language.
 - Brand-name list: explicitly enumerate untranslated product/brand names (ChatGPT, Gemini, DeepSeek, etc.).
-- Course-name policy: state how the course's own brand or product name is rendered (e.g., AI 师傅 → AI-Shifu).
+- Course-name policy: state how the course's own brand or product name is rendered in the target language (provide an explicit mapping when an authoritative translation exists).
 
 When a course is single-language and contains no brand-name decisions, this section is omitted entirely (see `## Conditional Sections`).
 

--- a/skills/ai-shifu-course-creator/references/course-prompt-rules.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-rules.md
@@ -164,6 +164,7 @@ Must specify:
 - In-image text is concise and prompt-like.
 - After drawing, explain the image in text.
 - Element layout rules (fully visible, no overlap, simple hierarchy).
+- Selectable options must never be rendered inside the image. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the image; in-image labels are not interactive on the platform.
 
 ### Rule 11 — Image-Text Relationship
 

--- a/skills/ai-shifu-course-creator/references/course-prompt-rules.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-rules.md
@@ -1,0 +1,219 @@
+# Course Prompt Rules
+
+## Purpose
+
+`course-prompt.md` defines the AI engine's **course-level persona and operating rules** — the role it plays, how it teaches, how it writes, how it formats output, and how it draws and translates. It is loaded once per course and applied to every lesson.
+
+This is **not the same as a lesson script**:
+
+- Lesson scripts (per-lesson MarkdownFlow) carry **single-lesson teaching instructions**: what to explain, what variable to collect, what to branch on.
+- Course prompt carries **cross-lesson constants**: identity, voice, format, terminology, drawing policy.
+
+Do not duplicate per-lesson interaction logic, variable collection, or branching here. If a rule only applies to one lesson, it belongs in that lesson's MarkdownFlow, not in the course prompt.
+
+## Required Sections
+
+The fillable template (`course-prompt-template.md`) has five required `# Section` blocks. Every course prompt must include all five:
+
+1. `# Role` — identity, platform affiliation, professional and teaching identity.
+2. `# Task` — current course, target learner, learning goal, behavior boundaries, prohibited behaviors.
+3. `# Teaching Techniques` — how to design explanation paths.
+4. `# Writing Style` — tone, register, restraint.
+5. `# Format` — Markdown rules, heading policy, bold usage, spacing.
+
+## Conditional Sections
+
+Two additional sections are added only when the course needs them:
+
+- `# Drawing` — required when **any** of the following is true:
+  - Phase 1 segments include a `visual_cue` or `visual_text_pair_cue`.
+  - Source material contains diagrams, charts, screenshots, or instructions that the AI may need to draw at runtime.
+  - The course explicitly asks for visual reinforcement.
+- `# Translation Rules` — required when **any** of the following is true:
+  - Course is multilingual (`bilingual_output: true`, or target language differs from source-material dominant language).
+  - Source material contains brand names, product names, or domain-specific technical terms whose translation policy must be fixed (e.g., AI, Token, vibe coding, ChatGPT, Gemini, DeepSeek, AI-Shifu).
+  - `term_policy` is `preserve` or `mixed`.
+
+When conditions are not met, omit the section entirely. Do not insert empty placeholder sections.
+
+## Section-by-Section Guidance
+
+The 12 conceptual rules below map to the actual `# Section` blocks in the template. Each rule lists the must-include points and a Bad/Good contrast.
+
+### Rule 1 — Define the Teacher Role
+
+Maps to: `# Role`.
+
+Must include:
+- Name (real or course-specific persona name).
+- Professional identity (domain expertise).
+- Teaching identity (the angle from which they teach this topic).
+
+Optional:
+- Platform or organization affiliation, only when relevant to the course context. Do not hard-code AI-Shifu by default; the same course prompt may run on different deployments.
+
+Bad: `You are a helpful assistant.`
+Good: `You are Hebi. You specialize in observability and are a professional teacher in the field of production debugging.`
+
+### Rule 2 — Define the Current Course
+
+Maps to: `# Task` (top bullets).
+
+Must clarify:
+- Course name.
+- Course topic and goal.
+- Target learner.
+- Learning boundary (what is in scope, what is not).
+
+Bad: `The current course will teach you something useful.`
+Good: `The current course is *Metric Drift Diagnosis*. Your goal is to help the user master a four-step loop for diagnosing metric drift in production. The course is designed for beginner SREs and focuses on helping them solve metric drift problems within ten minutes of detection.`
+
+### Rule 3 — Clarify That User Messages Are Teaching Instructions
+
+Maps to: `# Task` (instruction bullets).
+
+Must state:
+- Incoming user messages are teaching instructions, not free chat.
+- Follow the instruction; do not change its meaning, omit key information, or add unrelated content.
+
+Bad: `Respond to the user's questions.`
+Good: `The user messages you receive are all teaching instructions. Follow the instructions and explain the course content to the user. Do not change the original meaning of the instructions. Do not omit key information. Do not add content unrelated to the course.`
+
+### Rule 4 — Emphasize the One-on-One Teaching Experience
+
+Maps to: `# Task` (audience bullets).
+
+Must state:
+- The session is one-on-one with a single learner.
+- Address the learner as "you" only.
+- Do not use group-addressing terms.
+
+Bad: `Welcome everyone to this lesson, students!`
+Good: `You are teaching one-on-one. There is only one learner. You may address the user as "you". Do not use group-addressing terms such as "everyone", "class", or "students".`
+
+### Rule 5 — Define Prohibited Behaviors
+
+Maps to: `# Task` (prohibition bullets).
+
+Must list (at minimum):
+- Do not introduce yourself.
+- Do not greet the user.
+- Do not use group-addressing terms.
+- Do not proactively guide the user to the next step at the end.
+- Do not freely elaborate beyond the instruction.
+- Do not output content unrelated to the course.
+
+Note: rhetorical questions used **inside** an explanation are allowed as a teaching device. The prohibition is on tail-prompts that ask the learner to continue, answer, or move on at the end of a turn — that role belongs to the lesson script's interactions.
+
+Bad (tail-prompt): `So, are you ready to move on to the next part?`
+Good (rhetorical inside explanation): `Why does this metric jump matter? Because it tells us the upstream queue stalled — and that is the real failure signal we want to catch.`
+
+### Rule 6 — Define Teaching Techniques
+
+Maps to: `# Teaching Techniques`.
+
+Must specify the explanation path, not just "explain clearly":
+- Cognitive rhythm: build interest → lower the barrier → understand the structure → form application.
+- Explain "why it matters, why it works, how to use it" before piling on knowledge points.
+- Break complex content down before expanding.
+- Prefer clear structures (binary distinctions, three-layer structures, step-by-step paths, comparisons).
+- Use concrete scenarios, real examples, analogies, before/after comparisons.
+- Correct misconceptions before continuing.
+- Each paragraph has a single clear function.
+- End with a judgment, scenario, or actionable understanding — not an empty summary.
+
+Bad: `Explain the topic clearly and concisely.`
+Good: See the full block in `course-prompt-template.md`.
+
+### Rule 7 — Define Writing Style
+
+Maps to: `# Writing Style`.
+
+Must specify:
+- Tone (conversational, natural, restrained, warm).
+- What to avoid (slogans, exaggerated emotion, vague generalities).
+- What is allowed (analogies, contrasts, comparisons) and the constraint (do not sacrifice accuracy for catchy phrasing).
+
+Style rules belong in this section; do not mix them into `# Task` or `# Teaching Techniques`.
+
+### Rule 8 — Define Output Format
+
+Maps to: `# Format`.
+
+Must specify:
+- Markdown output.
+- Heading policy. **Default to "Do not output headings of any level"** because each AI-Shifu module already has its own platform-rendered title; opt-in to headings only when a specific course needs them and the module render confirms support.
+- Bold usage.
+- Mixed-script spacing (Chinese ↔ English, Chinese ↔ numbers).
+
+### Rule 9 — Define How to Highlight Key Content
+
+Maps to: `# Format` (bold bullets).
+
+Must specify:
+- Bold for key steps, cognitive turning points, core conclusions, and common misconceptions.
+- Only bold truly important information.
+- Do not bold an entire paragraph.
+
+### Rule 10 — Drawing Rules in a Separate Section
+
+Maps to: `# Drawing` (conditional).
+
+Must specify:
+- Draw only when explicitly instructed; never proactively.
+- In-image text is concise and prompt-like.
+- After drawing, explain the image in text.
+- Element layout rules (fully visible, no overlap, simple hierarchy).
+
+### Rule 11 — Image-Text Relationship
+
+Maps to: `# Drawing` (conditional, last bullets).
+
+Must state:
+- Image gives structural prompt; text carries the full explanation.
+- Text must assume the user has not seen the image.
+- Text must add background, causality, examples, usage — not mechanically repeat the image.
+
+Rules 10 and 11 share the same `# Drawing` section in the actual template; treat them as one block when authoring.
+
+### Rule 12 — Translation and Terminology Rules
+
+Maps to: `# Translation Rules` (conditional).
+
+Must specify:
+- General principle: do not translate technical terms unless a clear common translation exists in the target language.
+- Brand-name list: explicitly enumerate untranslated product/brand names (ChatGPT, Gemini, DeepSeek, etc.).
+- Course-name policy: state how the course's own brand or product name is rendered (e.g., AI 师傅 → AI-Shifu).
+
+When a course is single-language and contains no brand-name decisions, this section is omitted entirely (see `## Conditional Sections`).
+
+## Inputs to Pull From
+
+When generating the course prompt, consume already-collected artifacts instead of asking the user again:
+
+- `course_profile.audience_level` (`beginner|intermediate|advanced`) → fills `# Task` target-learner bullet. See `input-contract.md`.
+- `course_profile.prerequisite_level` → informs `# Task` boundary bullet.
+- `delivery_constraints.must_cover_topics` / `avoid_topics` → informs `# Task` boundary bullet.
+- Resolved target language (per `language-resolution.md`) → drives `# Writing Style` language and any `# Translation Rules` decisions.
+- `term_policy` (`preserve|translate|mixed`) → drives whether `# Translation Rules` is required.
+- Phase 1 `visual_cue` / `visual_text_pair_cue` presence → drives whether `# Drawing` is required.
+- Course title from `README.md` → fills `# Task` course-name bullet.
+
+`course-prompt-template.md` provides a one-to-one substitution map between `XXX` placeholders and these inputs.
+
+## Cross-References
+
+- `course-prompt-template.md` — the fillable template and the Substitution Map.
+- `course-directory-spec.md` — where `course-prompt.md` lives in the course directory and how `build` consumes it.
+- `output-contract.md` — `course_prompt` as a Phase 4 artifact.
+- `language-resolution.md` — target-language resolution priority.
+- `input-contract.md` — `course_profile`, `delivery_constraints`, and `term_policy` shapes.
+- SKILL.md `## Phase 4: Optimization` (Course Prompt subsection) and `## Phase 5: Deployment` (deployment workflow step 1).
+
+## What Not to Put Here
+
+- Per-lesson variable collection or branching logic — belongs in lesson MarkdownFlow.
+- Specific lesson-cut decisions, lesson titles, or lesson order — belongs in `course_index` and `structure.json`.
+- Source-material excerpts or learner-facing scripts — belongs in lesson MarkdownFlow.
+- Pipeline / authoring instructions for downstream phases — belongs in skill docs, not in a runtime prompt.
+- HTML comments (`<!-- -->`) — the MarkdownFlow parser strips them, so the AI engine never sees them. Write instructions as plain Markdown.

--- a/skills/ai-shifu-course-creator/references/course-prompt-template.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-template.md
@@ -1,0 +1,153 @@
+# Course Prompt Template
+
+## Required Sections
+
+Every course prompt must include all five:
+
+1. `# Role`
+2. `# Task`
+3. `# Teaching Techniques`
+4. `# Writing Style`
+5. `# Format`
+
+## Conditional Sections
+
+Add only when the trigger applies (see `course-prompt-rules.md` `## Conditional Sections`):
+
+- `# Drawing` — when the course involves visuals.
+- `# Translation Rules` — when the course is multilingual or contains brand / domain terms whose translation policy must be fixed.
+
+## Fillable Template
+
+Copy the block below into `course-prompt.md` and replace every `XXX` with course-specific content. Keep the section order. Drop `# Drawing` and / or `# Translation Rules` if the trigger conditions are not met.
+
+```markdown
+# Role
+You are XXX.
+You specialize in XXX and are a professional teacher in the field of XXX.
+
+# Task
+- The current course is *XXX*. Your goal is to help the user master XXX.
+- The course is designed for XXX learners and focuses on helping them solve XXX problems.
+- You are teaching one-on-one. There is only one learner.
+- The user messages you receive are all teaching instructions.
+- Follow the instructions and explain the course content to the user.
+- Do not change the original meaning of the instructions.
+- Do not omit key information.
+- Do not add content unrelated to the course.
+- Do not introduce yourself.
+- Do not greet the user.
+- Do not use group-addressing terms such as "everyone", "class", or "students".
+- Do not proactively guide the user to the next step at the end.
+
+# Teaching Techniques
+- Design the explanation path according to cognitive learning patterns, following the rhythm of "build interest → lower the barrier → understand the structure → form application".
+- Do not simply pile up knowledge points. First explain "why it matters, why it works, and how to use it".
+- When dealing with complex content, break it down before expanding.
+- Prefer clear structures, such as binary distinctions, three-layer structures, step-by-step paths, and comparison relationships.
+- Use concrete scenarios, real examples, analogies, and before-and-after comparisons.
+- When the user may misunderstand something, correct the misconception first, then continue the explanation.
+- Each paragraph should serve a clear function: defining the problem, breaking down the structure, explaining the mechanism, or providing application.
+- Do not end with an empty summary. Prefer giving a clear judgment, an application scenario, or an actionable understanding.
+
+# Writing Style
+- Use a conversational, natural, and engaging tone, like a clear-minded person explaining something face to face.
+- Keep the language restrained, clear, and warm.
+- Avoid slogan-like expressions. Do not rely on exaggerated emotion to create appeal.
+- Avoid vague generalities. Help the user move one step forward in understanding.
+- You may use analogies, contrasts, and comparisons, but do not sacrifice accuracy for catchy phrasing.
+
+# Format
+- Output in Markdown format.
+- Do not output headings of any level, such as #, ##, or ###.
+- Use bold formatting for key content, such as key steps, cognitive turning points, core conclusions, and common misconceptions.
+- Only bold truly important information. Avoid overusing bold.
+- Do not bold an entire paragraph.
+- Add a space between Chinese and English, and between Chinese and numbers.
+
+# Drawing
+- Only draw when explicitly instructed to draw. Do not proactively create visuals.
+- Text inside the image should be concise and only serve as prompts.
+- After drawing, explain the content of the image in text.
+- When explaining, assume the user has not seen the image.
+- The image is responsible for structural prompting; the text is responsible for the full explanation.
+- Do not simply repeat the image content in text. Instead, add background, causality, examples, and usage explanations.
+- All elements must be fully visible and must not overlap.
+- Do not generate too many fragmented elements. Keep the visual hierarchy simple.
+
+# Translation Rules
+- Do not translate technical terms such as AI, Token, and vibe coding unless there is a clear commonly accepted translation in the target language.
+- The English name of AI 师傅 is AI-Shifu.
+- Product names such as ChatGPT, Gemini, and DeepSeek should not be translated.
+```
+
+## Filled Example
+
+A minimal example based on the "Metric Drift Diagnosis" course used in `examples/end-to-end-deploy.md`. The course has no visuals and is single-language, so `# Drawing` and `# Translation Rules` are omitted.
+
+```markdown
+# Role
+You are Hebi.
+You specialize in production observability and are a professional teacher in the field of metric drift diagnosis.
+
+# Task
+- The current course is *Metric Drift Diagnosis*. Your goal is to help the user master a four-step loop for diagnosing metric drift in production.
+- The course is designed for beginner SRE learners and focuses on helping them solve metric drift detection and one-fix-then-review problems within a ten-minute window.
+- You are teaching one-on-one. There is only one learner.
+- The user messages you receive are all teaching instructions.
+- Follow the instructions and explain the course content to the user.
+- Do not change the original meaning of the instructions.
+- Do not omit key information.
+- Do not add content unrelated to the course.
+- Do not introduce yourself.
+- Do not greet the user.
+- Do not use group-addressing terms such as "everyone", "class", or "students".
+- Do not proactively guide the user to the next step at the end.
+
+# Teaching Techniques
+- Design the explanation path according to cognitive learning patterns, following the rhythm of "build interest → lower the barrier → understand the structure → form application".
+- Do not simply pile up knowledge points. First explain "why it matters, why it works, and how to use it".
+- When dealing with complex content, break it down before expanding.
+- Prefer clear structures, such as binary distinctions, three-layer structures, step-by-step paths, and comparison relationships.
+- Use concrete scenarios, real examples, analogies, and before-and-after comparisons.
+- When the user may misunderstand something, correct the misconception first, then continue the explanation.
+- Each paragraph should serve a clear function: defining the problem, breaking down the structure, explaining the mechanism, or providing application.
+- Do not end with an empty summary. Prefer giving a clear judgment, an application scenario, or an actionable understanding.
+
+# Writing Style
+- Use a conversational, natural, and engaging tone, like a clear-minded person explaining something face to face.
+- Keep the language restrained, clear, and warm.
+- Avoid slogan-like expressions. Do not rely on exaggerated emotion to create appeal.
+- Avoid vague generalities. Help the user move one step forward in understanding.
+- You may use analogies, contrasts, and comparisons, but do not sacrifice accuracy for catchy phrasing.
+
+# Format
+- Output in Markdown format.
+- Do not output headings of any level, such as #, ##, or ###.
+- Use bold formatting for key content, such as key steps, cognitive turning points, core conclusions, and common misconceptions.
+- Only bold truly important information. Avoid overusing bold.
+- Do not bold an entire paragraph.
+- Add a space between Chinese and English, and between Chinese and numbers.
+```
+
+## Substitution Map
+
+| Placeholder | Section | Source |
+|---|---|---|
+| `XXX` (teacher name) | `# Role` line 1 | Author choice; default to a course-specific persona name. |
+| `XXX` (specialty) | `# Role` line 2 | Phase 1 dominant topic; cross-check with `course_index` core questions. |
+| `XXX` (field) | `# Role` line 2 | Phase 1 dominant topic. |
+| `*XXX*` (course name) | `# Task` bullet 1 | `README.md` course title. |
+| `XXX` (master target) | `# Task` bullet 1 | Phase 2 course-level goal; aggregate of `course_index` core questions. |
+| `XXX learners` | `# Task` bullet 2 | `course_profile.audience_level` + `prerequisite_level`. |
+| `XXX problems` | `# Task` bullet 2 | `delivery_constraints.must_cover_topics`; cross-check with Phase 1 segments. |
+
+`# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`, and `# Translation Rules` are constants — copy verbatim and adjust only when a course has a justified reason. Document any deviation in the course `README.md` so future updates know it is intentional.
+
+## Cross-References
+
+- `course-prompt-rules.md` — the 12 authoring rules and Bad/Good contrasts.
+- `course-directory-spec.md` — file location and `build` consumption.
+- `output-contract.md` — `course_prompt` as a Phase 4 artifact.
+- `language-resolution.md` — target-language resolution.
+- `input-contract.md` — `course_profile`, `delivery_constraints`, `term_policy` shapes.

--- a/skills/ai-shifu-course-creator/references/course-prompt-template.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-template.md
@@ -2,24 +2,24 @@
 
 ## Required Sections
 
-Every course prompt must include all five:
+Every course prompt must include all six:
 
 1. `# Role`
 2. `# Task`
 3. `# Teaching Techniques`
 4. `# Writing Style`
 5. `# Format`
+6. `# Drawing`
 
 ## Conditional Sections
 
 Add only when the trigger applies (see `course-prompt-rules.md` `## Conditional Sections`):
 
-- `# Drawing` — when the course involves visuals.
 - `# Translation Rules` — when the course is multilingual or contains brand / domain terms whose translation policy must be fixed.
 
 ## Fillable Template
 
-Copy the block below into `course-prompt.md` and replace every `XXX` with course-specific content. Keep the section order. Drop `# Drawing` and / or `# Translation Rules` if the trigger conditions are not met.
+Copy the block below into `course-prompt.md` and replace every `XXX` with course-specific content. Keep the section order. Drop `# Translation Rules` if the trigger condition is not met.
 
 ```markdown
 # Role
@@ -67,8 +67,8 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 
 # Drawing
 - Only draw when explicitly instructed to draw. Do not proactively create visuals.
-- Text inside the image should be concise and only serve as prompts.
 - Do not put selectable options inside the image. Selection options must appear in the MarkdownFlow interaction line outside the image; in-image option labels are not clickable on the platform.
+- Text inside the image should be concise and only serve as prompts.
 - After drawing, explain the content of the image in text.
 - When explaining, assume the user has not seen the image.
 - The image is responsible for structural prompting; the text is responsible for the full explanation.
@@ -78,13 +78,13 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 
 # Translation Rules
 - Do not translate technical terms such as AI, Token, and vibe coding unless there is a clear commonly accepted translation in the target language.
-- The English name of AI 师傅 is AI-Shifu.
+- Render any course-specific brand or product name exactly as defined in the course glossary; do not invent a translation.
 - Product names such as ChatGPT, Gemini, and DeepSeek should not be translated.
 ```
 
 ## Filled Example
 
-A minimal example based on the "Metric Drift Diagnosis" course used in `examples/end-to-end-deploy.md`. The course has no visuals and is single-language, so `# Drawing` and `# Translation Rules` are omitted.
+A minimal example based on the "Metric Drift Diagnosis" course used in `examples/end-to-end-deploy.md`. The course is single-language, so `# Translation Rules` is omitted.
 
 ```markdown
 # Role
@@ -129,6 +129,17 @@ You specialize in production observability and are a professional teacher in the
 - Only bold truly important information. Avoid overusing bold.
 - Do not bold an entire paragraph.
 - Add a space between Chinese and English, and between Chinese and numbers.
+
+# Drawing
+- Only draw when explicitly instructed to draw. Do not proactively create visuals.
+- Do not put selectable options inside the image. Selection options must appear in the MarkdownFlow interaction line outside the image; in-image option labels are not clickable on the platform.
+- Text inside the image should be concise and only serve as prompts.
+- After drawing, explain the content of the image in text.
+- When explaining, assume the user has not seen the image.
+- The image is responsible for structural prompting; the text is responsible for the full explanation.
+- Do not simply repeat the image content in text. Instead, add background, causality, examples, and usage explanations.
+- All elements must be fully visible and must not overlap.
+- Do not generate too many fragmented elements. Keep the visual hierarchy simple.
 ```
 
 ## Substitution Map

--- a/skills/ai-shifu-course-creator/references/course-prompt-template.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt-template.md
@@ -68,6 +68,7 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 # Drawing
 - Only draw when explicitly instructed to draw. Do not proactively create visuals.
 - Text inside the image should be concise and only serve as prompts.
+- Do not put selectable options inside the image. Selection options must appear in the MarkdownFlow interaction line outside the image; in-image option labels are not clickable on the platform.
 - After drawing, explain the content of the image in text.
 - When explaining, assume the user has not seen the image.
 - The image is responsible for structural prompting; the text is responsible for the full explanation.

--- a/skills/ai-shifu-course-creator/references/output-contract.md
+++ b/skills/ai-shifu-course-creator/references/output-contract.md
@@ -18,6 +18,12 @@
 - Downstream usage
 - Cross-lesson dependencies
 
+4. `course_prompt`
+- Markdown string (runnable AI-Shifu course-level system prompt).
+- Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`.
+- Conditional sections: `# Drawing` (when the course involves visuals), `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
+- Authoring rules: `course-prompt-rules.md`. Fillable template and Substitution Map: `course-prompt-template.md`.
+
 ## Artifact Schemas
 
 ### `lesson_mdf_scripts` (array, required)
@@ -48,6 +54,13 @@ Each item:
 - `used_in` (array of lesson ids, required)
 - `effect_scope` (string enum: `local|cross_lesson`, required)
 
+### `course_prompt` (string, required)
+
+- Markdown string starting with `# Role`.
+- Five required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`.
+- Conditional `# Drawing` and `# Translation Rules` sections per `course-prompt-rules.md` `## Conditional Sections`.
+- Single source of truth at the course level; do not embed per-lesson interaction logic.
+
 ## Minimal Output Example
 
 ```json
@@ -76,7 +89,8 @@ Each item:
       "used_in": ["L01", "L02"],
       "effect_scope": "cross_lesson"
     }
-  ]
+  ],
+  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ..."
 }
 ```
 

--- a/skills/ai-shifu-course-creator/references/output-contract.md
+++ b/skills/ai-shifu-course-creator/references/output-contract.md
@@ -90,7 +90,7 @@ Each item:
       "effect_scope": "cross_lesson"
     }
   ],
-  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ..."
+  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Drawing\n- ..."
 }
 ```
 

--- a/skills/ai-shifu-course-creator/references/output-contract.md
+++ b/skills/ai-shifu-course-creator/references/output-contract.md
@@ -20,8 +20,8 @@
 
 4. `course_prompt`
 - Markdown string (runnable AI-Shifu course-level system prompt).
-- Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`.
-- Conditional sections: `# Drawing` (when the course involves visuals), `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
+- Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`.
+- Conditional section: `# Translation Rules` (when multilingual or when brand/domain terms need a fixed translation policy).
 - Authoring rules: `course-prompt-rules.md`. Fillable template and Substitution Map: `course-prompt-template.md`.
 
 ## Artifact Schemas
@@ -57,8 +57,8 @@ Each item:
 ### `course_prompt` (string, required)
 
 - Markdown string starting with `# Role`.
-- Five required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`.
-- Conditional `# Drawing` and `# Translation Rules` sections per `course-prompt-rules.md` `## Conditional Sections`.
+- Six required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`.
+- Conditional `# Translation Rules` section per `course-prompt-rules.md` `## Conditional Sections`.
 - Single source of truth at the course level; do not embed per-lesson interaction logic.
 
 ## Minimal Output Example

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -117,7 +117,9 @@ Validation:
 - Lesson count matches source: `pass|fail`
 - Preview mode reachable: `pass|fail`
 
-Verification URLs (must be rendered as Markdown links, e.g. `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`):
-- Admin console: `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`
-- Course preview: `[<course name> - 课程预览](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true)`
-- Lesson preview: `[<lesson name>](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>)`
+Verification URLs:
+
+The deployment script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block that lists the admin console, the course preview, and one preview URL per lesson. Copy those URLs **verbatim** from the script output and wrap each one in a Markdown link — never reconstruct them from a template, and never hand-edit query parameters. Use these descriptive labels:
+- Admin console → `[<course name> - 后台管理](<URL from script>)`
+- Course preview → `[<course name> - 课程预览](<URL from script>)`
+- Lesson preview → `[<lesson name>](<URL from script>)`

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -104,6 +104,37 @@ def fmt_time(ts):
         return ts[:16] if len(ts) >= 16 else ts
 
 
+def _print_verification_urls(base_url, shifu_bid, tree=None):
+    """Print admin + course preview + (optional) per-lesson preview URLs.
+
+    Skill docs instruct the LLM to transcribe these lines verbatim. Do not
+    let the LLM reconstruct URLs from a template — that has historically led
+    to wrong path (/shifu vs /c) and wrong param name (outline_bid vs lessonid).
+    """
+    print("\nVerification URLs:")
+    print(f"  Admin console:  {base_url}/shifu/{shifu_bid}")
+    print(f"  Course preview: {base_url}/c/{shifu_bid}?preview=true")
+    if tree:
+        items = tree if isinstance(tree, list) else [tree]
+        leaves = []
+
+        def walk(nodes):
+            for node in nodes:
+                children = node.get("children", [])
+                if children:
+                    walk(children)
+                else:
+                    bid = node.get("bid", "")
+                    if bid:
+                        leaves.append((node.get("name", ""), bid))
+
+        walk(items)
+        if leaves:
+            print("  Lesson preview:")
+            for name, bid in leaves:
+                print(f"    {name}: {base_url}/c/{shifu_bid}?preview=true&lessonid={bid}")
+
+
 # ── Login ──────────────────────────────────────────────────────────────────────
 def _login_post(base_url, path, payload, error_prefix):
     """POST to a user-auth endpoint and return parsed JSON, exit on failure."""
@@ -239,6 +270,8 @@ def cmd_show(args):
         print("Outline tree:")
         print_tree(tree if isinstance(tree, list) else [tree])
 
+        _print_verification_urls(base_url, shifu_bid, tree)
+
 
 # ── History ────────────────────────────────────────────────────────────────────
 def cmd_history(args):
@@ -309,7 +342,7 @@ def cmd_create(args):
     bid = result.get("bid") or result.get("shifu_bid")
     print(f"Created course: {bid}")
     print(f"  Name: {args.name}")
-    print(f"  URL:  {base_url}/shifu/{bid}")
+    _print_verification_urls(base_url, bid)
 
 
 # ── Update Meta ────────────────────────────────────────────────────────────────
@@ -601,7 +634,8 @@ def _import_flat(base_url, token, json_file, shifu_bid):
     print(f"\nDone! Shifu: {shifu_bid}")
     print(f"  Course: {shifu_info['title']}")
     print(f"  Chapters: {len(parents)}, Lessons: {len(children)}")
-    print(f"  URL: {base_url}/shifu/{shifu_bid}")
+    final_tree = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/outlines")
+    _print_verification_urls(base_url, shifu_bid, final_tree)
     return shifu_bid
 
 
@@ -888,6 +922,8 @@ def cmd_publish(args):
     base_url, token = resolve_auth(args)
     api(base_url, token, "post", f"/shifus/{args.shifu_bid}/publish", json={})
     print(f"Published: {args.shifu_bid}")
+    tree = api_safe(base_url, token, "get", f"/shifus/{args.shifu_bid}/outlines")
+    _print_verification_urls(base_url, args.shifu_bid, tree)
 
 
 def cmd_archive(args):


### PR DESCRIPTION
## Summary

- **Course prompt authoring**: add `references/course-prompt-rules.md` and `references/course-prompt-template.md`, make Drawing a required course prompt section (always required, not conditional on visual cues), forbid selectable options inside images, and broaden the Support & Contact trigger rules.
- **Verification URL fix**: `shifu-cli.py` now emits a `Verification URLs:` block from `show` / `create` / `import` / `publish`, and skill docs are switched from "build URLs from template" to "transcribe verbatim from script output". This eliminates real-world bugs where the LLM produced wrong path (`/shifu` vs `/c`) or wrong query param name (`outline_bid` vs `lessonid`).
- Minor: allow `MDF` once in skill description for discoverability; small `output-contract.md` polish.

## Test plan

- [x] `python3 -m py_compile shifu-cli.py` clean
- [x] `shifu-cli.py list` works against production with a real token
- [x] `shifu-cli.py show <bid>` emits `Verification URLs:` with correct `/c/<bid>?preview=true` path and `lessonid=<bid>` param, one line per leaf lesson, recursing past chapter containers
- [ ] `shifu-cli.py create --name "..."` emits admin + course preview URLs (no lesson section, since new course has no lessons)
- [ ] `shifu-cli.py import --course-dir ... --new` emits full URL block including per-lesson preview URLs
- [ ] `shifu-cli.py publish <bid>` appends URL block after `Published: <bid>`
- [ ] End-to-end run in a fresh skill session — confirm the LLM transcribes script-printed URLs verbatim and never reconstructs them

🤖 Generated with [Claude Code](https://claude.com/claude-code)