### PR TITLE
[codex] add Codex plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "ai-shifu-skills",
+  "version": "0.1.0",
+  "description": "Reusable AI-Shifu skills for course production, topic direction, and deployment workflows.",
+  "author": {
+    "name": "AI-Shifu",
+    "url": "https://github.com/ai-shifu"
+  },
+  "homepage": "https://github.com/ai-shifu/skills",
+  "repository": "https://github.com/ai-shifu/skills",
+  "license": "MIT",
+  "keywords": ["ai-shifu", "skills", "course-authoring", "course-production"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AI-Shifu Skills",
+    "shortDescription": "Course production skills for AI-Shifu.",
+    "longDescription": "Reusable AI-Shifu skills for course topic advising, MarkdownFlow script generation, optimization, deployment, and course operations workflows.",
+    "developerName": "AI-Shifu",
+    "category": "Education",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://github.com/ai-shifu/skills",
+    "defaultPrompt": [
+      "Use ai-shifu-course-creator to turn source material into a deployable course.",
+      "Use course-direction-advisor to evaluate a course direction."
+    ],
+    "brandColor": "#10A37F"
+  }
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Validate skill quality
         run: python3 scripts/validate_skill_quality.py
+
+      - name: Run validation tests
+        run: python3 scripts/test_validate_skill_quality.py

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ skills/
 The skill keeps `SKILL.md` as the behavior source of truth.
 Core skill metadata lives in `skills/ai-shifu-course-creator/skill.yaml`.
 
+## Codex Plugin
+
+This repository includes a Codex plugin manifest at `.codex-plugin/plugin.json`.
+The plugin exposes the repository's `./skills/` directory so Codex can install
+and list the bundled skills through a plugin marketplace or a direct Git-backed
+plugin source.
+
+Codex plugin id:
+
+```text
+ai-shifu-skills
+```
+
 ## Course Authoring & Deployment Paths
 
 Choose one path based on control needs:
