### PR TITLE
feat(shifu-cli): add credit-detail subcommand + deprecate bill_daily DSL recipes

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -350,7 +350,7 @@ Post-deployment data queries on live courses. Trigger this section whenever a co
 - When the user mentioned a course by title, the current `shifu_bid → title` was confirmed via Course Metadata Recipe 0a / 0b before the downstream query ran. Historical titles were never substituted for current ones.
 - `shifu_bid` and outline mappings established before any course-level query.
 - DSL body matches grammar in `dsl.md`; filters reflect the user's intent (e.g. `status = 502` for "paid", not `>= 502`).
-- Credit queries scope to `usage_scene = 1203` when measuring learner-side consumption (preview is `1202`, debug is `1201`).
+- Credit consumption queries use `shifu-cli.py credit-detail` (server-side join). Do **not** issue a DSL query against `bill_daily_usage_metrics` — it is empty in production pending the daily aggregation cron. To restrict to learner-driven spend pass `--scene 1203` (preview is `1202`, debug is `1201`).
 - Follow-up counts anchored on `type = 321` (not `role = 2`), and rely on the API's auto-injected `status = 1` rather than an explicit clause.
 - Translation Gate applied before the answer is shown.
 - Privacy refusals honoured for inaccessible fields (phone, email, real name, ID number, avatar, birthday).

--- a/skills/ai-shifu-course-creator/references/analytics/overview.md
+++ b/skills/ai-shifu-course-creator/references/analytics/overview.md
@@ -11,7 +11,7 @@ Enter the analytics path when a course author or admin asks about:
 - ratings, listen-vs-read preference
 - follow-up Q&A counts or specific learner conversations
 - follow-up Q&A volume by lesson
-- credit consumption (by day, model, scene, usage type, billing metric)
+- credit consumption (per-charge detail / by day / by model / by scene / by usage type) — use `shifu-cli.py credit-detail` (the DSL `bill_daily_usage_metrics` table is currently empty in production until the daily aggregation cron is registered)
 - which wallet absorbed the deduction for a given course
 - audience profile distribution (goals, level, preferences)
 - individual learner tracking — with the privacy rules in `privacy-and-presentation.md`
@@ -83,6 +83,7 @@ Cross-course analysis: send one `analytics-query` per `shifu_bid` and merge resu
 2. Apply the privacy rules in `privacy-and-presentation.md` if the query touches `user_users`, `generated_content`, or `var_variable_values.value`.
 3. Apply the Translation Gate in `privacy-and-presentation.md` before presenting any result.
 4. **If the user mentioned a course by title**, run Course Metadata Recipe 0a / 0b first to confirm the current `shifu_bid → title` mapping. Never report a historical title as the course's current name.
+5. **If the user asks about credit consumption**, use `shifu-cli.py credit-detail` instead of issuing a DSL query against `bill_daily_usage_metrics` — that table is empty in production pending the daily aggregation cron.
 
 ## Error Codes the CLI May Surface
 

--- a/skills/ai-shifu-course-creator/references/analytics/recipes.md
+++ b/skills/ai-shifu-course-creator/references/analytics/recipes.md
@@ -160,101 +160,92 @@ python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
 
 > Each row's `progress_record_bid` must be translated to a chapter/lesson name via the two-step lookup in `tables.md` (ID Field Translation Rules).
 
-## Credit Consumption (use `bill_daily_usage_metrics`)
+## Credit Consumption (use `shifu-cli.py credit-detail`)
 
-> `consumed_credits` is the authoritative wallet-deduction figure — already rate-adjusted by the billing settlement job. No further conversion needed. Always add `where usage_scene = 1203` when measuring real learner-driven spend (1202 = author preview, 1201 = author debug).
+> **The DSL `bill_daily_usage_metrics` recipes that lived here previously are deprecated.** That table is currently empty in production because the daily aggregation Celery beat job is not registered. Use the `credit-detail` CLI command below — it joins `bill_usage` × `credit_ledger_entries` server-side and returns the real credit deduction for the requested shifu. When the daily aggregation job is eventually enabled, the DSL recipes can be reinstated for "by-day trend" queries; until then `credit-detail` is the only path.
 
