### PR TITLE
refactor(ai-shifu-course-creator): tighten authoring & runtime rules to close model loopholes

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -24,7 +24,7 @@ The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `-
 
 When no valid token is available, guide the user through login. AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users.
 
-Fixed flow: phone → send code → SMS code → complete. Run the steps in order.
+Fixed flow: ask for phone → send code → ask for SMS code → complete. Run the steps in order.
 
 Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else.
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -24,10 +24,9 @@ The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `-
 
 When no valid token is available, guide the user through login. AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users.
 
-Two rules govern how to run this flow:
+Fixed flow: phone → send code → SMS code → complete. Run the steps in order.
 
-- **No candidate set exists.** The phone number is the user's own number, and the SMS code is whatever message the user just received — both must be typed by the user verbatim. Do not present, suggest, or pre-fill any candidate values, examples, or option lists; there is nothing to choose from.
-- **Login is linear and branchless.** Steps run in order with no fork: ask phone → send code → ask code → complete. There is no registration-status branch ("have you signed up?"), no skip / defer branch, and no intermediate confirmation step. Each step's only output is the next step's input.
+Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else.
 
 Steps:
 

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -69,6 +69,38 @@ Ask the learner: Which option best matches your situation? ?[%{{choice}} Option 
 
 For interaction-design quality (concrete prompts, branching, deepening interactions), see [pedagogy.md#interaction-design](pedagogy.md#interaction-design).
 
+## Branching on User Input
+
+MarkdownFlow has no programming-style conditionals, loops, or boolean logic. There is no parser that evaluates `{{var}} == "A"`; there are no `if` blocks, `switch` blocks, or ternary expressions to wire up control flow.
+
+Branching is enacted by writing **natural-language instructions** that describe what the AI should generate under each possible learner input. Phrasings such as "If the learner's input is X, then …" are **generation strategies the AI follows**, not `if`-`else` code.
+
+Example:
+
+```markdown
+Ask the learner for their stance on the claim above.
+?[%{{attitude}} Agree | Partially agree | Disagree]
+
+The learner's stance is {{attitude}}.
+
+- If the learner's stance is Agree, acknowledge the agreement appreciatively.
+- If the learner's stance is Partially agree, ask which parts they agree with and which parts they do not.
+- If the learner's stance is Disagree, ask why they disagree.
+```
+
+The bullet phrasing reads like `if`, but it is not `if` — it is an instruction the AI engine interprets while generating. Nothing in MarkdownFlow evaluates the condition. The branching is enacted by the AI following the instruction.
+
+### No program syntax around `{{var}}`
+
+A Teaching Prompt looks like code (variables, interaction markers, branched outcomes), but it is read by a language model, not executed by an interpreter. Wrapping `{{var}}` in `if`-`else` blocks, ternary expressions, `switch` / `case`, or fenced pseudo-code blocks makes the script look like a program and pushes the AI toward executing-not-interpreting behavior, which degrades teaching quality.
+
+Express every branch as a plain instruction sentence:
+
+- Bad: `if {{level}} == "beginner": use simple analogies`
+- Good: `For {{level}} = beginner, use simple analogies; for intermediate, introduce technical terms; for expert, go deep into edge cases.`
+
+> The point of MarkdownFlow is not to write the lesson content directly, but to use natural language to precisely instruct the AI on how to generate content under each possible learner input.
+
 ## Deterministic Blocks
 
 - Single-line fixed text: `===fixed text===`
@@ -114,5 +146,6 @@ Use deterministic blocks only for truly fixed content. Do not lock entire lesson
 - `?[%{{var}} Question prompt? Option A | Option B]` — question inside the interaction line; move it to the line above.
 - `Ask the learner the question. ?[%{{var}} A | B | C]` — interaction not on its own line.
 - Pre-interaction text enumerates choices A / B / C but `?[%{{var}} X | Y | Z]` exposes a different set — the narrative description and the interaction options must stay aligned (same set, order, and wording).
+- `if {{var}} == "A": …` / `{{#if var}}…{{/if}}` / `switch ({{var}}) { … }` — program-style branching syntax around `{{var}}`. MarkdownFlow has no conditional parser; express branches as plain instruction sentences (see [Branching on User Input](#branching-on-user-input)).
 - Wrapping an entire lesson body in `=== … ===` or `!=== … !===`.
 - Referencing `{{var}}` in learner-facing text before any `?[%{{var}} …]` collects it.


### PR DESCRIPTION
## Summary

Two unrelated rule tightenings that share the same root cause — earlier wording described the *desired* behavior without naming the *wrong* behavior, so the model kept inventing variants that technically didn't violate anything. Both updates make the rule load-bearing by stating the prohibited shape directly.

### 1. Agent Login Flow — runtime behavior

Collapse the previous two-rule formulation (\"no candidate set exists\" + \"linear and branchless\") into a positive flow declaration plus a single \"do not ask anything else\" prohibition.

The old wording left semantic loopholes that agents exploited in practice:
- Asked \"have you logged in before?\" — a status-check variant the rule named only via the \"have you signed up?\" example.
- Presented \"I'll provide my phone\" as a single intent-style option — a selection variant the rule framed only at the value level.

New rules close those loopholes by construction: any side question that isn't part of the fixed `phone → send code → SMS code → complete` flow is rejected, with four example classes (status checks, readiness / intent confirmations, acknowledgment pauses, inter-step recaps) so the agent recognizes side questions as one class instead of memorizing individual bans.

### 2. Branching on User Input — authoring style

Address the failure mode where generated Teaching Prompts contain program-style branching (`if {{var}} == \"A\": ...`) because `pedagogy.md` script-style rules described the desired imperative voice but never named the wrong style. A model writing `if`-`else` blocks felt fine — \"if/else\" reads as imperative.

A new `## Branching on User Input` section in `markdownflow.md` makes the rule load-bearing: MarkdownFlow has no conditional parser, and branches are enacted by natural-language instructions the AI engine interprets, not code it executes. A worked example shows what an \"If learner's stance is X, do Y\" instruction looks like, plus a Bad/Good pair for branching that references `{{var}}`.

`## Common Mistakes` also gets a new entry listing the three program-syntax shapes (`if`, `{{#if}}`, `switch`) and links to the new section.

## Test plan

- [ ] Trigger the skill with no `.env` token; confirm the agent jumps straight to asking for the phone number (no \"have you signed up / logged in before?\", no readiness confirmation, no intent-style option, no recap between steps).
- [ ] Repeat the login test on a second host environment if available, to confirm the new wording behaves the same across runtimes.
- [ ] Author a lesson that branches on a `{{level}}` style variable; confirm the generated Teaching Prompt expresses the branch as plain instruction sentences (e.g. \"For {{level}} = beginner, …\") and not as `if`-`else`, `{{#if}}`, or `switch` blocks.
- [ ] Run review-checklist over a generated lesson to confirm program-style branching is now caught by the new Common Mistakes entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Agent Login Flow with a strict, linear authentication sequence: collect phone number → send SMS → collect SMS code → complete login.
  * Added a "Branching on User Input" section to MarkdownFlow clarifying that learner-facing branching is descriptive (not code), with examples and guidance to avoid program-style conditional syntax.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/skills/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->