### PR TITLE
feat: add verify command and SMS once-only login rules

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -105,9 +105,17 @@ cloud for an existing one — this is the explicit front guard from the editing
 flowchart.
 
 1. **Recognize intent** — new course, or edit an existing one?
-2. **Ensure login** — the existence check needs the cloud. If `.env` has no valid
-   token, guide the user through `shifu-cli.py login` **now**
-   (`references/cli/cli-reference.md#authentication`).
+2. **Ensure login — verify first, do NOT re-login blindly.** Run
+   `shifu-cli.py verify`. It returns exit code `0` when the stored token is
+   still valid — skip login entirely and continue to step 3. Only when it
+   returns `1` (expired/invalid) do you guide the user through a **single**
+   SMS login session (below). Exit code `2` (network issue) means retry
+   later — still do NOT trigger a new login.
+   - **Token checks are cheap; SMS is expensive** — each phone number only
+     gets 5 SMS codes per day. Never re-login just because you're unsure —
+     `verify` answers the question.
+   - When a login is needed, follow the agent login flow in
+     `references/cli/cli-reference.md#agent-login-flow`.
 3. **Check whether a related course already exists** — run
    `shifu-cli.py find-title <keyword>` (targeted title search; do **not** dump the
    whole `list`).
@@ -377,7 +385,16 @@ The standard end-to-end flow chains deploy + publish: build → import (deploy) 
 
 ### Authentication
 
-When no valid token is available, guide the user through `shifu-cli.py login` (SMS flow: phone number + 4-digit verification code; CLI defaults to `https://app.ai-shifu.cn`). Full flow in `references/cli/cli-reference.md#authentication`.
+**Verify first — never re-login blindly.** Before any operation that needs a
+token, run `shifu-cli.py verify`:
+- exit `0` → token is valid, continue.  **Do NOT trigger the login flow.**
+- exit `1` → token is expired/invalid, guide the user through a **single**
+  SMS login session (see `references/cli/cli-reference.md#agent-login-flow`).
+- exit `2` → network issue, retry later — still do NOT trigger a new login.
+
+Each phone number only gets **5 SMS verification codes per day**.  Re-logging
+when the token is still valid wastes one of those slots and can lock the user
+out.  `verify` answers the question cheaply (one lightweight API call, no SMS).
 
 Always use CLI commands. Never make raw HTTP/API calls directly.
 
@@ -494,7 +511,7 @@ Post-deployment data queries on live courses. Trigger this section whenever a co
 
 ### Workflow
 
-1. **Resolve credentials** — reuse the Deployment authentication. If `.env` lacks a valid `SHIFU_TOKEN`, guide the user through `shifu-cli.py login` per `references/cli/cli-reference.md#agent-login-flow`.
+1. **Resolve credentials** — run `shifu-cli.py verify`. If exit 0 the stored token is valid; if exit 1, guide the user through the SMS login flow per `references/cli/cli-reference.md#agent-login-flow`.
 2. **Resolve the course** — run `shifu-cli.py list` (or `shifu-cli.py find-title <keyword>`) to map `shifu_bid ↔ course name`. **If the user mentioned a course by title**, always resolve the *current* `shifu_bid → title` via Course Metadata recipes 0a / 0b in `references/analytics/recipes.md` before issuing downstream queries — `list` is a draft snapshot and can show stale or historical titles. Never report a historical title as the course's current name.
 3. **Resolve the outline** (only for course-level analysis) — run `shifu-cli.py show <shifu_bid>` to map `outline_item_bid → name / position`. Skipping this makes outline-dimension numbers unreadable.
 4. **Run DSL queries** — `shifu-cli.py analytics-query <shifu_bid> --dsl '<json-body>'` (or `--dsl-file query.json` for long bodies).

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -8,35 +8,85 @@ python3 {skillDir}/scripts/shifu-cli.py <command>
 
 ## Authentication
 