@@ -69,6 +82,7 @@ Use management commands (list, show, update, rename, reorder, delete, publish, a
 
 ```bash
 python3 scripts/validate_skill_quality.py
+python3 scripts/test_validate_skill_quality.py
 ```
 
 ## Language Policy

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,18 @@ skills/
 skill 以 `SKILL.md` 作为行为定义。
 机器可读元数据位于 `skills/ai-shifu-course-creator/skill.yaml`。
 
+## Codex Plugin
+
+本仓库已包含 Codex 插件清单：`.codex-plugin/plugin.json`。
+该插件将仓库中的 `./skills/` 目录暴露给 Codex，便于通过插件市场或
+Git-backed plugin source 安装并列出这些 skills。
+
+Codex plugin id：
+
+```text
+ai-shifu-skills
+```
+
 ## 课程生产与部署路径
 
 按控制粒度选择其一：
@@ -69,6 +81,7 @@ skill 以 `SKILL.md` 作为行为定义。
 
 ```bash
 python3 scripts/validate_skill_quality.py
+python3 scripts/test_validate_skill_quality.py
 ```
 
 ## 语言策略（面向使用者）

--- a/scripts/test_validate_skill_quality.py
+++ b/scripts/test_validate_skill_quality.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for repository-level validation helpers."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_skill_quality import IssueBag, validate_codex_plugin_manifest
+
+
+class CodexPluginManifestValidationTest(unittest.TestCase):
+    def test_missing_codex_plugin_manifest_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            issues = IssueBag()
+
+            validate_codex_plugin_manifest(repo_root, issues)
+
+            self.assertIn(
+                ".codex-plugin/plugin.json is required for Codex plugin installs",
+                issues.errors,
+            )
+
+    def test_valid_codex_plugin_manifest_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            (repo_root / "skills").mkdir()
+            manifest_dir = repo_root / ".codex-plugin"
+            manifest_dir.mkdir()
+            (manifest_dir / "plugin.json").write_text(
+                """{
+  "name": "ai-shifu-skills",
+  "version": "0.1.0",
+  "description": "Reusable AI-Shifu skills for course production.",
+  "author": {
+    "name": "AI-Shifu"
+  },
+  "homepage": "https://github.com/ai-shifu/skills",
+  "repository": "https://github.com/ai-shifu/skills",
+  "license": "MIT",
+  "keywords": ["ai-shifu", "skills", "course-authoring"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AI-Shifu Skills",
+    "shortDescription": "Course production skills for AI-Shifu.",
+    "longDescription": "Reusable AI-Shifu skills for course topic advising, course script generation, and course deployment workflows.",
+    "developerName": "AI-Shifu",
+    "category": "Education",
+    "capabilities": ["Interactive", "Read", "Write"]
+  }
+}
+""",
+                encoding="utf-8",
+            )
+            issues = IssueBag()
+
+            validate_codex_plugin_manifest(repo_root, issues)
+
+            self.assertEqual([], issues.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -8,17 +8,20 @@ from __future__ import annotations
 
 import re
 import sys
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
 RE_KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 RE_XML_TAG = re.compile(r"[<>]")
 RE_REF_PATH = re.compile(r"references/[A-Za-z0-9_./-]+\.md")
+RE_SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 FORBIDDEN_WORDS = {"claude", "anthropic"}
 
 MAX_DESCRIPTION_LEN = 1024
 MIN_DESCRIPTION_LEN_RECOMMENDED = 50
 MAX_COMPATIBILITY_LEN = 500
+CODEX_PLUGIN_PATH_FIELDS = ("skills", "mcpServers", "apps", "hooks")
 
 
 @dataclass
@@ -163,6 +166,149 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
             )
 
 
+def _require_non_empty_str(
+    obj: dict[str, object],
+    field: str,
+    issues: IssueBag,
+    label: str,
+) -> str:
+    value = obj.get(field)
+    if not isinstance(value, str) or not value.strip():
+        issues.add_error(f"{label}: field '{field}' must be a non-empty string")
+        return ""
+    return value.strip()
+
+
+def _validate_plugin_relative_path(
+    repo_root: Path,
+    value: object,
+    issues: IssueBag,
+    label: str,
+) -> None:
+    if not isinstance(value, str) or not value.strip():
+        issues.add_error(f"{label} must be a non-empty string path")
+        return
+    if not value.startswith("./"):
+        issues.add_error(f"{label} must start with ./")
+        return
+
+    rel = value[2:]
+    if not rel:
+        issues.add_error(f"{label} must not be empty")
+        return
+
+    parts = rel.split("/")
+    for index, part in enumerate(parts):
+        is_trailing_slash = part == "" and index == len(parts) - 1
+        if is_trailing_slash:
+            continue
+        if part in {"", ".", ".."}:
+            issues.add_error(f"{label} must stay inside the plugin root")
+            return
+
+    normalized = rel[:-1] if rel.endswith("/") else rel
+    target = (repo_root / normalized).resolve()
+    try:
+        target.relative_to(repo_root.resolve())
+    except ValueError:
+        issues.add_error(f"{label} must stay inside the plugin root")
+        return
+
+    if not target.exists():
+        issues.add_error(f"{label} points to a missing path: {value}")
+
+
+def validate_codex_plugin_manifest(repo_root: Path, issues: IssueBag) -> None:
+    manifest_path = repo_root / ".codex-plugin" / "plugin.json"
+    if not manifest_path.exists():
+        issues.add_error(".codex-plugin/plugin.json is required for Codex plugin installs")
+        return
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        issues.add_error(f"{manifest_path}: invalid JSON: {exc}")
+        return
+
+    if not isinstance(manifest, dict):
+        issues.add_error(f"{manifest_path}: root value must be an object")
+        return
+
+    name = _require_non_empty_str(manifest, "name", issues, str(manifest_path))
+    if name and not RE_KEBAB_CASE.match(name):
+        issues.add_error(f"{manifest_path}: field 'name' must be kebab-case")
+
+    version = _require_non_empty_str(manifest, "version", issues, str(manifest_path))
+    if version and not RE_SEMVER.match(version):
+        issues.add_error(f"{manifest_path}: field 'version' must be strict semver")
+
+    for field in ("description", "homepage", "repository", "license"):
+        _require_non_empty_str(manifest, field, issues, str(manifest_path))
+
+    author = manifest.get("author")
+    if not isinstance(author, dict):
+        issues.add_error(f"{manifest_path}: field 'author' must be an object")
+    else:
+        _require_non_empty_str(author, "name", issues, f"{manifest_path}: author")
+
+    keywords = manifest.get("keywords")
+    if not isinstance(keywords, list) or not keywords:
+        issues.add_error(f"{manifest_path}: field 'keywords' must be a non-empty array")
+    elif not all(isinstance(item, str) and item.strip() for item in keywords):
+        issues.add_error(f"{manifest_path}: field 'keywords' must contain only non-empty strings")
+
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        issues.add_error(f"{manifest_path}: field 'interface' must be an object")
+    else:
+        for field in (
+            "displayName",
+            "shortDescription",
+            "longDescription",
+            "developerName",
+            "category",
+        ):
+            _require_non_empty_str(interface, field, issues, f"{manifest_path}: interface")
+
+        capabilities = interface.get("capabilities")
+        if not isinstance(capabilities, list) or not capabilities:
+            issues.add_error(
+                f"{manifest_path}: interface.capabilities must be a non-empty array"
+            )
+        elif not all(isinstance(item, str) and item.strip() for item in capabilities):
+            issues.add_error(
+                f"{manifest_path}: interface.capabilities must contain only non-empty strings"
+            )
+
+    has_component = False
+    for field in CODEX_PLUGIN_PATH_FIELDS:
+        if field not in manifest:
+            continue
+        has_component = True
+        value = manifest[field]
+        if isinstance(value, list):
+            for index, item in enumerate(value):
+                _validate_plugin_relative_path(
+                    repo_root,
+                    item,
+                    issues,
+                    f"{manifest_path}: {field}[{index}]",
+                )
+        else:
+            _validate_plugin_relative_path(
+                repo_root,
+                value,
+                issues,
+                f"{manifest_path}: {field}",
+            )
+
+    if not has_component:
+        issues.add_error(
+            f"{manifest_path}: at least one component path is required "
+            "(skills, mcpServers, apps, or hooks)"
+        )
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     skills_root = repo_root / "skills"
@@ -176,6 +322,7 @@ def main() -> int:
         return 1
 
     issues = IssueBag()
+    validate_codex_plugin_manifest(repo_root, issues)
     for skill_dir in skill_dirs:
         validate_skill(skill_dir, issues)
 


### PR DESCRIPTION
## Summary
- Add `.codex-plugin/plugin.json` so the repository can be installed as a Codex plugin.
- Extend skill validation to check the Codex plugin manifest and component paths.
- Document Codex plugin usage in English and Chinese READMEs, and run the new validation test in CI.

## Test Plan
- `python3 -m json.tool .codex-plugin/plugin.json >/dev/null`
- `python3 scripts/test_validate_skill_quality.py`
- `python3 scripts/validate_skill_quality.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Codex Plugin section in README files (English and Chinese) documenting plugin configuration and setup
  * Updated metadata validation instructions with new test commands

* **Chores**
  * Added plugin manifest configuration file
  * Enhanced validation workflow with comprehensive test coverage for manifest validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/skills/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->