-### Recipe 8 — Total credits over a date range
-
-```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "aggregate":[{"fn":"sum","field":"consumed_credits","alias":"total_credits"}],
- "where":[
-   {"field":"usage_scene","op":"=","value":1203},
-   {"field":"stat_date","op":"between","value":["2026-05-01","2026-05-14"]}],
- "limit":1
-}'
-```
-
-### Recipe 9 — Credits: LLM vs TTS split
+### Recipe 8 — Today's credit consumption
 
 ```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "select":["usage_type"],
- "aggregate":[{"fn":"sum","field":"consumed_credits","alias":"credits"}],
- "where":[{"field":"usage_scene","op":"=","value":1203}],
- "group_by":["usage_type"],
- "limit":10
-}'
+python3 scripts/shifu-cli.py credit-detail <bid> --start 2026-05-16 --end 2026-05-16
 ```
 
-> Returns: `usage_type = 1101` (LLM) vs `1102` (TTS) credit breakdown.
+Returns `summary` (total credits, distinct users / progress records, wallet creator, time range) plus `rows` (per-usage detail: created_at, user_bid, progress_record_bid, outline_item_bid, usage_type, usage_scene, provider, model, credits).
 
-### Recipe 10 — Credits by model (ranked)
+### Recipe 9 — Credits over an arbitrary date window
 
 ```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "select":["provider","model"],
- "aggregate":[{"fn":"sum","field":"consumed_credits","alias":"credits"}],
- "where":[{"field":"usage_scene","op":"=","value":1203}],
- "group_by":["provider","model"],
- "order_by":[{"field":"credits","dir":"desc"}],
- "limit":10
-}'
+python3 scripts/shifu-cli.py credit-detail <bid> --start 2026-05-01 --end 2026-05-15
 ```
 
-### Recipe 11 — Daily credit trend
+`start` / `end` are inclusive ISO dates; end must be on or after start.
+
+### Recipe 10 — Production-only spend (exclude preview / debug)
 
 ```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "select":["stat_date"],
- "aggregate":[{"fn":"sum","field":"consumed_credits","alias":"credits"}],
- "where":[{"field":"usage_scene","op":"=","value":1203}],
- "group_by":["stat_date"],
- "order_by":[{"field":"stat_date","dir":"asc"}],
- "limit":90
-}'
+python3 scripts/shifu-cli.py credit-detail <bid> --scene 1203
 ```
 
-### Recipe 12 — Input vs cache vs output credit split
+`--scene` accepts a comma-separated subset of `{1201, 1202, 1203}` (debug / preview / production). Combine with `--start` / `--end` to scope a window.
+
+### Recipe 11 — LLM-only vs TTS-only
 
 ```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "select":["billing_metric"],
- "aggregate":[{"fn":"sum","field":"consumed_credits","alias":"credits"}],
- "where":[
-   {"field":"usage_scene","op":"=","value":1203},
-   {"field":"usage_type","op":"=","value":1101}],
- "group_by":["billing_metric"],
- "order_by":[{"field":"credits","dir":"desc"}],
- "limit":10
-}'
+# LLM only
+python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1101
+
+# TTS only
+python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1102
 ```
 
-> Returns three rows for LLM (`usage_type = 1101`): `billing_metric = 7451` (input), `7452` (cache-hit, typically the cheapest), `7453` (output). Use this to identify whether output tokens or uncached input is the dominant cost driver.
+`--usage-type` accepts a comma-separated subset of `{1101, 1102}`.
 
-### Recipe 13 — Single-day deep-dive (locate an unusually expensive day)
+### Recipe 12 — Pagination for large windows
 
 ```bash
-python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
- "table":"bill_daily_usage_metrics",
- "select":["provider","model","usage_scene","usage_type","billing_metric"],
- "aggregate":[
-   {"fn":"sum","field":"consumed_credits","alias":"credits"},
-   {"fn":"sum","field":"record_count","alias":"calls"}],
- "where":[{"field":"stat_date","op":"=","value":"2026-05-13"}],
- "group_by":["provider","model","usage_scene","usage_type","billing_metric"],
- "order_by":[{"field":"credits","dir":"desc"}],
- "limit":50
-}'
+python3 scripts/shifu-cli.py credit-detail <bid> --start 2026-05-01 --limit 200 --offset 200
 ```
 
