### PR TITLE
feat(ai-shifu-course-creator): simplify post-deploy URLs and add public course URL

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -308,7 +308,7 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 ### Verification
 
 After any deployment or management operation, verify the result:
-1. Show the user three verification URLs — admin console, course preview, and lesson preview. The script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block — copy those URLs verbatim and wrap each in a Markdown link per `references/report-template.md` (Deployment → Verification URLs, plus the top-level Formatting Rules). Never reconstruct URLs from a template by hand.
+1. Show the user the verification URLs the script printed — admin console, course preview, and (when the script also printed it) the published public URL. Copy URLs verbatim from the script output and render each as three lines: a Markdown link, a bare URL on the next line for copy-friendliness, and a `↳` line with the fixed Chinese description (per `references/report-template.md` — Deployment → Verification URLs, plus the top-level Formatting Rules exception). Never reconstruct URLs from a template by hand. Lesson-level URLs are intentionally omitted to keep the report scannable; if the user later asks for a specific lesson link, use `show <shifu_bid>` to find the `outline_bid` and build it on demand.
 2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's Teaching Prompt, variable collection, and interaction logic.
 
 ### Validation

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -271,7 +271,12 @@ Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_cons
 
 ## Deployment
 
-Deploy optimized Teaching Prompts to the AI-Shifu platform as live courses.
+Ship optimized Teaching Prompts to the AI-Shifu platform as live courses. Two distinct actions are involved — use the right Chinese term when talking to the user:
+
+- **部署 (Deploy)** — upload local course files to the platform via `build` + `import`. After this the course exists on the platform but is not yet visible to learners on a public URL.
+- **发布 (Publish)** — run `publish` on the platform, which pushes the current draft to the public student-facing URL. Only after this step does `<base>/c/<bid>` (no `preview=true`) work.
+
+The standard end-to-end flow chains both: build → import (部署) → publish (发布).
 
 ### Prerequisites
 
@@ -297,18 +302,18 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 **From pipeline (Path A continuation):**
 1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), optional `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
-3. Run `import --new --json-file <dir>/shifu-import.json` to create the course.
-4. Run `publish <shifu_bid>` to make it live.
+3. **部署**: Run `import --new --json-file <dir>/shifu-import.json` to upload the course onto the platform.
+4. **发布**: Run `publish <shifu_bid>` to push the course to its public student-facing URL.
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
 1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`) and a `course-prompt.md`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`.
-2. Run `build`, `import`, `publish` as above.
+2. Run `build` → `import` (部署) → `publish` (发布) as above.
 
 ### Verification
 
 After any deployment or management operation, verify the result:
-1. Show the user the verification URLs the script printed — admin console, course preview, and (when the script also printed it) the published public URL. Copy URLs verbatim from the script output and render each as three lines: a Markdown link, a bare URL on the next line for copy-friendliness, and a `↳` line with the fixed Chinese description (per `references/report-template.md` — Deployment → Verification URLs, plus the top-level Formatting Rules exception). Never reconstruct URLs from a template by hand. Lesson-level URLs are intentionally omitted to keep the report scannable; if the user later asks for a specific lesson link, use `show <shifu_bid>` to find the `outline_bid` and build it on demand.
+1. Show the user the verification URLs the script printed — admin console, course preview, and (when the script also printed it) the published public URL. Copy URLs verbatim from the script output and render each as three lines: a Markdown link, a bare URL on the next line for copy-friendliness, and a third line with the fixed Chinese description (per `references/report-template.md` — Deployment → Verification URLs, plus the top-level Formatting Rules exception). Never reconstruct URLs from a template by hand. Lesson-level URLs are intentionally omitted to keep the report scannable; if the user later asks for a specific lesson link, use `show <shifu_bid>` to find the `outline_bid` and build it on demand.
 2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's Teaching Prompt, variable collection, and interaction logic.
 
 ### Validation

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -271,12 +271,12 @@ Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_cons
 
 ## Deployment
 
-Ship optimized Teaching Prompts to the AI-Shifu platform as live courses. Two distinct actions are involved — use the right Chinese term when talking to the user:
+Ship optimized Teaching Prompts to the AI-Shifu platform as live courses. Two distinct actions are involved and should not be conflated:
 
-- **部署 (Deploy)** — upload local course files to the platform via `build` + `import`. After this the course exists on the platform but is not yet visible to learners on a public URL.
-- **发布 (Publish)** — run `publish` on the platform, which pushes the current draft to the public student-facing URL. Only after this step does `<base>/c/<bid>` (no `preview=true`) work.
+- **Deploy** — upload local course files to the platform via `build` + `import`. After this the course exists on the platform but is not yet visible to learners on a public URL.
+- **Publish** — run `publish` on the platform, which pushes the current draft to the public student-facing URL. Only after this step does `<base>/c/<bid>` (no `preview=true`) work.
 
-The standard end-to-end flow chains both: build → import (部署) → publish (发布).
+The standard end-to-end flow chains both: build → import (deploy) → publish.
 
 ### Prerequisites
 
@@ -302,13 +302,13 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 **From pipeline (Path A continuation):**
 1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), optional `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
