### PR TITLE
fix: clarify usage paths reference

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -97,7 +97,7 @@ Deployment                                (build + import + publish to platform)
         ╰─ optional ─▶ Analytics          (post-deployment data queries on live courses)
 ```
 
-Segmentation, Generation, and Optimization can each be invoked standalone — see Usage Paths (Path B) for the sub-paths (Segment only / Generate only / Optimize only). Analytics is a separate post-deployment path — see Path E.
+Segmentation, Generation, and Optimization can each be invoked standalone — see Usage Paths (Path B) for the sub-paths (Segment only / Generate only / Optimize only). Analytics is a separate post-deployment path — see Usage Paths (Path E).
 
 ## Usage Paths
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -97,7 +97,7 @@ Deployment                                (build + import + publish to platform)
         ╰─ optional ─▶ Analytics          (post-deployment data queries on live courses)
 ```
 
-Segmentation, Generation, and Optimization can each be invoked standalone — see [Usage Paths](#usage-paths) Path B for the sub-paths (Segment only / Generate only / Optimize only). Analytics is a separate post-deployment path — see Path E.
+Segmentation, Generation, and Optimization can each be invoked standalone — see Usage Paths (Path B) for the sub-paths (Segment only / Generate only / Optimize only). Analytics is a separate post-deployment path — see Path E.
 
 ## Usage Paths
 


### PR DESCRIPTION
## What changed

- Reworded the AI-Shifu course creator skill's pipeline note to reference Usage Paths (Path B) without using an inline Markdown anchor.

## Why

- Keeps the documentation readable while avoiding a fragile internal anchor reference in the skill body.

## Validation

- `python3 scripts/validate_skill_quality.py skills/ai-shifu-course-creator`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pipeline overview to explain that Segmentation, Generation, and Optimization can be invoked independently via specific usage paths, and that Analytics operates as a separate post-deployment feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/skills/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->