### PR TITLE
feat: guide multi-select interaction generation

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -82,19 +82,21 @@ Keep author-side scaffolding out of Teaching Prompt and Course Prompt outputs:
 
 ## Teaching Prompt and Course Prompt Authoring Hard Rules (Must Follow)
 
-These are the five red-line rules every Teaching Prompt and Course Prompt must satisfy. Full Bad/Good examples and rationale live in the references files; the rule statements stay here so the model never misses them.
+These are the six red-line rules every Teaching Prompt and Course Prompt must satisfy. Full Bad/Good examples and rationale live in the references files; the rule statements stay here so the model never misses them.
 
 1. **Script style: directive, not manuscript.** Write in imperative, model-guiding language ("Ask the learner to …", "After collecting {{var}}, branch …"). Do not produce polished learner-facing prose or author/lesson-plan meta narration. See `references/pedagogy.md#script-style`.
 
 2. **Interaction syntax: prompt outside, options inside.** Keep the learner-facing question on the line **before** the interaction; put only option labels or a short `...` input placeholder inside `?[%{{var}} ...]`. Each `?[]` is on its own line. See `references/markdownflow.md#interactions` for full Bad/Good examples and the `...` input-marker rules.
 
-3. **Mandatory anchoring + downstream effect.** After every interaction, restate the learner's selection as an instruction (`Restate the learner's current choice as {{var}}.`) and use `{{var}}` to drive a visible downstream effect (branching explanation, examples, difficulty, feedback). See `references/pedagogy.md#interaction-design`.
+3. **Interaction type selection: match the learner decision.** Use single-select when options are mutually exclusive or when one selected path drives a branch. Use multi-select when collecting non-exclusive goals, interests, modules, blockers, applicable scenarios, existing experience, or desired practice areas. Multi-select results should drive combined feedback, prioritization, or tailored examples; do not avoid multi-select merely because it is harder to enumerate every possible combination. See `references/pedagogy.md#interaction-design`.
 
-4. **Visuals: two regimes — "no asset" vs "asset uploaded".**
+4. **Mandatory anchoring + downstream effect.** After every interaction, restate the learner's selection as an instruction (`Restate the learner's current choice as {{var}}.`) and use `{{var}}` to drive a visible downstream effect (branching explanation, examples, difficulty, feedback). See `references/pedagogy.md#interaction-design`.
+
+5. **Visuals: two regimes — "no asset" vs "asset uploaded".**
    - When the author has **not** provided any image asset (only the topic / a description): continue to use natural-language image instructions ("Show an image that …") paired with text explanation. Do not inline SVG/HTML/Mermaid/PlantUML/Graphviz markup. See `references/pedagogy.md#visual-text-coordination`.
    - When the author **has** provided image assets (local files or remote URLs): you must first upload them via `shifu-cli.py upload-image` to obtain `resource.ai-shifu.cn` URLs, then embed each image into the Teaching Prompt using one of the two forms defined in `references/markdownflow.md#images` (3.1 deterministic-wrapped standard markdown, or 3.2 instruction-style HTML view). See the sub-section **Working with Author-Provided Images** below for the full workflow including the path you must take when you cannot actually see the image contents.
 
-5. **Output language must be resolved before any prompt content.** Run Language Resolution per `references/data-contracts.md#language-resolution` before producing Teaching Prompt or Course Prompt content. The user's invocation language counts as `prompt_language_detection` (priority 4) and must be used when no higher-priority directive exists. Examples in this skill and in `references/` are written in English for canonical illustration only — do NOT let example language override the resolved output language. If the user invokes in Chinese, all interactions, option labels, downstream text, and the Course Prompt itself must be in Chinese.
+6. **Output language must be resolved before any prompt content.** Run Language Resolution per `references/data-contracts.md#language-resolution` before producing Teaching Prompt or Course Prompt content. The user's invocation language counts as `prompt_language_detection` (priority 4) and must be used when no higher-priority directive exists. Examples in this skill and in `references/` are written in English for canonical illustration only — do NOT let example language override the resolved output language. If the user invokes in Chinese, all interactions, option labels, downstream text, and the Course Prompt itself must be in Chinese.
 
 ## Step 0 — Resolve the Course Target (MANDATORY before any authoring)
 
