### PR TITLE
feat: add course TTS toggle command

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -415,17 +415,19 @@ never resets attributes. `pull` writes the current attributes into
 `structure.json` (`access`/`hidden`) and `course-config.json` as a **read-only
 reference** for you. Change attributes only when the user explicitly asks:
 `set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--course-dir <dir>]`
-for a lesson's permission; course-level settings are changed in the platform editor.
+for a lesson's permission; `set-tts <shifu_bid> --enabled true|false [--course-dir <dir>]`
+for course listening mode. Other course-level settings are changed in the
+platform editor.
 
 **Editing an existing course → use granular non-destructive commands**
-(`pull → update-lesson / add-lesson / delete-lesson / reorder / set-access`).
+(`pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`).
 The destructive whole-course `import` recreates every outline (a recreated lesson
 gets the platform-default permission), so reserve `import --new` for brand-new
 courses — do not use it to iterate an existing one.
 
 ### CLI Commands
 
-All commands documented in `references/cli/cli-reference.md` (deployment: `build` / `import` / `publish` / `show`; version sync: `pull` / `status`; management for Path D: `list` / `update-meta` / `update-lesson` / `rename-lesson` / `set-access` / `reorder` / `delete-lesson` / `archive`). JSON schema in `references/cli/import-json-format.md`.
+All commands documented in `references/cli/cli-reference.md` (deployment: `build` / `import` / `publish` / `show`; version sync: `pull` / `status`; management for Path D: `list` / `update-meta` / `update-lesson` / `rename-lesson` / `set-access` / `set-tts` / `reorder` / `delete-lesson` / `archive`). JSON schema in `references/cli/import-json-format.md`.
 
 ### Deployment Workflow
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -172,6 +172,7 @@ update-lesson <shifu_bid> <outline_bid> --teaching-prompt-file lesson.md [--cour
 rename-lesson <shifu_bid> <outline_bid> --name "New Name"
 reorder <shifu_bid> --order bid1,bid2,bid3
 set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--hidden true|false] [--course-dir ./course-a/]