-Run login once — the token persists in `{skillDir}/.env` for subsequent commands:
+The token persists in `{skillDir}/.env` and is valid for **7 days**, with each
+successful API call refreshing the expiry (sliding window — an active user never
+expires).  Before every operation that needs a token, run the one-shot check:
 
 ```bash
-# Step 1: Send SMS verification code
+verify                         # exit 0 = valid, 1 = expired, 2 = unknown
+```
+
+When `verify` returns 1, run the SMS login once:
+
+```bash
+# Step 1: Send SMS verification code (once per session — see below)
 login --phone 13800138000
 
-# Step 2: Complete login with the code
+# Step 2: Complete login with the 4-digit code
 login --phone 13800138000 --sms-code 1234
 ```
 
-The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `--token` / `SHIFU_TOKEN` directly.
+The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set
+`--token` / `SHIFU_TOKEN` directly.
 
 ### Agent Login Flow
 
-When no valid token is available, guide the user through login. AI-Shifu's SMS login auto-creates an account on first use, so the same flow works for both new and returning users.
+**Gate: run `shifu-cli.py verify` first.** Exit 0 → skip login entirely; exit 1
+→ run the flow below **once**; exit 2 → retry later, do NOT trigger a new login.
 
-Fixed flow: preview + ask for phone → send code → ask for SMS code → complete. Run the steps in order.
+**Hard constraint — one phone number = one SMS send per login session.**  Each
+phone number is capped at **5 SMS codes per day**.  Sending a second SMS when the
+first is still in transit wastes a slot and risks locking the user out.  The
+agent MUST:
+- Collect the phone number → send `login --phone <phone>` **exactly once**.
+- If the user asks "didn't receive / resend", reply "验证码在 60 秒内到达，请稍等" —
+  do NOT resend unless **3 consecutive wrong codes** have been entered.
+- After the 3rd consecutive wrong code, send `login --phone <phone>` one more
+  time (this is the final SMS for this session).
 
-Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else. The Step 1 flow preview is a one-shot heads-up, not a confirmation prompt — do not wait for the user to acknowledge it before asking for the phone.
+Fixed flow: verify → (only if needed) ask for phone → send code → ask for SMS
+code → complete. Run the steps in order. Do not ask anything else.
+
+Do not ask anything else. No status checks ("have you signed up / logged in
+before?"), no readiness or intent confirmations ("ready to start?", "I'll
+provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn
+collects exactly the next value (phone, then SMS code), nothing else. The
+Step 1 flow preview is a one-shot heads-up, not a confirmation prompt — do not
+wait for the user to acknowledge it before asking for the phone.
 
 Steps:
 
-1. In a single turn, give the user a one-line preview of the full flow and then immediately ask for the phone number. Cover all of these in the preview: (a) SMS login, no password; (b) a 4-digit code will be sent to the phone; (c) the user replies with the code in the next turn; (d) on success the token is saved locally and login is complete; (e) new phone numbers auto-create an account on first use. Keep it brief — one or two sentences total — then ask for the phone in the same reply.
-2. Send SMS code:
+1. In a single turn, give the user a one-line preview of the full flow and then
+   immediately ask for the phone number. Cover all of these in the preview:
+   (a) SMS login, no password; (b) a 4-digit code will be sent to the phone;
+   (c) the user replies with the code in the next turn; (d) on success the token
+   is saved locally and login is complete; (e) new phone numbers auto-create an
+   account on first use. Keep it brief — one or two sentences total — then ask
+   for the phone in the same reply.
+2. Send SMS code **once**:
    `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone>`
 3. Ask the user for the 4-digit verification code they received.
 4. Complete login:
    `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --sms-code <4-digit-code>`
 5. Token is automatically saved — proceed with the requested operation.
+
+**Error → agent behavior quick reference:**
+
+| What happened | Agent response |
+|---|---|
+| `verify` exit 0 | Token valid — continue, no login |
+| `verify` exit 1 | Run the SMS flow above **once** |
+| `verify` exit 2 | Network issue — retry `verify` later |
+| login returned "SMS sent" | Wait for user to provide code; do NOT resend |
+| login returned "smsSendTooFrequent" | Wait 60 s then retry; do NOT send the phone again |
+| login returned sms code error (1st or 2nd time) | Ask user to re-enter code; do NOT resend SMS |
+| login returned sms code error (**3rd** consecutive time) | Re-send `login --phone <phone>` to get a new code |
+| Any API call returned code 1005 (token expired) | Run `verify` → login flow |
+
+**Token persistence.** The login step writes `SHIFU_TOKEN=<jwt>` into
+`{skillDir}/.env`. Once saved, `verify` is the gate — the token stays valid for
+7 days with sliding refresh. If the token expires (error codes `1001` / `1004`
+/ `1005`), re-run the login flow — the `.env` is overwritten in place.
 
 Always use CLI commands. Never make raw HTTP/API calls directly.
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -92,7 +92,7 @@ def resolve_auth(args):
         sys.exit(1)
 
     payload = _jwt_payload(token)
-    if payload:
+    if isinstance(payload, dict):
         ts = payload.get("time_stamp")
         if isinstance(ts, (int, float)) and (time.time() - ts) > TOKEN_EXPIRE_SECONDS:
             print("Warning: token may be expired (issued > 7 days ago). "
@@ -502,6 +502,9 @@ def cmd_verify(args):
         data = resp.json()
     except ValueError:
         print("Token status: unknown (invalid JSON response)")
+        sys.exit(2)
+    if not isinstance(data, dict):
+        print("Token status: unknown (unexpected JSON response)")
         sys.exit(2)
     code = data.get("code")
     if code == 0:

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2,6 +2,7 @@
 """AI-Shifu Course CLI - Unified tool for course CRUD operations."""
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -53,12 +54,26 @@ def save_env(token):
 
 
 def resolve_auth(args):
-    """Resolve token from CLI args or .env. Base URL is fixed to DEFAULT_BASE_URL."""
+    """Resolve token from CLI args or .env. Base URL is fixed to DEFAULT_BASE_URL.
+
+    When the JWT carries a ``time_stamp`` older than 7 days, a warning is printed
+    to stderr (the authoritative expiry check is the backend's DB record, so this
+    is only a nudge — the call still proceeds).
+    """
     token = getattr(args, "token", None) or os.environ.get("SHIFU_TOKEN")
     if not token:
         print("Error: no token available. Run 'shifu-cli.py login' first, "
               "or use --token / set SHIFU_TOKEN in .env")
         sys.exit(1)
+
+    payload = _jwt_payload(token)
+    if payload:
+        ts = payload.get("time_stamp")
+        if ts and (time.time() - ts) > TOKEN_EXPIRE_SECONDS:
+            print("Warning: token may be expired (issued > 7 days ago). "
+                  "Run `shifu-cli.py verify` to check, or `shifu-cli.py login` "
+                  "to re-login.",
+                  file=sys.stderr)
 
     return DEFAULT_BASE_URL, token
 
@@ -430,6 +445,68 @@ def cmd_login(args):
                     {"mobile": phone}, "Failed to send SMS")
         print(f"SMS code sent to {masked}. "
               f"Run again with --sms-code <4-digit-code> to complete login.")
+
+
+# ── Verify Token ────────────────────────────────────────────────────────────────
+TOKEN_EXPIRE_SECONDS = 604800  # 7 days, matches backend TOKEN_EXPIRE_TIME
+
+# Backend error codes that mean "token is not usable":
+_TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
+# 1001 = userNotFound, 1004 = userNotLogin, 1005 = userTokenExpired
+
+
+def _jwt_payload(token):
+    """Decode the JWT payload (no verification) for a lightweight expiry hint.
+
+    The ai-shifu JWT only carries ``user_id`` + ``time_stamp`` (no ``exp``), so a
+    true expiry check requires asking the backend.  We just extract ``time_stamp``
+    for a cheap early warning — the authoritative decision is in ``cmd_verify``.
+    Returns None when the token cannot be parsed as a JWT.
+    """
+    try:
+        encoded = token.split(".")[1]
+        # JWT base64url: replace URL-safe chars and add padding
+        encoded = encoded.replace("-", "+").replace("_", "/")
+        encoded += "=" * ((4 - len(encoded) % 4) % 4)
+        return json.loads(base64.b64decode(encoded))
+    except Exception:
+        return None
+
+
+def cmd_verify(args):
+    """Check whether the stored token is still valid, using a lightweight API call.
+
+    Exit codes:
+      0 — token is valid (API accepted it)
+      1 — token is expired / invalid (error codes 1001 / 1004 / 1005)
+      2 — unknown (network / service error — cannot determine)
+    """
+    base_url, token = resolve_auth(args)
+    try:
+        url = f"{base_url}/api/shifu/shifus?limit=1"
+        headers = {"Cookie": f"token={token}", "Content-Type": "application/json"}
+        resp = requests.get(url, headers=headers, timeout=15)
+    except requests.RequestException as e:
+        print(f"Token status: unknown (network error: {e})")
+        sys.exit(2)
+    if not resp.ok:
+        print(f"Token status: unknown (HTTP {resp.status_code})")
+        sys.exit(2)
+    try:
+        data = resp.json()
+    except ValueError:
+        print("Token status: unknown (invalid JSON response)")
+        sys.exit(2)
+    code = data.get("code")
+    if code == 0:
+        print("Token is valid")
+        sys.exit(0)
+    if code in _TOKEN_ERROR_CODES:
+        print("Token is expired or invalid — re-run `shifu-cli.py login`")
+        sys.exit(1)
+    # Any other business code (e.g. no courses) — the token was recognised.
+    print(f"Token is valid (API returned code {code})")
+    sys.exit(0)
 
 
 # ── List ───────────────────────────────────────────────────────────────────────
@@ -2271,6 +2348,11 @@ def build_parser():
     p.add_argument("--sms-code", default=None,
                    help="4-digit SMS verification code")
 
+    # ── verify ──
+    sub.add_parser("verify", parents=[parent_parser],
+                   help="Check whether the stored token is still valid "
+                        "(exit 0 = valid, 1 = expired, 2 = unknown)")
+
     # ── list ──
     sub.add_parser("list", parents=[parent_parser], help="List all courses")
 
@@ -2495,6 +2577,7 @@ def main():
 
     commands = {
         "login": cmd_login,
+        "verify": cmd_verify,
         "list": cmd_list,
         "show": cmd_show,
         "pull": cmd_pull,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -35,6 +35,13 @@ DRAFT_CONFLICT_CODE = 4007
 #   0 = success, 1 = hard error (api() default), 2 = conflict auto-pulled, redo
 EXIT_CONFLICT = 2
 
+# Token lifetime (matches backend TOKEN_EXPIRE_TIME = 604800 = 7 days) and the
+# backend error codes that mean "token is not usable" — used by `verify` and the
+# resolve_auth() early-expiry hint.
+TOKEN_EXPIRE_SECONDS = 604800
+_TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
+# 1001 = userNotFound, 1004 = userNotLogin, 1005 = userTokenExpired
+
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
 def load_env():
@@ -53,6 +60,24 @@ def save_env(token):
     os.chmod(env_path, 0o600)
 
 
+def _jwt_payload(token):
+    """Decode the JWT payload (no verification) for a lightweight expiry hint.
+
+    The ai-shifu JWT only carries ``user_id`` + ``time_stamp`` (no ``exp``), so a
+    true expiry check requires asking the backend.  We just extract ``time_stamp``
+    for a cheap early warning — the authoritative decision is in ``cmd_verify``.
+    Returns None when the token cannot be parsed as a JWT.
+    """
+    try:
+        encoded = token.split(".")[1]
+        # JWT base64url: replace URL-safe chars and add padding
+        encoded = encoded.replace("-", "+").replace("_", "/")
+        encoded += "=" * ((4 - len(encoded) % 4) % 4)
+        return json.loads(base64.b64decode(encoded))
+    except Exception:
+        return None
+
+
 def resolve_auth(args):
     """Resolve token from CLI args or .env. Base URL is fixed to DEFAULT_BASE_URL.
 
@@ -69,7 +94,7 @@ def resolve_auth(args):
     payload = _jwt_payload(token)
     if payload:
         ts = payload.get("time_stamp")
-        if ts and (time.time() - ts) > TOKEN_EXPIRE_SECONDS:
+        if isinstance(ts, (int, float)) and (time.time() - ts) > TOKEN_EXPIRE_SECONDS:
             print("Warning: token may be expired (issued > 7 days ago). "
                   "Run `shifu-cli.py verify` to check, or `shifu-cli.py login` "
                   "to re-login.",
@@ -448,31 +473,6 @@ def cmd_login(args):
 
 
 # ── Verify Token ────────────────────────────────────────────────────────────────
-TOKEN_EXPIRE_SECONDS = 604800  # 7 days, matches backend TOKEN_EXPIRE_TIME
-
-# Backend error codes that mean "token is not usable":
-_TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
-# 1001 = userNotFound, 1004 = userNotLogin, 1005 = userTokenExpired
-
-
-def _jwt_payload(token):
-    """Decode the JWT payload (no verification) for a lightweight expiry hint.
-
-    The ai-shifu JWT only carries ``user_id`` + ``time_stamp`` (no ``exp``), so a
-    true expiry check requires asking the backend.  We just extract ``time_stamp``
-    for a cheap early warning — the authoritative decision is in ``cmd_verify``.
-    Returns None when the token cannot be parsed as a JWT.
-    """
-    try:
-        encoded = token.split(".")[1]
-        # JWT base64url: replace URL-safe chars and add padding
-        encoded = encoded.replace("-", "+").replace("_", "/")
-        encoded += "=" * ((4 - len(encoded) % 4) % 4)
-        return json.loads(base64.b64decode(encoded))
-    except Exception:
-        return None
-
-
 def cmd_verify(args):
     """Check whether the stored token is still valid, using a lightweight API call.
 
@@ -490,6 +490,12 @@ def cmd_verify(args):
         print(f"Token status: unknown (network error: {e})")
         sys.exit(2)
     if not resp.ok:
+        # A gateway/proxy can reject a bad token before the app runs — 401/403
+        # definitively mean "not authenticated", so report expired (exit 1) so the
+        # agent re-logins instead of retrying forever as if it were a network blip.
+        if resp.status_code in (401, 403):
+            print("Token is expired or invalid — re-run `shifu-cli.py login`")
+            sys.exit(1)
         print(f"Token status: unknown (HTTP {resp.status_code})")
         sys.exit(2)
     try:


### PR DESCRIPTION
…gin rules

Problem: the agent re-logged every session (wasting daily SMS quota of 5 codes per phone number) because the CLI never validated whether a stored token was still good, and SKILL.md said "if no valid token" without defining how to check validity.

Changes:
- shifu-cli.py: new `verify` command — one lightweight GET /shifus?limit=1 to check the token, exit 0=valid / 1=expired / 2=unknown. No SMS sent.
- resolve_auth(): decode JWT timestamp for an early-expiry stderr nudge (non-blocking; the authoritative check is still the backend DB).
- SKILL.md Step 0 / Authentication / Analytics: "Ensure login" rewritten to verify-first — only trigger SMS login when verify exits 1.
- cli-reference.md Agent Login Flow: hard rule that one phone number gets exactly one SMS send, only a 3rd consecutive wrong code permits a re-send. Error-code → agent-behaviour quick-reference table added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verify-first authentication flow to check token status before starting any token-dependent login.
  * Introduced a `verify` one-shot command that classifies token state (usable, expired/invalid, or unknown) for safer decision-making.

* **Documentation**
  * Updated instructions to require verification before token usage, including explicit exit-code behavior.
  * Expanded the CLI authentication documentation with the token lifecycle (7-day sliding validity) and a strict, rate-limited SMS login protocol with defined retry/resend rules and error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->