### PR TITLE
fix: remove lesson title body extraction

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -334,14 +334,14 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 ### Deployment Workflow
 
 **From pipeline (Path A continuation):**
-1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), optional `structure.json`.
+1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), and required `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
 3. **Deploy**: Run `import --new --json-file <dir>/shifu-import.json` to upload the course onto the platform.
 4. **Publish**: Run `publish <shifu_bid>` to push the course to its public student-facing URL.
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
-1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`) and a `course-prompt.md`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`.
+1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`), a `course-prompt.md`, and `structure.json`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`. If `structure.json` is missing, create it before running `build`.
 2. Run `build` → `import` (deploy) → `publish` as above.
 
 ### Verification

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -117,7 +117,7 @@ Build behavior:
 
 - **Course title** resolution order: `--title` CLI arg -> first heading in `README.md` -> directory name
 - **Chapter structure**: if `structure.json` exists, generates multi-chapter structure per its definition; otherwise creates a single chapter (named via `--chapter-name` or defaults to course title) containing all `lesson-*.md` files in sorted order
-- **Lesson title** resolution order: `title` field in `structure.json` -> `lesson_title: ...` line in the Teaching Prompt -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
+- **Lesson title** resolution order: `title` field in `structure.json` -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
 
 ## Image Upload
 

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -82,7 +82,7 @@ Schema:
       "title": "Chapter Title",
       "lessons": [
         {"file": "lesson-01.md", "title": "Lesson Title"},
-        {"file": "lesson-02.md"}
+        {"file": "lesson-02.md", "title": "Another Lesson Title"}
       ]
     }
   ]
@@ -94,4 +94,4 @@ Field reference:
 - `chapters[].title` (required): Chapter display name
 - `chapters[].lessons[]` (required): Array of lesson objects
 - `chapters[].lessons[].file` (required): Filename in the `lessons/` directory (must exist)
-- `chapters[].lessons[].title` (optional): Lesson display name. If omitted, auto-extracted from the Teaching Prompt (`lesson_title: ...` line in the MarkdownFlow content) or derived from filename
+- `chapters[].lessons[].title` (required): Lesson display name.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -4,7 +4,6 @@
 import argparse
 import json
 import os
-import re
 import sys
 import time
 import uuid
@@ -823,11 +822,8 @@ def cmd_import(args):
 
 
 # ── Build ──────────────────────────────────────────────────────────────────────
-def _extract_lesson_title(content, filename):
-    """Extract lesson_title from HTML comment block, fallback to filename."""
-    match = re.search(r'lesson_title:\s*(.+)', content)
-    if match:
-        return match.group(1).strip()
+def _derive_lesson_title(filename):
+    """Derive a readable lesson title from the lesson filename."""
     name = Path(filename).stem
     return name.replace("-", " ").title()
 
@@ -920,7 +916,7 @@ def _build_import_json(course_dir, title=None, description=None,
                     content = f.read()
 
                 item_bid = str(uuid.uuid4()).replace("-", "")
-                ls_title = ls_def.get("title") or _extract_lesson_title(content, ls_file)
+                ls_title = ls_def.get("title") or _derive_lesson_title(ls_file)
 
                 outline_items.append({
                     "outline_item_bid": item_bid,
@@ -983,7 +979,7 @@ def _build_import_json(course_dir, title=None, description=None,
                 content = f.read()
 
             item_bid = str(uuid.uuid4()).replace("-", "")
-            lesson_title = _extract_lesson_title(content, filename)
+            lesson_title = _derive_lesson_title(filename)
 
             outline_items.append({
                 "outline_item_bid": item_bid,


### PR DESCRIPTION
## Summary

- Remove `lesson_title: ...` body extraction from the AI-Shifu course builder.
- Update CLI documentation so lesson titles resolve from `structure.json` or filename-derived defaults.
- Strengthen the course-creator skill prompt and course directory spec so generated course directories include `structure.json` with explicit lesson titles.

## Validation

- `python3 scripts/validate_skill_quality.py skills/ai-shifu-course-creator`
- `git diff --check`
- Temporary offline build check confirming `structure.json` lesson titles are used for `outline_items`, while legacy body `lesson_title: ...` lines are ignored as a title source.