### PR TITLE
fix: emit verification URLs from shifu-cli.py instead of templating in the LLM

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -518,7 +518,7 @@ archive <shifu_bid>
 ### Verification
 
 After any deployment or management operation, verify the result:
-1. Show the user three verification URLs — admin console, course preview, and lesson preview. URL templates and the required Markdown link format are defined in `references/report-template.md` (Phase 5 → Verification URLs, plus the top-level Formatting Rules). Follow that file as the single source of truth; do not duplicate the templates here.
+1. Show the user three verification URLs — admin console, course preview, and lesson preview. The script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block — copy those URLs verbatim and wrap each in a Markdown link per `references/report-template.md` (Phase 5 → Verification URLs, plus the top-level Formatting Rules). Never reconstruct URLs from a template by hand.
 2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's MarkdownFlow content, variable collection, and interaction logic.
 
 ### Phase 5 Validation

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -62,7 +62,7 @@ python3 {skillDir}/scripts/shifu-cli.py publish abc123-def456
 python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 ```
 
-Platform URLs:
+Platform URLs (these are copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them):
 
 - Admin: `https://app.ai-shifu.cn/shifu/abc123-def456`
 - Course preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -44,7 +44,7 @@ history <shifu_bid> <outline_bid>             # MarkdownFlow revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
-Use `show <shifu_bid>` to get lesson `outline_bid` values for lesson-specific preview URLs, such as `https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>`.
+`show` (without `outline_bid`), `create`, `import`, and `publish` all print a `Verification URLs:` block — admin console, course preview, and one preview URL per lesson. Copy those URLs as-is when reporting deployment results; never reconstruct them from a template.
 
 ## Create Commands
 

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -117,7 +117,9 @@ Validation:
 - Lesson count matches source: `pass|fail`
 - Preview mode reachable: `pass|fail`
 
-Verification URLs (must be rendered as Markdown links, e.g. `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`):
-- Admin console: `[<course name> - 后台管理](https://app.ai-shifu.cn/shifu/<shifu_bid>)`
-- Course preview: `[<course name> - 课程预览](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true)`
-- Lesson preview: `[<lesson name>](https://app.ai-shifu.cn/c/<shifu_bid>?preview=true&lessonid=<outline_bid>)`
+Verification URLs:
+
+The deployment script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block that lists the admin console, the course preview, and one preview URL per lesson. Copy those URLs **verbatim** from the script output and wrap each one in a Markdown link — never reconstruct them from a template, and never hand-edit query parameters. Use these descriptive labels:
+- Admin console → `[<course name> - 后台管理](<URL from script>)`
+- Course preview → `[<course name> - 课程预览](<URL from script>)`
+- Lesson preview → `[<lesson name>](<URL from script>)`

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -104,6 +104,37 @@ def fmt_time(ts):
         return ts[:16] if len(ts) >= 16 else ts
 
 
+def _print_verification_urls(base_url, shifu_bid, tree=None):
+    """Print admin + course preview + (optional) per-lesson preview URLs.
+
+    Skill docs instruct the LLM to transcribe these lines verbatim. Do not
+    let the LLM reconstruct URLs from a template — that has historically led
+    to wrong path (/shifu vs /c) and wrong param name (outline_bid vs lessonid).
+    """
+    print("\nVerification URLs:")
+    print(f"  Admin console:  {base_url}/shifu/{shifu_bid}")
+    print(f"  Course preview: {base_url}/c/{shifu_bid}?preview=true")
+    if tree:
+        items = tree if isinstance(tree, list) else [tree]
+        leaves = []
+
+        def walk(nodes):
+            for node in nodes:
+                children = node.get("children", [])
+                if children:
+                    walk(children)
+                else:
+                    bid = node.get("bid", "")
+                    if bid:
+                        leaves.append((node.get("name", ""), bid))
+
+        walk(items)
+        if leaves:
+            print("  Lesson preview:")
+            for name, bid in leaves:
+                print(f"    {name}: {base_url}/c/{shifu_bid}?preview=true&lessonid={bid}")
+
+
 # ── Login ──────────────────────────────────────────────────────────────────────
 def _login_post(base_url, path, payload, error_prefix):
     """POST to a user-auth endpoint and return parsed JSON, exit on failure."""
@@ -239,6 +270,8 @@ def cmd_show(args):
         print("Outline tree:")
         print_tree(tree if isinstance(tree, list) else [tree])
 
+        _print_verification_urls(base_url, shifu_bid, tree)
+
 
 # ── History ────────────────────────────────────────────────────────────────────
 def cmd_history(args):
@@ -309,7 +342,7 @@ def cmd_create(args):
     bid = result.get("bid") or result.get("shifu_bid")
     print(f"Created course: {bid}")
     print(f"  Name: {args.name}")
-    print(f"  URL:  {base_url}/shifu/{bid}")
+    _print_verification_urls(base_url, bid)
 
 
 # ── Update Meta ────────────────────────────────────────────────────────────────
@@ -601,7 +634,8 @@ def _import_flat(base_url, token, json_file, shifu_bid):
     print(f"\nDone! Shifu: {shifu_bid}")
     print(f"  Course: {shifu_info['title']}")
     print(f"  Chapters: {len(parents)}, Lessons: {len(children)}")
-    print(f"  URL: {base_url}/shifu/{shifu_bid}")
+    final_tree = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/outlines")
+    _print_verification_urls(base_url, shifu_bid, final_tree)
     return shifu_bid
 
 
@@ -888,6 +922,8 @@ def cmd_publish(args):
     base_url, token = resolve_auth(args)
     api(base_url, token, "post", f"/shifus/{args.shifu_bid}/publish", json={})
     print(f"Published: {args.shifu_bid}")
+    tree = api_safe(base_url, token, "get", f"/shifus/{args.shifu_bid}/outlines")
+    _print_verification_urls(base_url, args.shifu_bid, tree)
 
 
 def cmd_archive(args):


### PR DESCRIPTION
## Summary

- The LLM was instructed by `report-template.md` to construct admin/preview URLs from a string template, which produced real bugs:
  - wrong path: `/shifu/<bid>?preview=true` (the admin path) instead of the preview path `/c/<bid>?preview=true`
  - wrong query param: `outline_bid=...` (the field name in the script) instead of `lessonid=...` (what the platform expects)
- Fix moves URL generation from the LLM into `shifu-cli.py`. A new `_print_verification_urls()` helper is called from `show` / `create` / `import` / `publish`, printing a `Verification URLs:` block (admin + course preview + one URL per leaf lesson). Skill docs (`report-template.md`, `SKILL.md`, `cli-reference.md`, `end-to-end-deploy.md`) are switched from "build URLs from template" to "transcribe verbatim from script output".

## Test plan

- [x] `python3 -m py_compile shifu-cli.py` — clean
- [x] `shifu-cli.py show <bid>` against production — emits `Verification URLs:` with correct `/c/<bid>?preview=true` path and `lessonid=<bid>` param, one line per leaf lesson, recursing past chapter container nodes
- [ ] Browser-confirm an admin / course preview / lesson preview URL each
- [ ] `shifu-cli.py create --name "..."` emits admin + course preview URLs (no lesson section, since new course has no lessons)
- [ ] `shifu-cli.py import --course-dir ... --new` emits full URL block including per-lesson preview URLs
- [ ] `shifu-cli.py publish <bid>` appends URL block after `Published: <bid>`
- [ ] Fresh skill session — confirm the LLM transcribes script-printed URLs verbatim and never reconstructs them

🤖 Generated with [Claude Code](https://claude.com/claude-code)