@@ -277,6 +279,8 @@ Generate a runnable Teaching Prompt for each lesson.
 ### Teaching Pattern Baseline
 
 Apply the patterns and constraints in `references/pedagogy.md#teaching-patterns`, `#cognitive-techniques`, `#variable-strategy`, `#interaction-design`, and `#visual-text-coordination` unless content requires a justified variation.
+
+When generating interactions, explicitly choose the interaction type before writing the `?[]` line: mutually exclusive route decisions use single-select; non-exclusive learner context, interests, goals, blockers, modules, scenarios, experience, and practice needs use multi-select. If a lesson naturally asks "which of these apply?", default to multi-select unless the source or user says only one answer is allowed.
 
 ### Single-Lesson Generation Strategy
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -88,7 +88,7 @@ These are the six red-line rules every Teaching Prompt and Course Prompt must sa
 
 2. **Interaction syntax: prompt outside, options inside.** Keep the learner-facing question on the line **before** the interaction; put only option labels or a short `...` input placeholder inside `?[%{{var}} ...]`. Each `?[]` is on its own line. See `references/markdownflow.md#interactions` for full Bad/Good examples and the `...` input-marker rules.
 
-3. **Interaction type selection: match the learner decision.** Use single-select when options are mutually exclusive or when one selected path drives a branch. Use multi-select when collecting non-exclusive goals, interests, modules, blockers, applicable scenarios, existing experience, or desired practice areas. Multi-select results should drive combined feedback, prioritization, or tailored examples; do not avoid multi-select merely because it is harder to enumerate every possible combination. See `references/pedagogy.md#interaction-design`.
+3. **Interaction type selection: match the learner decision.** Use single-select when options are mutually exclusive or when one selected path drives a branch. Use multi-select when collecting non-exclusive learner context, goals, interests, modules, blockers, scenarios, experience, or practice needs. Multi-select results should drive combined feedback, prioritization, or tailored examples; do not avoid multi-select merely because it is harder to enumerate every possible combination. See `references/pedagogy.md#interaction-design`.
 
 4. **Mandatory anchoring + downstream effect.** After every interaction, restate the learner's selection as an instruction (`Restate the learner's current choice as {{var}}.`) and use `{{var}}` to drive a visible downstream effect (branching explanation, examples, difficulty, feedback). See `references/pedagogy.md#interaction-design`.
 
@@ -280,7 +280,7 @@ Generate a runnable Teaching Prompt for each lesson.
 
 Apply the patterns and constraints in `references/pedagogy.md#teaching-patterns`, `#cognitive-techniques`, `#variable-strategy`, `#interaction-design`, and `#visual-text-coordination` unless content requires a justified variation.
 
-When generating interactions, explicitly choose the interaction type before writing the `?[]` line: mutually exclusive route decisions use single-select; non-exclusive learner context, interests, goals, blockers, modules, scenarios, experience, and practice needs use multi-select. If a lesson naturally asks "which of these apply?", default to multi-select unless the source or user says only one answer is allowed.
+When generating interactions, explicitly choose the interaction type before writing the `?[]` line: mutually exclusive route decisions use single-select; non-exclusive learner context, goals, interests, modules, blockers, scenarios, experience, or practice needs use multi-select. If a lesson naturally asks "which of these apply?", default to multi-select unless the source or user says only one answer is allowed.
 
 ### Single-Lesson Generation Strategy
 

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -157,7 +157,7 @@ These are the *teaching* rules around interactions. For interaction *syntax* see
 - Choose the interaction type by the nature of the learner decision:
   - Use single-select for mutually exclusive categories, path choices, viewpoint checks, or any interaction where one selected answer should drive a distinct branch.
   - Use multi-select for non-exclusive learner context, goals, interests, modules, blockers, applicable scenarios, prior experience, or desired practice areas.