-3. **部署**: Run `import --new --json-file <dir>/shifu-import.json` to upload the course onto the platform.
-4. **发布**: Run `publish <shifu_bid>` to push the course to its public student-facing URL.
+3. **Deploy**: Run `import --new --json-file <dir>/shifu-import.json` to upload the course onto the platform.
+4. **Publish**: Run `publish <shifu_bid>` to push the course to its public student-facing URL.
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
 1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`) and a `course-prompt.md`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`.
-2. Run `build` → `import` (部署) → `publish` (发布) as above.
+2. Run `build` → `import` (deploy) → `publish` as above.
 
 ### Verification
 

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -64,11 +64,17 @@ python3 {skillDir}/scripts/shifu-cli.py publish abc123-def456
 python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 ```
 
-Platform URLs (these are copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them):
+Platform URLs (copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them; render each as Markdown link + bare URL + `↳` Chinese hint per `references/report-template.md`):
 
-- Admin: `https://app.ai-shifu.cn/shifu/abc123-def456`
-- Course preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true`
-- Lesson preview: `https://app.ai-shifu.cn/c/abc123-def456?preview=true&lessonid=<outline_bid>`
+- [我的课程 - 后台管理](https://app.ai-shifu.cn/shifu/abc123-def456)
+  https://app.ai-shifu.cn/shifu/abc123-def456
+  ↳ 课程的管理后台地址。需要修改课程内容、调整 lesson、查看分析数据时，在这里操作。
+- [我的课程 - 课程预览](https://app.ai-shifu.cn/c/abc123-def456?preview=true)
+  https://app.ai-shifu.cn/c/abc123-def456?preview=true
+  ↳ 老师专用的预览地址。仅课程作者本人可见，用于发布前后自测课程效果。
+- [我的课程 - 已发布课程](https://app.ai-shifu.cn/c/abc123-def456)
+  https://app.ai-shifu.cn/c/abc123-def456
+  ↳ 课程的对外公开地址，可以复制给学员使用。仅在课程已 publish 后生效。
 
 ## Acceptance Notes
 

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -64,17 +64,17 @@ python3 {skillDir}/scripts/shifu-cli.py publish abc123-def456
 python3 {skillDir}/scripts/shifu-cli.py show abc123-def456
 ```
 
-Platform URLs (copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them; render each as Markdown link + bare URL + `↳` Chinese hint per `references/report-template.md`):
+Platform URLs (copied verbatim from the `Verification URLs:` block printed by `publish` / `import` / `show` — do not reconstruct them; render each as Markdown link + bare URL + a Chinese-description line per `references/report-template.md`):
 
 - [我的课程 - 后台管理](https://app.ai-shifu.cn/shifu/abc123-def456)
   https://app.ai-shifu.cn/shifu/abc123-def456
-  ↳ 课程的管理后台地址。需要修改课程内容、调整 lesson、查看分析数据时，在这里操作。
+  课程的管理后台地址：需要管理课程的内容、设置小节是否隐藏、是否付费等，在这里操作。
 - [我的课程 - 课程预览](https://app.ai-shifu.cn/c/abc123-def456?preview=true)
   https://app.ai-shifu.cn/c/abc123-def456?preview=true
-  ↳ 老师专用的预览地址。仅课程作者本人可见，用于发布前后自测课程效果。
+  课程预览地址：仅课程作者本人可见，用于发布前后自测课程效果。
 - [我的课程 - 已发布课程](https://app.ai-shifu.cn/c/abc123-def456)
   https://app.ai-shifu.cn/c/abc123-def456
-  ↳ 课程的对外公开地址，可以复制给学员使用。仅在课程已 publish 后生效。
+  课程的公开学习地址：可以发送给学员使用。仅在课程已发布后生效。
 
 ## Acceptance Notes
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -50,7 +50,7 @@ history <shifu_bid> <outline_bid>             # Teaching Prompt revision history
 export <shifu_bid> [-o file.json]             # Export course as JSON
 ```
 
-`show` (without `outline_bid`), `create`, `import`, and `publish` all print a `Verification URLs:` block — admin console, course preview, and one preview URL per lesson. Copy those URLs as-is when reporting deployment results; never reconstruct them from a template.
+`show` (without `outline_bid`), `create`, `import`, and `publish` all print a `Verification URLs:` block. Lines included depend on the command: `publish` and `show` add a `Published URL:` line (the public student-facing address — `<base>/c/<bid>` without `preview=true`); `create` and `import` omit it because the course is not yet published. Each URL is followed by a one-line `# ...` Chinese hint about its purpose. Per-lesson preview URLs are no longer printed — if you need one, use `show <shifu_bid>` to find the `outline_bid` and build `<base>/c/<bid>?preview=true&lessonid=<outline_bid>` on demand. Copy printed URLs as-is when reporting; never reconstruct them from a template.
 
 ## Analytics Query
 

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -135,19 +135,19 @@ Lesson-level preview URLs are no longer printed at all (they used to clutter rep
 Copy each printed URL **verbatim** (never reconstruct from a template, never hand-edit query parameters) and render it as three lines per the top-level Formatting Rules exception. Use these fixed labels and Chinese descriptions:
 
 - Admin console →
-  ```
+  ```md
   - [<course name> - 后台管理](<URL from script>)
     <URL from script>
     课程的管理后台地址：需要管理课程的内容、设置小节是否隐藏、是否付费等，在这里操作。
   ```
 - Course preview →
-  ```
+  ```md
   - [<course name> - 课程预览](<URL from script>)
     <URL from script>
     课程预览地址：仅课程作者本人可见，用于发布前后自测课程效果。
   ```
 - Published URL (only when the script printed it) →
-  ```
+  ```md
   - [<course name> - 已发布课程](<URL from script>)
     <URL from script>
     课程的公开学习地址：可以发送给学员使用。仅在课程已发布后生效。

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -6,10 +6,15 @@ Use the section matching the executed phase. Omit sections for phases not run.
 
 These rules apply to every report produced from this template, and to any other user-visible chat output that includes URLs.
 
-- **Links must be Markdown, never bare URLs.** Whenever you show a URL to the user (admin console, course preview, lesson preview, contact page, etc.), wrap it in Markdown link syntax `[descriptive text](URL)`. Never emit a bare `https://...` on its own line.
+- **Links must be Markdown, never bare URLs.** Whenever you show a URL to the user (admin console, course preview, contact page, etc.), wrap it in Markdown link syntax `[descriptive text](URL)`. Never emit a bare `https://...` on its own line.
 - **Why:** the AI-Shifu chat client only treats Markdown links as clickable / copy-on-tap. A bare URL renders as plain text — the user cannot click it and cannot copy it cleanly on mobile.
 - **Where this applies:** phase reports below, the opening introduction, the contact line, and any ad-hoc message that surfaces a URL to the user.
 - **Where this does NOT apply:** URLs inside Teaching Prompts (those follow MarkdownFlow image / link rules) and URLs shown inside fenced code blocks for reference.
+- **Exception — deployment / management Verification URLs.** When transcribing the `Verification URLs:` block printed by `shifu-cli.py` (`publish` / `import` / `create` / `show`), emit each URL as **three lines**:
+  1. A Markdown link — `[<course name> - <用途中文标签>](<URL>)`
+  2. The same URL again on its own line (intentionally bare), indented two spaces — so the user can long-press / select to copy it cleanly.
+  3. A `↳` line with the short Chinese description of what that URL is for (see Deployment Report → Verification URLs for the fixed phrasing).
+  The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients.
 
 ## Segmentation Report
 
@@ -119,7 +124,33 @@ Validation:
 
 Verification URLs:
 
-The deployment script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block that lists the admin console, the course preview, and one preview URL per lesson. Copy those URLs **verbatim** from the script output and wrap each one in a Markdown link — never reconstruct them from a template, and never hand-edit query parameters. Use these descriptive labels:
-- Admin console → `[<course name> - 后台管理](<URL from script>)`
-- Course preview → `[<course name> - 课程预览](<URL from script>)`
-- Lesson preview → `[<lesson name>](<URL from script>)`
+The deployment script (`shifu-cli.py publish` / `import` / `create` / `show`) prints a `Verification URLs:` block. **What you must show the user is dictated by what the script printed — don't add lines that aren't there, don't drop lines that are.** Possible lines:
+
+- `Admin console:` — always present.
+- `Course preview:` — always present.
+- `Published URL:` — present only after `publish` and on `show` (i.e. when the course is in a published state). `create` / `import` deliberately omit it because the course is not yet published; the public address would 404.
+
+Lesson-level preview URLs are no longer printed at all (they used to clutter reports for multi-lesson courses). If the user later asks for a specific lesson link, run `show <shifu_bid>` to find the `outline_bid` and hand-build `<base>/c/<bid>?preview=true&lessonid=<outline_bid>` on demand — don't pre-emit them.
+
+Copy each printed URL **verbatim** (never reconstruct from a template, never hand-edit query parameters) and render it as three lines per the top-level Formatting Rules exception. Use these fixed labels and Chinese descriptions:
+
+- Admin console →
+  ```
+  - [<course name> - 后台管理](<URL from script>)
+    <URL from script>
+    ↳ 课程的管理后台地址。需要修改课程内容、调整 lesson、查看分析数据时，在这里操作。
+  ```
+- Course preview →
+  ```
+  - [<course name> - 课程预览](<URL from script>)
+    <URL from script>
+    ↳ 老师专用的预览地址。仅课程作者本人可见，用于发布前后自测课程效果。
+  ```
+- Published URL (only when the script printed it) →
+  ```
+  - [<course name> - 已发布课程](<URL from script>)
+    <URL from script>
+    ↳ 课程的对外公开地址，可以复制给学员使用。仅在课程已 publish 后生效。
+  ```
+
+When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one line below them: `> 课程尚未发布，运行 \`publish <shifu_bid>\` 后会得到可对外分享的地址。`

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -13,7 +13,7 @@ These rules apply to every report produced from this template, and to any other 
 - **Exception — deployment / management Verification URLs.** When transcribing the `Verification URLs:` block printed by `shifu-cli.py` (`publish` / `import` / `create` / `show`), emit each URL as **three lines**:
   1. A Markdown link — `[<course name> - <用途中文标签>](<URL>)`
   2. The same URL again on its own line (intentionally bare), indented two spaces — so the user can long-press / select to copy it cleanly.
-  3. A `↳` line with the short Chinese description of what that URL is for (see Deployment Report → Verification URLs for the fixed phrasing).
+  3. A plain Chinese sentence describing what that URL is for (see Deployment Report → Verification URLs for the fixed phrasing).
   The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients.
 
 ## Segmentation Report
@@ -138,19 +138,19 @@ Copy each printed URL **verbatim** (never reconstruct from a template, never han
   ```
   - [<course name> - 后台管理](<URL from script>)
     <URL from script>
-    ↳ 课程的管理后台地址。需要修改课程内容、调整 lesson、查看分析数据时，在这里操作。
+    课程的管理后台地址：需要管理课程的内容、设置小节是否隐藏、是否付费等，在这里操作。
   ```
 - Course preview →
   ```
   - [<course name> - 课程预览](<URL from script>)
     <URL from script>
-    ↳ 老师专用的预览地址。仅课程作者本人可见，用于发布前后自测课程效果。
+    课程预览地址：仅课程作者本人可见，用于发布前后自测课程效果。
   ```
 - Published URL (only when the script printed it) →
   ```
   - [<course name> - 已发布课程](<URL from script>)
     <URL from script>
-    ↳ 课程的对外公开地址，可以复制给学员使用。仅在课程已 publish 后生效。
+    课程的公开学习地址：可以发送给学员使用。仅在课程已发布后生效。
   ```
 
 When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one line below them: `> 课程尚未发布，运行 \`publish <shifu_bid>\` 后会得到可对外分享的地址。`

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -172,12 +172,12 @@ def _print_verification_urls(base_url, shifu_bid, include_published=False):
     """
     print("\nVerification URLs:")
     print(f"  Admin console:    {base_url}/shifu/{shifu_bid}")
-    print("    # 管理后台 - 修改课程内容、调整 lesson、查看分析数据时使用")
+    print("    # 课程的管理后台地址：需要管理课程的内容、设置小节是否隐藏、是否付费等，在这里操作。")
     print(f"  Course preview:   {base_url}/c/{shifu_bid}?preview=true")
-    print("    # 老师预览 - 仅课程作者本人可见，发布前后自测用")
+    print("    # 课程预览地址：仅课程作者本人可见，用于发布前后自测课程效果。")
     if include_published:
         print(f"  Published URL:    {base_url}/c/{shifu_bid}")
-        print("    # 对外地址 - 可复制给学员；仅在课程已 publish 后生效")
+        print("    # 课程的公开学习地址：可以发送给学员使用。仅在课程已发布后生效。")
 
 
 # ── Login ──────────────────────────────────────────────────────────────────────

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -156,35 +156,28 @@ def fmt_time(ts):
         return ts[:16] if len(ts) >= 16 else ts
 
 
-def _print_verification_urls(base_url, shifu_bid, tree=None):
-    """Print admin + course preview + (optional) per-lesson preview URLs.
+def _print_verification_urls(base_url, shifu_bid, include_published=False):
+    """Print admin + course preview, and (when published) the public URL.
 
     Skill docs instruct the LLM to transcribe these lines verbatim. Do not
     let the LLM reconstruct URLs from a template — that has historically led
     to wrong path (/shifu vs /c) and wrong param name (outline_bid vs lessonid).
+
+    `include_published=True` adds the public student-facing URL (no preview
+    query param). Callers should set it only when the course is known to be
+    in a published state (e.g. right after `publish`, or in `show` which
+    queries existing courses that are typically already published).
+    Lesson-level URLs are intentionally not printed — they bloat reports for
+    multi-lesson courses; build one on demand via `show <shifu_bid>` if needed.
     """
     print("\nVerification URLs:")
-    print(f"  Admin console:  {base_url}/shifu/{shifu_bid}")
-    print(f"  Course preview: {base_url}/c/{shifu_bid}?preview=true")
-    if tree:
-        items = tree if isinstance(tree, list) else [tree]
-        leaves = []
-
-        def walk(nodes):
-            for node in nodes:
-                children = node.get("children", [])
-                if children:
-                    walk(children)
-                else:
-                    bid = node.get("bid", "")
-                    if bid:
-                        leaves.append((node.get("name", ""), bid))
-
-        walk(items)
-        if leaves:
-            print("  Lesson preview:")
-            for name, bid in leaves:
-                print(f"    {name}: {base_url}/c/{shifu_bid}?preview=true&lessonid={bid}")
+    print(f"  Admin console:    {base_url}/shifu/{shifu_bid}")
+    print("    # 管理后台 - 修改课程内容、调整 lesson、查看分析数据时使用")
+    print(f"  Course preview:   {base_url}/c/{shifu_bid}?preview=true")
+    print("    # 老师预览 - 仅课程作者本人可见，发布前后自测用")
+    if include_published:
+        print(f"  Published URL:    {base_url}/c/{shifu_bid}")
+        print("    # 对外地址 - 可复制给学员；仅在课程已 publish 后生效")
 
 
 # ── Login ──────────────────────────────────────────────────────────────────────
@@ -400,7 +393,7 @@ def cmd_show(args):
         print("Outline tree:")
         print_tree(tree if isinstance(tree, list) else [tree])
 
-        _print_verification_urls(base_url, shifu_bid, tree)
+        _print_verification_urls(base_url, shifu_bid, include_published=True)
 
 
 # ── History ────────────────────────────────────────────────────────────────────
@@ -764,8 +757,7 @@ def _import_flat(base_url, token, json_file, shifu_bid):
     print(f"\nDone! Shifu: {shifu_bid}")
     print(f"  Course: {shifu_info['title']}")
     print(f"  Chapters: {len(parents)}, Lessons: {len(children)}")
-    final_tree = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/outlines")
-    _print_verification_urls(base_url, shifu_bid, final_tree)
+    _print_verification_urls(base_url, shifu_bid)
     return shifu_bid
 
 
@@ -1052,8 +1044,7 @@ def cmd_publish(args):
     base_url, token = resolve_auth(args)
     api(base_url, token, "post", f"/shifus/{args.shifu_bid}/publish", json={})
     print(f"Published: {args.shifu_bid}")
-    tree = api_safe(base_url, token, "get", f"/shifus/{args.shifu_bid}/outlines")
-    _print_verification_urls(base_url, args.shifu_bid, tree)
+    _print_verification_urls(base_url, args.shifu_bid, include_published=True)
 
 
 def cmd_archive(args):


### PR DESCRIPTION
## Summary

- Drop per-lesson preview URLs from `shifu-cli.py` output and skill docs — they cluttered reports for multi-lesson courses.
- Add a `Published URL:` (`<base>/c/<bid>`, no `preview=true`) printed by `publish` / `show`, so course authors can copy and share it with learners.
- Render each verification URL as Markdown link + bare URL + a fixed Chinese description, so users can both click and copy. Distinguish *deploy* (build+import, uploads files) from *publish* (push to the public student-facing URL).

## What changed

- `scripts/shifu-cli.py` — `_print_verification_urls` reworked: `tree` → `include_published`; lesson preview loop removed; added Chinese hint after each URL; removed two redundant outlines API calls in `cmd_create` / `cmd_publish`.
- `SKILL.md` — Deployment section distinguishes deploy vs publish; verification step references the new three-line format.
- `references/report-template.md` — top-level Formatting Rules adds the three-line verification URL exception; Deployment Report → Verification URLs block rewritten with fixed labels and Chinese descriptions.
- `references/cli/cli-reference.md` — documents which command prints which URL lines.
- `examples/end-to-end-deploy.md` — example output updated.

## Test plan

- [ ] `python3 scripts/shifu-cli.py show <published shifu_bid>` prints admin + course preview + Published URL, each followed by a Chinese description; no `Lesson preview:` block.
- [ ] `python3 scripts/shifu-cli.py publish <bid>` prints the same three-URL block.
- [ ] `python3 scripts/shifu-cli.py import --new --json-file ...` prints admin + course preview only (no Published URL, since not yet published).
- [ ] `python3 scripts/shifu-cli.py create ...` prints the same as import.
- [ ] Skim SKILL.md / report-template.md to confirm the deploy vs publish wording is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified distinction between Deploy (build + import) and Publish steps in deployment workflow
  * Updated verification URL output format to display three lines per URL (Markdown link, bare URL, Chinese description)
  * Lesson-level preview URLs now accessed on-demand via `show` command instead of auto-printed
  * Updated CLI reference and deployment guides to reflect current behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/skills/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->