-> Use this when a single day's total jumps unexpectedly. The full provider × model × scene × metric breakdown surfaces which combination drove the spike. Note that `usage_scene = 1202` rows here are author-side previews, not learner activity.
+`--limit` caps at 1000; the `summary` block always reflects the full filtered set regardless of paging.
+
+### Recipe 13 — Reading the response
+
+Pseudo-shape:
+
+```json
+{
+  "code": 0,
+  "data": {
+    "summary": {
+      "total_records":   52,
+      "total_credits":   "26.6900",
+      "unique_users":    1,
+      "unique_progress": 5,
+      "wallet_creator_bid": "029bacf0...",
+      "time_range": ["2026-05-15 16:05:18", "2026-05-15 23:45:17"]
+    },
+    "rows": [
+      {
+        "usage_bid": "...",
+        "created_at": "2026-05-15 23:45:17",
+        "user_bid": "...",
+        "progress_record_bid": "...",
+        "outline_item_bid": "...",
+        "usage_type":  1101,
+        "usage_scene": 1203,
+        "provider":    "deepseek",
+        "model":       "deepseek-v4-flash",
+        "credits":     "0.5100",
+        "wallet_creator_bid": "029bacf0..."
+      }
+    ],
+    "limit":  100,
+    "offset": 0
+  }
+}
+```
+
+`total_credits` and per-row `credits` are decimal strings (preserved precisely from the ledger, no float rounding). Apply the standard translation rules before presenting: `outline_item_bid` → "Lesson X.Y: <title>"; `user_bid` → ordinal labels (Learner A / B / C) per `privacy-and-presentation.md`; round credits to 2 decimal places (e.g. `26.69 积分`).
 
 ## Active Learners
 

--- a/skills/ai-shifu-course-creator/references/analytics/tables.md
+++ b/skills/ai-shifu-course-creator/references/analytics/tables.md
@@ -12,7 +12,7 @@ The 10 tables you can query, the fields each carries, the code/enum tables to tr
 | `order_orders` | Enrolments / revenue / channel distribution / refund rate / **total spend per learner** | `user_bid`, `status` (501-505, see code table; **paid** = `502`), `payment_channel` (pingxx/stripe/alipay/wechatpay/…), `paid_price` |
 | `var_variable_values` | Learner profile distribution (goals / level / preferences) | `user_bid`, `variable_bid`, `value` (aggregate only — **do not select raw value**; see `privacy-and-presentation.md`) |
 | `shifu_user_archives` | Active learner count / archive rate | `user_bid`, `archived` (0 active / 1 archived) |