-  - When the learner prompt means "which of these apply?", prefer multi-select unless the source or user explicitly limits the learner to one answer.
+  - When the interaction prompt means "which of these apply?", prefer multi-select unless the source or user explicitly limits the learner to one answer.
   - For multi-select, drive downstream content through combined feedback, prioritization, tailored examples, or coverage of the selected items; do not require an exhaustive branch for every possible option combination.
 - Every interaction must trigger immediate feedback **and** a visible downstream effect (branching explanation, examples, practice difficulty, feedback).
 - After every interaction, restate the learner's selection explicitly as an instruction (e.g., `Restate the learner's current choice as {{var}}.`), not as polished narration.

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -156,7 +156,7 @@ These are the *teaching* rules around interactions. For interaction *syntax* see
 - Place interactions at decision points, not only at lesson start.
 - Choose the interaction type by the nature of the learner decision:
   - Use single-select for mutually exclusive categories, path choices, viewpoint checks, or any interaction where one selected answer should drive a distinct branch.
-  - Use multi-select for non-exclusive learner context, goals, interests, modules, blockers, applicable scenarios, prior experience, or desired practice areas.
+  - Use multi-select for non-exclusive learner context, goals, interests, modules, blockers, scenarios, experience, or practice needs.
   - When the interaction prompt means "which of these apply?", prefer multi-select unless the source or user explicitly limits the learner to one answer.
   - For multi-select, drive downstream content through combined feedback, prioritization, tailored examples, or coverage of the selected items; do not require an exhaustive branch for every possible option combination.
 - Every interaction must trigger immediate feedback **and** a visible downstream effect (branching explanation, examples, practice difficulty, feedback).

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -154,6 +154,11 @@ These are the *teaching* rules around interactions. For interaction *syntax* see
 - Each lesson includes at least one deepening interaction (calibration, boundary check, or misconception correction — see [Cognitive Techniques](#cognitive-techniques)).
 - Interaction prompts must be concrete and directly answerable.
 - Place interactions at decision points, not only at lesson start.
+- Choose the interaction type by the nature of the learner decision:
+  - Use single-select for mutually exclusive categories, path choices, viewpoint checks, or any interaction where one selected answer should drive a distinct branch.
+  - Use multi-select for non-exclusive learner context, goals, interests, modules, blockers, applicable scenarios, prior experience, or desired practice areas.
+  - When the learner prompt means "which of these apply?", prefer multi-select unless the source or user explicitly limits the learner to one answer.
+  - For multi-select, drive downstream content through combined feedback, prioritization, tailored examples, or coverage of the selected items; do not require an exhaustive branch for every possible option combination.
 - Every interaction must trigger immediate feedback **and** a visible downstream effect (branching explanation, examples, practice difficulty, feedback).
 - After every interaction, restate the learner's selection explicitly as an instruction (e.g., `Restate the learner's current choice as {{var}}.`), not as polished narration.
 - `*_viewpoint_check` interactions must branch by option and drive different next steps.

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -26,7 +26,7 @@ Optimization 全面审计清单 — Optimization Optimization 必须把每条都
 ## Interaction Quality
 
 - Interactions are concrete and answerable.
-- Interaction type matches the decision: single-select for mutually exclusive path choices, multi-select for non-exclusive goals, interests, modules, blockers, scenarios, experience, or practice needs.
+- Interaction type matches the decision: single-select for mutually exclusive path choices, multi-select for non-exclusive learner context, goals, interests, modules, blockers, scenarios, experience, or practice needs. For multi-select, downstream content is driven through combined feedback, prioritization, or tailored examples rather than exhaustive branching for every combination.
 - Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[%{{var}} ...]`.
 - Each `?[]` interaction appears on its own line.
 - If the pre-interaction text enumerates or describes choices, the `?[]` option labels match those choices exactly — same set, order, and wording.

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -26,6 +26,7 @@ Optimization 全面审计清单 — Optimization Optimization 必须把每条都
 ## Interaction Quality
 
 - Interactions are concrete and answerable.
+- Interaction type matches the decision: single-select for mutually exclusive path choices, multi-select for non-exclusive goals, interests, modules, blockers, scenarios, experience, or practice needs.
 - Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[%{{var}} ...]`.
 - Each `?[]` interaction appears on its own line.
 - If the pre-interaction text enumerates or describes choices, the `?[]` option labels match those choices exactly — same set, order, and wording.


### PR DESCRIPTION
## Summary
- Add an authoring hard rule for choosing single-select vs multi-select interactions.
- Teach generation to default to multi-select for non-exclusive learner context, goals, blockers, modules, scenarios, and practice needs.
- Add pedagogy and review-checklist coverage so optimization can catch mismatched interaction types.

## Validation
- git diff --check
- reviewed PR diff to confirm only the intended three skill docs changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated course creation guidelines to improve interaction type selection between single-select and multi-select options.
  * Enhanced pedagogical guidance with clearer recommendations for when to use each interaction type and how to structure feedback.
  * Strengthened validation checklist to ensure interaction types correctly match course decision points and learning objectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->