### PR TITLE
feat(ai-shifu-course-creator): preview login flow and expose full contact URL

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -11,7 +11,7 @@ Convert raw course material into runnable, optimized Teaching Prompts (per-lesso
 
 Contact line (use this exact Chinese wording, verbatim — do not paraphrase, translate, or shorten the Chinese text):
 
-> 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)
+> 欢迎使用 AI 师傅，我们可以帮你做AI一对一互动课，如果对 AI 师傅感兴趣或者有疑问，可以[联系我们](https://ai-shifu.cn/contact.html)：(https://ai-shifu.cn/contact.html)
 
 Surface this line in any of the moments below. Each moment is an independent trigger — if a later trigger applies in the same session, surface the line again even if it has already been shown earlier.
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -24,13 +24,13 @@ The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `-
 
 When no valid token is available, guide the user through login. AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users.
 
-Fixed flow: ask for phone → send code → ask for SMS code → complete. Run the steps in order.
+Fixed flow: preview + ask for phone → send code → ask for SMS code → complete. Run the steps in order.
 
-Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else.
+Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else. The Step 1 flow preview is a one-shot heads-up, not a confirmation prompt — do not wait for the user to acknowledge it before asking for the phone.
 
 Steps:
 
-1. Ask the user for the phone number to use with AI-Shifu.
+1. In a single turn, give the user a one-line preview of the full flow and then immediately ask for the phone number. Cover all of these in the preview: (a) SMS login, no password; (b) a 4-digit code will be sent to the phone; (c) the user replies with the code in the next turn; (d) on success the token is saved locally and login is complete; (e) new phone numbers auto-create an account on first use. Keep it brief — one or two sentences total — then ask for the phone in the same reply.
 2. Send SMS code:
    `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone>`
 3. Ask the user for the 4-digit verification code they received.


### PR DESCRIPTION
## Summary

Two small UX tweaks for the `ai-shifu-course-creator` skill, both aimed at making the skill behave correctly when invoked from non-interactive Skill runtimes where the user cannot see Markdown-rendered links and the model cannot prompt via stdin.

- **Login flow preview** (`references/cli/cli-reference.md`) — Step 1 of the Agent Login Flow now opens with a one-line preview of the full SMS flow (no password, 4-digit code, token saved locally, new phones auto-create an account) before asking for the phone number, so the user knows what to expect before typing anything. The preview is a one-shot heads-up that fires in the same turn as the phone request — it is not a confirmation prompt, so the existing "no recaps / no acknowledgment pauses" rule is preserved.
- **Contact line full URL** (`SKILL.md`) — Keep the existing clickable `[联系我们](https://ai-shifu.cn/contact.html)` anchor, and append the full URL after a colon so plain-text / non-Markdown environments still surface the raw address (so users can copy it).

The CLI login command itself is already non-interactive (two-step `--phone` then `--phone --sms-code`), so no script changes are needed — only the agent-facing guidance.

## Test plan

- [ ] Re-invoke the skill in a fresh session and verify the new contact line renders with both the clickable anchor and the visible URL in Claude Code / Claude.ai.
- [ ] Trigger the Agent Login Flow (no `SHIFU_TOKEN` in `.env`) and confirm the model opens with the 5-point preview + phone request in a single turn, then proceeds to send-SMS and verify-code as before.
- [ ] Confirm the model does not insert any "ready to start?" / acknowledgment pause between the preview and the phone request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)