+set-tts <shifu_bid> --enabled true|false [--course-dir ./course-a/]
 ```
 
 `update-meta` sends only the content fields you pass (`--name` / `--description`
@@ -186,7 +187,12 @@ permission.
 lesson's other fields untouched. With `--course-dir` it also writes the value
 into the `structure.json` reference.
 
-`update-lesson` and `update-meta` are version-aware when given `--course-dir`
+`set-tts` enables or disables course listening mode without re-importing; it
+sends only `tts_enabled` and leaves provider/model/voice/speed/pitch/emotion
+unchanged. With `--course-dir` it refreshes `course-config.json` and records the
+new course revision in `.shifu-sync.json`.
+
+`update-lesson`, `update-meta`, and `set-tts` are version-aware when given `--course-dir`
 (a directory with a `.shifu-sync.json` from `pull`):
 
 - `update-lesson` uses the **recorded baseline** revision for that outline (its
@@ -195,11 +201,11 @@ into the `structure.json` reference.
   the legacy behavior of taking the current cloud head as the baseline
   (degraded — concurrent edits are not caught). On success it writes the new
   revision back to the manifest and keeps the local lesson file in lockstep.
-- `update-meta` has no server-side lock, so it compares the cloud course-level
-  revision against the manifest baseline before writing; any cloud advance is
-  treated conservatively as a conflict.
+- `update-meta` and `set-tts` have no server-side lock, so they compare the cloud
+  course-level revision against the manifest baseline before writing; any cloud
+  advance is treated conservatively as a conflict.
 
-**On conflict** both commands auto-pull the cloud copy over local (backing up
+**On conflict** these commands auto-pull the cloud copy over local (backing up
 your un-pushed change to `<file>.conflict` for a lesson, or
 `.shifu-meta.conflict.json` for meta — your work is never lost), print who
 changed it and when, and exit `2`. Re-apply your edit on the freshly pulled
@@ -240,11 +246,12 @@ So `update-lesson` (content only) and `update-meta` (only the `--name` /
 
 `pull` still writes the attributes into `structure.json` (`access`/`hidden`) and
 `course-config.json` as a **read-only reference** for the agent. To change an
-attribute, do it explicitly: `set-access` for a lesson's permission, or the
-platform editor for course-level settings.
+attribute, do it explicitly: `set-access` for a lesson's permission, `set-tts`
+for course listening mode, or the platform editor for other course-level
+settings.
 
 > **Iterating an existing course:** prefer the non-destructive granular commands
-> — `pull → update-lesson / add-lesson / delete-lesson / reorder / set-access`.
+> — `pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`.
 > The destructive whole-course `import` recreates every outline, so a recreated
 > lesson gets the platform default permission; use `import --new` for brand-new
 > courses, not to iterate an existing one.

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -141,6 +141,10 @@ default — the backend preserves any attribute a write leaves out, so iterating
 content never resets model/price/TTS/Ask. The course **name** lives in
 `README.md` and the **system prompt** in `course-prompt.md`.
 
+The exception is an explicit listening-mode update: `set-tts --course-dir`
+refreshes this snapshot after changing `tts_enabled`. It still does not make
+`build` or `import` push course-level attributes.
+
 ```json
 {
   "model": "", "temperature": 0.3, "price": 0, "keywords": [], "avatar": "",
@@ -154,5 +158,7 @@ content never resets model/price/TTS/Ask. The course **name** lives in
 
 To change a single lesson's permission, use
 `shifu-cli.py set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--hidden true|false] [--course-dir <dir>]`
-(passing `--course-dir` also updates the `structure.json` reference). Course-level
-attributes are changed in the platform editor.
+(passing `--course-dir` also updates the `structure.json` reference). To change
+course listening mode, use
+`shifu-cli.py set-tts <shifu_bid> --enabled true|false [--course-dir <dir>]`.
+Other course-level attributes are changed in the platform editor.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1214,6 +1214,57 @@ def cmd_create(args):
 
 
 # ── Update Meta ────────────────────────────────────────────────────────────────
+def _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
+                                intended_meta):
+    """Check course-level draft revision conflicts before a detail write."""
+    if not (manifest and manifest.get("shifu_bid") == shifu_bid):
+        return
+
+    local_course_rev = (manifest.get("course") or {}).get("revision")
+    cloud_meta = api_safe(base_url, token, "get",
+                          f"/shifus/{shifu_bid}/draft-meta") or {}
+    cloud_rev = cloud_meta.get("revision")
+    if (cloud_rev is not None and local_course_rev is not None
+            and cloud_rev > local_course_rev):
+        _auto_pull_overwrite(base_url, token, shifu_bid, course_dir,
+                             scope="meta", intended_meta=intended_meta,
+                             conflict_meta=cloud_meta)
+        sys.exit(EXIT_CONFLICT)
+
+
+def _update_course_manifest_after_push(base_url, token, shifu_bid, course_dir,
+                                       manifest, course_updates=None):
+    """Re-read and record the new course-level revision after a detail write."""
+    fresh = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/draft-meta")
+    if not isinstance(fresh, dict) or fresh.get("revision") is None:
+        # The POST already bumped the cloud revision; if we cannot read the new
+        # value, writing the old revision back with a fresh last_push_at would
+        # make the next edit see cloud > local and raise a false conflict.
+        print("Warning: could not read the new course revision from the "
+              "server; the sync manifest was left unchanged. Run "
+              "`pull --course-dir <dir>` to resync.", file=sys.stderr)
+        return
+
+    # Explicit check (not setdefault): a hand-edited manifest with "course": null
+    # would make setdefault return None and crash below.
+    course = manifest.get("course")
+    if not isinstance(course, dict):
+        course = {}
+        manifest["course"] = course
+
+    course["revision"] = fresh.get("revision")
+    for key, value in (course_updates or {}).items():
+        if value is not None:
+            course[key] = value
+    if fresh.get("updated_at") is not None:
+        course["updated_at"] = fresh.get("updated_at")
+    fresh_user = (fresh.get("updated_user") or {}).get("user_bid")
+    if fresh_user is not None:
+        course["updated_user_bid"] = fresh_user
+    manifest["last_push_at"] = _now_iso()
+    _write_sync(course_dir, manifest)
+
+
 def cmd_update_meta(args):
     """Update course metadata (name, description, system prompt, etc.).
 
@@ -1230,19 +1281,10 @@ def cmd_update_meta(args):
     course_dir = getattr(args, "course_dir", None)
 
     manifest = _load_sync(course_dir) if course_dir else None
-    if manifest and manifest.get("shifu_bid") == shifu_bid:
-        local_course_rev = (manifest.get("course") or {}).get("revision")
-        cloud_meta = api_safe(base_url, token, "get",
-                              f"/shifus/{shifu_bid}/draft-meta") or {}
-        cloud_rev = cloud_meta.get("revision")
-        if (cloud_rev is not None and local_course_rev is not None
-                and cloud_rev > local_course_rev):
-            intended = {"name": args.name, "description": args.description,
-                        "course_prompt_file": args.course_prompt_file}
-            _auto_pull_overwrite(base_url, token, shifu_bid, course_dir,
-                                 scope="meta", intended_meta=intended,
-                                 conflict_meta=cloud_meta)
-            sys.exit(EXIT_CONFLICT)
+    intended = {"name": args.name, "description": args.description,
+                "course_prompt_file": args.course_prompt_file}
+    _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
+                                intended)
 
     # Send ONLY the content fields the user is changing. The backend uses PATCH
     # semantics (an omitted field is left unchanged), so we deliberately do NOT
@@ -1269,31 +1311,9 @@ def cmd_update_meta(args):
     # Re-read the course-level revision (the detail POST response does not carry
     # it) and record it as the new baseline so subsequent edits compare cleanly.
     if manifest and manifest.get("shifu_bid") == shifu_bid:
-        fresh = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/draft-meta")
-        if not isinstance(fresh, dict) or fresh.get("revision") is None:
-            # The POST already bumped the cloud revision; if we cannot read the
-            # new value, writing the *old* revision back (with a fresh
-            # last_push_at) would make the next edit see cloud > local and raise
-            # a false conflict. Leave the manifest untouched and tell the user.
-            print("Warning: could not read the new course revision from the "
-                  "server; the sync manifest was left unchanged. Run "
-                  "`pull --course-dir <dir>` to resync.", file=sys.stderr)
-        else:
-            # Explicit check (not setdefault): a hand-edited manifest with
-            # "course": null would make setdefault return None and crash below.
-            course = manifest.get("course")
-            if not isinstance(course, dict):
-                course = {}
-                manifest["course"] = course
-            course["revision"] = fresh.get("revision")
-            course["name"] = payload.get("name", course.get("name"))
-            if fresh.get("updated_at") is not None:
-                course["updated_at"] = fresh.get("updated_at")
-            fresh_user = (fresh.get("updated_user") or {}).get("user_bid")
-            if fresh_user is not None:
-                course["updated_user_bid"] = fresh_user
-            manifest["last_push_at"] = _now_iso()
-            _write_sync(course_dir, manifest)
+        _update_course_manifest_after_push(
+            base_url, token, shifu_bid, course_dir, manifest,
+            course_updates={"name": payload.get("name")})
 
 
 # ── Set TTS ───────────────────────────────────────────────────────────────────
@@ -1305,18 +1325,9 @@ def cmd_set_tts(args):
     course_dir = getattr(args, "course_dir", None)
 
     manifest = _load_sync(course_dir) if course_dir else None
-    if manifest and manifest.get("shifu_bid") == shifu_bid:
-        local_course_rev = (manifest.get("course") or {}).get("revision")
-        cloud_meta = api_safe(base_url, token, "get",
-                              f"/shifus/{shifu_bid}/draft-meta") or {}
-        cloud_rev = cloud_meta.get("revision")
-        if (cloud_rev is not None and local_course_rev is not None
-                and cloud_rev > local_course_rev):
-            intended = {"tts_enabled": enabled}
-            _auto_pull_overwrite(base_url, token, shifu_bid, course_dir,
-                                 scope="meta", intended_meta=intended,
-                                 conflict_meta=cloud_meta)
-            sys.exit(EXIT_CONFLICT)
+    intended = {"tts_enabled": enabled}
+    _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
+                                intended)
 
     # Send only the TTS switch. Provider/model/voice/speed/pitch/emotion remain
     # whatever the platform currently stores.
@@ -1335,24 +1346,8 @@ def cmd_set_tts(args):
                   f"{COURSE_CONFIG_NAME} was left unchanged. Run "
                   "`pull --course-dir <dir>` to resync.", file=sys.stderr)
 
-        fresh = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/draft-meta")
-        if not isinstance(fresh, dict) or fresh.get("revision") is None:
-            print("Warning: could not read the new course revision from the "
-                  "server; the sync manifest was left unchanged. Run "
-                  "`pull --course-dir <dir>` to resync.", file=sys.stderr)
-        else:
-            course = manifest.get("course")
-            if not isinstance(course, dict):
-                course = {}
-                manifest["course"] = course
-            course["revision"] = fresh.get("revision")
-            if fresh.get("updated_at") is not None:
-                course["updated_at"] = fresh.get("updated_at")
-            fresh_user = (fresh.get("updated_user") or {}).get("user_bid")
-            if fresh_user is not None:
-                course["updated_user_bid"] = fresh_user
-            manifest["last_push_at"] = _now_iso()
-            _write_sync(course_dir, manifest)
+        _update_course_manifest_after_push(base_url, token, shifu_bid,
+                                           course_dir, manifest)
 
 
 # ── Add Chapter ────────────────────────────────────────────────────────────────

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1296,6 +1296,65 @@ def cmd_update_meta(args):
             _write_sync(course_dir, manifest)
 
 
+# ── Set TTS ───────────────────────────────────────────────────────────────────
+def cmd_set_tts(args):
+    """Enable or disable course listening mode without changing other attributes."""
+    base_url, token = resolve_auth(args)
+    shifu_bid = args.shifu_bid
+    enabled = args.enabled == "true"
+    course_dir = getattr(args, "course_dir", None)
+
+    manifest = _load_sync(course_dir) if course_dir else None
+    if manifest and manifest.get("shifu_bid") == shifu_bid:
+        local_course_rev = (manifest.get("course") or {}).get("revision")
+        cloud_meta = api_safe(base_url, token, "get",
+                              f"/shifus/{shifu_bid}/draft-meta") or {}
+        cloud_rev = cloud_meta.get("revision")
+        if (cloud_rev is not None and local_course_rev is not None
+                and cloud_rev > local_course_rev):
+            intended = {"tts_enabled": enabled}
+            _auto_pull_overwrite(base_url, token, shifu_bid, course_dir,
+                                 scope="meta", intended_meta=intended,
+                                 conflict_meta=cloud_meta)
+            sys.exit(EXIT_CONFLICT)
+
+    # Send only the TTS switch. Provider/model/voice/speed/pitch/emotion remain
+    # whatever the platform currently stores.
+    api(base_url, token, "post", f"/shifus/{shifu_bid}/detail",
+        json={"tts_enabled": enabled})
+    print(f"Set course {shifu_bid} TTS -> "
+          f"{'enabled' if enabled else 'disabled'}")
+
+    if manifest and manifest.get("shifu_bid") == shifu_bid:
+        fresh_detail = api_safe(base_url, token, "get",
+                                f"/shifus/{shifu_bid}/detail")
+        if isinstance(fresh_detail, dict):
+            _write_course_config(course_dir, _course_config_from_detail(fresh_detail))
+        else:
+            print("Warning: could not read updated course detail; "
+                  f"{COURSE_CONFIG_NAME} was left unchanged. Run "
+                  "`pull --course-dir <dir>` to resync.", file=sys.stderr)
+
+        fresh = api_safe(base_url, token, "get", f"/shifus/{shifu_bid}/draft-meta")
+        if not isinstance(fresh, dict) or fresh.get("revision") is None:
+            print("Warning: could not read the new course revision from the "
+                  "server; the sync manifest was left unchanged. Run "
+                  "`pull --course-dir <dir>` to resync.", file=sys.stderr)
+        else:
+            course = manifest.get("course")
+            if not isinstance(course, dict):
+                course = {}
+                manifest["course"] = course
+            course["revision"] = fresh.get("revision")
+            if fresh.get("updated_at") is not None:
+                course["updated_at"] = fresh.get("updated_at")
+            fresh_user = (fresh.get("updated_user") or {}).get("user_bid")
+            if fresh_user is not None:
+                course["updated_user_bid"] = fresh_user
+            manifest["last_push_at"] = _now_iso()
+            _write_sync(course_dir, manifest)
+
+
 # ── Add Chapter ────────────────────────────────────────────────────────────────
 def cmd_add_chapter(args):
     """Add a new top-level chapter to a course."""
@@ -2467,6 +2526,15 @@ def build_parser():
     p.add_argument("--course-dir", default=None,
                    help="Also reflect the change into local structure.json")
 
+    # ── set-tts ──
+    p = sub.add_parser("set-tts", parents=[parent_parser],
+                       help="Enable or disable course listening mode (TTS)")
+    p.add_argument("shifu_bid", help="Course BID")
+    p.add_argument("--enabled", required=True, choices=["true", "false"],
+                   help="true=enable listening mode, false=disable it")
+    p.add_argument("--course-dir", default=None,
+                   help=f"Also refresh local {COURSE_CONFIG_NAME} and sync manifest")
+
     # ── delete-lesson ──
     p = sub.add_parser("delete-lesson", parents=[parent_parser],
                        help="Delete a lesson")
@@ -2600,6 +2668,7 @@ def main():
         "update-lesson": cmd_update_lesson,
         "rename-lesson": cmd_rename_lesson,
         "set-access": cmd_set_access,
+        "set-tts": cmd_set_tts,
         "delete-lesson": cmd_delete_lesson,
         "reorder": cmd_reorder,
         "import": cmd_import,


### PR DESCRIPTION
## Summary
- add set-tts command to enable or disable course listening mode
- send only tts_enabled so other course attributes remain unchanged
- refresh course-config.json and sync metadata when --course-dir is supplied
- document set-tts in the AI-Shifu course creator skill references

## Tests
- python3 -m py_compile skills/ai-shifu-course-creator/scripts/shifu-cli.py
- python3 skills/ai-shifu-course-creator/scripts/shifu-cli.py --help
- python3 skills/ai-shifu-course-creator/scripts/shifu-cli.py set-tts --help
- python3 skills/ai-shifu-course-creator/scripts/shifu-cli.py set-tts dummy --enabled maybe
- python3 scripts/validate_skill_quality.py
- git diff --check
- rg -n "MDF" skills/ai-shifu-course-creator