-| `bill_daily_usage_metrics` | **Credit consumption** (by day / model / scene / usage type / billing metric) — `consumed_credits` is the authoritative wallet-deduction figure | `stat_date`, `creator_bid` (the wallet that absorbed the deduction — by construction equals the caller's bid because `shifu_bid` scope already binds the result), `usage_scene` (1201 debug / 1202 preview / 1203 learner production), `usage_type` (1101 LLM / 1102 TTS), `provider`, `model`, `billing_metric` (7451 LLM input / 7452 LLM cache / 7453 LLM output), `consumed_credits` (**exact credits, already converted at the billing rate**), `record_count`; filterable by `stat_date` / `usage_scene` / `usage_type` / `provider` / `model` / `billing_metric` |
+| `bill_daily_usage_metrics` ⚠️ EMPTY | Was designed to hold pre-aggregated daily credit totals. **Currently 0 rows in production** — the `billing.aggregate_daily_usage_metrics` Celery beat job is not yet registered, so nothing populates this table. **Do not query for credit data via this DSL table; use `shifu-cli.py credit-detail` instead** (server-side bill_usage × credit_ledger_entries join). When the cron is eventually enabled, the previous DSL recipes will work again — until then they always return empty. | `stat_date`, `creator_bid`, `usage_scene` (1201 debug / 1202 preview / 1203 production), `usage_type` (1101 LLM / 1102 TTS), `provider`, `model`, `billing_metric` (7451 LLM input / 7452 LLM cache / 7453 LLM output), `consumed_credits`, `record_count` |
 | `user_users` ⚠️ | **Look up nickname by known `user_bid`** / **reverse-look up `user_bid` by phone or email** | `user_bid`, `nickname` (auto PII-redacted), `user_identify` (masked, e.g. `138*****000`); restricted-access rules in `privacy-and-presentation.md` |
 | `shifu_published_shifus` 🆕 | **Current published title for one of my courses** / does the same `shifu_bid` have rename history? | `title`, `created_user_bid`, `created_at`, `updated_at`. **Row-lookup only** — aggregate / group_by are rejected; `title` accepts `op=like` with trailing-% (anti-enumeration: ≥ 2 non-wildcard chars); `limit ≤ 50`; owner-only (auto-filtered to `created_user_bid = <you>`) |
 | `shifu_draft_shifus` 🆕 | **Current draft (editor) title** — useful when the draft has been renamed but not yet re-published, so the published title still lags | Same fields and restrictions as `shifu_published_shifus` |
@@ -21,7 +21,7 @@ The 9 shifu-scoped tables (everything except `user_users`) are automatically con
 
 `user_users` is a **global** user table (no `shifu_bid` column). Its access is heavily restricted — read `privacy-and-presentation.md` before querying.
 
-**Token usage is intentionally not exposed.** Creators can only see credit consumption via `bill_daily_usage_metrics.consumed_credits` (already rate-adjusted by the billing settlement job). Raw token counts are not a creator-facing data surface — they live in internal billing tables not reachable from this DSL.
+**Token usage is intentionally not exposed.** Creators can only see *credit* consumption. The canonical real-time path is `shifu-cli.py credit-detail <bid>`, which the backend joins on the fly from `bill_usage` × `credit_ledger_entries` and returns ABS(amount) as `credits` (positive). When the daily aggregation cron is enabled, `bill_daily_usage_metrics.consumed_credits` will become the path for "by-day trend" DSL queries; until then it is empty and `credit-detail` is the only working path.
 
 ## Course title is "current published", not "history"
 
@@ -203,12 +203,12 @@ A learner can have multiple progress records for the **same lesson** (`outline_i
 
 ## Three Independent "Amounts" — Never Mix
 
-| Amount type | Source | Who pays | Queryable in DSL |
+| Amount type | Source | Who pays | How to query |
 |---|---|---|---|
-| **Course price / revenue** | `order_orders.paid_price` | Learner pays the creator | yes |
-| **Model call credit consumption** | `bill_daily_usage_metrics.consumed_credits` | Creator's credits are deducted | yes |
-| **Plan / credit pack purchases** | Internal billing tables | Creator recharges credits | no |
+| **Course price / revenue** | `order_orders.paid_price` | Learner pays the creator | DSL `order_orders` |
+| **Model call credit consumption** | `credit_ledger_entries.amount` (joined with `bill_usage` server-side) | Creator's credits are deducted | `shifu-cli.py credit-detail <bid>` (`bill_daily_usage_metrics` is currently empty pending cron registration) |
+| **Plan / credit pack purchases** | Internal billing tables | Creator recharges credits | not queryable |
 
-If the user asks "how much revenue did my course earn" → query `order_orders`. If the user asks "how many credits did I spend / what did it cost" → query `bill_daily_usage_metrics`. **These are completely different — do not mix them.**
+If the user asks "how much revenue did my course earn" → DSL `order_orders`. If the user asks "how many credits did I spend / what did it cost" → `shifu-cli.py credit-detail`. **These are completely different — do not mix them.**
 
-`consumed_credits` is the only credit-cost figure exposed to creators; it is already rate-adjusted by the billing settlement job. Do not try to re-derive credits from token counts — token data is not part of the creator DSL surface.
+The `credit-detail` endpoint returns the absolute credit amount (`ABS(credit_ledger_entries.amount)`) already in account-currency units; no further conversion needed. Do not try to re-derive credits from token counts — token data is not part of the creator surface.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -83,24 +83,17 @@ def api_safe(base_url, token, method, path, **kwargs):
         return None
 
 
-def api_analytics(base_url, token, body, session=None):
-    """POST a DSL query to /api/creator-analytics/query.
+def _post_creator_analytics(base_url, token, path, body, session=None):
+    """POST to a /api/creator-analytics/<path> endpoint with auth headers.
 
-    Unlike api(), does NOT exit on non-zero `code` — analytics business
-    errors (11001-11007, 1001, 1004, 1005) carry meaning the agent must
-    see in order to fix the DSL or re-authenticate.
-
-    ``session`` is an optional :class:`requests.Session` for connection
-    reuse when the caller is fanning out many small queries (e.g.
-    ``cmd_list`` / ``cmd_find_title`` issuing one metadata lookup per
-    shifu_bid). Reusing the same TCP / TLS session avoids re-doing the
-    handshake on every request.
-
-    Returns (transport_ok, payload). On transport_ok the payload is the
-    parsed JSON response (may carry a non-zero code). On transport failure
-    payload is a small dict describing what went wrong.
+    Shared transport helper for the DSL query and credit-detail endpoints.
+    Returns (transport_ok, payload). Non-zero business codes do NOT raise —
+    callers need to surface them. ``session`` is an optional
+    :class:`requests.Session` for TCP / TLS connection reuse when the caller
+    is fanning out many small queries.
     """
-    url = f"{base_url}/api/creator-analytics/query"
+
+    url = f"{base_url}/api/creator-analytics{path}"
     headers = {
         "Authorization": f"Bearer {token}",
         "Token": token,
@@ -117,6 +110,24 @@ def api_analytics(base_url, token, body, session=None):
         return True, resp.json()
     except json.JSONDecodeError:
         return False, {"parse_error": "non-JSON response", "text": resp.text[:1000]}
+
+
+def api_analytics(base_url, token, body, session=None):
+    """POST a DSL query to /api/creator-analytics/query."""
+    return _post_creator_analytics(base_url, token, "/query", body, session=session)
+
+
+def api_credit_detail(base_url, token, body, session=None):
+    """POST to /api/creator-analytics/credit-detail.
+
+    Unlike ``api_analytics``, this endpoint is not DSL-based — it expects a
+    fixed schema (``shifu_bid`` + optional date/scene/type filters and
+    pagination) and the backend handles the bill_usage × credit_ledger_entries
+    join server-side. See ``cmd_credit_detail`` for the CLI surface.
+    """
+    return _post_creator_analytics(
+        base_url, token, "/credit-detail", body, session=session
+    )
 
 
 def safe_join_path(base_dir, filename):
@@ -1192,6 +1203,53 @@ def cmd_find_title(args):
               "historical title — check `shifu-cli.py list` for current titles.")
 
 
+# ── Credit Detail ──────────────────────────────────────────────────────────────
+def cmd_credit_detail(args):
+    """Fetch server-side joined credit consumption detail for one shifu.
+
+    Calls POST /api/creator-analytics/credit-detail, which joins
+    bill_usage × credit_ledger_entries on (source_bid = usage_bid AND
+    source_type = USAGE). Returns a per-row payload alongside a summary
+    block (total records, total credits, distinct users, distinct progress
+    records, wallet creator bid, time range).
+
+    Use this whenever the user asks about credit consumption — the DSL
+    bill_daily_usage_metrics table is empty in production until the daily
+    aggregation cron is enabled.
+    """
+
+    base_url, token = resolve_auth(args)
+    body = {"shifu_bid": args.shifu_bid}
+    if args.start:
+        body["start_date"] = args.start
+    if args.end:
+        body["end_date"] = args.end
+    if args.scene:
+        try:
+            body["usage_scene"] = [int(s) for s in args.scene.split(",") if s.strip()]
+        except ValueError:
+            print("Error: --scene must be a comma-separated list of integers")
+            sys.exit(1)
+    if args.usage_type:
+        try:
+            body["usage_type"] = [
+                int(t) for t in args.usage_type.split(",") if t.strip()
+            ]
+        except ValueError:
+            print("Error: --usage-type must be a comma-separated list of integers")
+            sys.exit(1)
+    if args.limit is not None:
+        body["limit"] = args.limit
+    if args.offset is not None:
+        body["offset"] = args.offset
+
+    ok, payload = api_credit_detail(base_url, token, body)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if not ok or not isinstance(payload, dict) or payload.get("code") != 0:
+        sys.exit(1)
+
+
 # ── CLI Entry Point ────────────────────────────────────────────────────────────
 def build_parser():
     """Build and return the argument parser with all subcommands."""
@@ -1356,6 +1414,23 @@ def build_parser():
                         "whitespace-normalized; matches current published and "
                         "draft titles only — never historical / renamed titles)")
 
+    # ── credit-detail ──
+    p = sub.add_parser("credit-detail", parents=[parent_parser],
+                       help="Fetch joined credit consumption detail for one shifu")
+    p.add_argument("shifu_bid", help="Course BID")
+    p.add_argument("--start", help="Inclusive ISO date lower bound, e.g. 2026-05-15")
+    p.add_argument("--end", help="Inclusive ISO date upper bound, e.g. 2026-05-16")
+    p.add_argument("--scene",
+                   help="Comma-separated usage_scene codes, e.g. 1202,1203 "
+                        "(1201 debug / 1202 preview / 1203 production)")
+    p.add_argument("--usage-type", dest="usage_type",
+                   help="Comma-separated usage_type codes, e.g. 1101,1102 "
+                        "(1101 LLM / 1102 TTS)")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Row count cap, 1..1000 (default 100 server-side)")
+    p.add_argument("--offset", type=int, default=None,
+                   help="Pagination offset (default 0)")
+
     return parser
 
 
@@ -1390,6 +1465,7 @@ def main():
         "unarchive": cmd_unarchive,
         "analytics-query": cmd_analytics_query,
         "find-title": cmd_find_title,
+        "credit-detail": cmd_credit_detail,
     }
 
     handler = commands.get(args.command)

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -93,7 +93,12 @@ def _post_creator_analytics(base_url, token, path, body, session=None):
     is fanning out many small queries.
     """
 
-    url = f"{base_url}/api/creator-analytics{path}"
+    # Tolerate `path` with or without a leading slash — callers in this
+    # file consistently pass "/query" / "/credit-detail", but stripping
+    # guards against a future caller forgetting the slash, which would
+    # otherwise produce "/api/creator-analyticsquery". Flagged on PR #49
+    # review.
+    url = f"{base_url}/api/creator-analytics/{path.lstrip('/')}"
     headers = {
         "Authorization": f"Bearer {token}",
         "Token": token,
@@ -1224,20 +1229,45 @@ def cmd_credit_detail(args):
         body["start_date"] = args.start
     if args.end:
         body["end_date"] = args.end
+    # --scene / --usage-type are comma-separated integers. Two guards
+    # (raised on PR #49 review):
+    #   1. ValueError → report on stderr (CLI best practice) and exit 1.
+    #   2. Parsed list empty (e.g. user passed `--scene " "`) → exit 1
+    #      explicitly rather than silently sending an empty list, which
+    #      the backend would reject with `11002 invalidDsl` anyway; the
+    #      explicit local error gives a cleaner message.
     if args.scene:
         try:
-            body["usage_scene"] = [int(s) for s in args.scene.split(",") if s.strip()]
+            scenes = [int(s) for s in args.scene.split(",") if s.strip()]
         except ValueError:
-            print("Error: --scene must be a comma-separated list of integers")
+            print(
+                "Error: --scene must be a comma-separated list of integers",
+                file=sys.stderr,
+            )
             sys.exit(1)
+        if not scenes:
+            print(
+                "Error: --scene must contain at least one integer",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        body["usage_scene"] = scenes
     if args.usage_type:
         try:
-            body["usage_type"] = [
-                int(t) for t in args.usage_type.split(",") if t.strip()
-            ]
+            usage_types = [int(t) for t in args.usage_type.split(",") if t.strip()]
         except ValueError:
-            print("Error: --usage-type must be a comma-separated list of integers")
+            print(
+                "Error: --usage-type must be a comma-separated list of integers",
+                file=sys.stderr,
+            )
             sys.exit(1)
+        if not usage_types:
+            print(
+                "Error: --usage-type must contain at least one integer",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        body["usage_type"] = usage_types
     if args.limit is not None:
         body["limit"] = args.limit
     if args.offset is not None:


### PR DESCRIPTION
## Summary

Pair PR for the backend credit-detail endpoint in [ai-shifu/ai-shifu#1771](https://github.com/ai-shifu/ai-shifu/pull/1771). Adds a new `shifu-cli.py credit-detail` subcommand and rewrites the affected skill docs.

## Motivation

The DSL `bill_daily_usage_metrics` table is empty in production because the backend's `billing.aggregate_daily_usage_metrics` Celery beat job is not registered, so the previous skill recipes that issued DSL queries against that table always returned empty results. The companion backend PR adds `POST /api/creator-analytics/credit-detail` which joins `bill_usage × credit_ledger_entries` server-side. This PR exposes that endpoint to the LLM through a single CLI command and points the skill docs at it.

## Changes

### `scripts/shifu-cli.py`
- Extract `_post_creator_analytics(base_url, token, path, body, session=None)` shared helper so the new `api_credit_detail` reuses the same auth/transport plumbing as `api_analytics`.
- New `cmd_credit_detail` parses `--start / --end / --scene / --usage-type / --limit / --offset` and POSTs to `/credit-detail`.
- Register `credit-detail` in `build_parser` and the `commands` dispatch dict.

### Skill documentation
- `references/analytics/recipes.md`: replace **Credit Consumption** Recipes 8–13 (all of which queried `bill_daily_usage_metrics`) with 6 new recipes that drive `shifu-cli.py credit-detail`. Section header now says **"Credit Consumption (use `shifu-cli.py credit-detail`)"** with a leading paragraph explaining why the old DSL path is deprecated.
- `references/analytics/tables.md`: `bill_daily_usage_metrics` row flagged with **⚠️ EMPTY**; the "Token usage is not exposed" paragraph and the "Three Independent Amounts" table both point at `credit-detail` as the canonical credit path.
- `references/analytics/overview.md`: "When to Use" entry for credit consumption now points at `credit-detail`; "Picking the Right DSL" step 5 added.
- `SKILL.md`: Analytics Validation rule reworded to route credit queries to `credit-detail`; `--scene 1203` mapping called out.

## Out of scope

- Token fields (`bill_usage.input` / `output` / `input_cache` / `total`) remain non-exposed.
- DSL whitelist unchanged; `credit_ledger_entries` not in DSL.
- When the backend daily aggregation cron is eventually enabled and `bill_daily_usage_metrics` starts carrying data, we can reinstate DSL recipes for "by-day trend" — at that point `credit-detail` keeps its role as the real-time path.

## Test plan

- [x] `python3 shifu-cli.py --help` lists `credit-detail` in the subcommand set
- [x] `python3 shifu-cli.py credit-detail --help` shows the full flag list
- [x] `grep -RnE '"table":"bill_daily_usage_metrics"' skills/ai-shifu-course-creator/references/analytics/` → 0 hits (no remaining DSL recipe queries the empty table)
- [ ] Manual: against a real backend with the companion PR deployed, run `shifu-cli.py credit-detail <known_bid> --start 2026-05-15 --end 2026-05-16` and confirm `summary.total_credits` matches the PDF's manual SQL on the same shifu

🤖 Generated with [Claude Code](https://claude.com/claude-code)