### PR TITLE
docs: clarify AI-Shifu login flow to avoid spurious "registered yet?" prompt

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -22,7 +22,9 @@ The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `-
 
 ### Agent Login Flow
 
-When no valid token is available, guide the user through login. Do **not** ask "are you registered yet?" or present a registration branch — AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users. Just ask which phone number they want to use, then proceed:
+When no valid token is available, guide the user through login. AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users.
+
+**Do not ask the user whether they have registered for AI-Shifu.** Do not present a "have you signed up yet?" question, an A/B choice between "log in" and "sign up", or any other registration-status branch. Go straight to asking for the phone number:
 
 1. Ask the user which phone number they want to use with AI-Shifu.
 2. Send SMS code:

--- a/skills/ai-shifu-course-creator/references/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli-reference.md
@@ -22,9 +22,9 @@ The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `-
 
 ### Agent Login Flow
 
-When no valid token is available, guide the user through login:
+When no valid token is available, guide the user through login. Do **not** ask "are you registered yet?" or present a registration branch — AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users. Just ask which phone number they want to use, then proceed:
 
-1. Ask for their registered phone number.
+1. Ask the user which phone number they want to use with AI-Shifu.
 2. Send SMS code:
    `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone>`
 3. Ask the user for the 4-digit verification code they received.


### PR DESCRIPTION
## Summary
- Reword the Agent Login Flow in `cli-reference.md` so agents ask which phone number the user wants to use with AI-Shifu, instead of asking for their "registered phone number"
- Add an explicit note that AI-Shifu's SMS login auto-creates an account on first use, so no pre-emptive "are you registered yet?" question is needed

## Motivation
Some agents misread "Ask for their registered phone number" as a cue to verify registration first, then offered a spurious "I haven't signed up" branch before sending the SMS code. The new wording removes that misreading.

## Test plan
- [ ] Re-run the `ai-shifu-course-creator` Phase 5 deploy flow with no cached token and confirm the agent goes straight to asking for a phone number (no "are you registered?" branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI Agent Login Flow guidance for the token-missing path, including improved phone number selection and SMS login steps documentation with explicit note on account auto-creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/skills/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->