### PR TITLE
docs: add bilingual skill display names

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -4,5 +4,5 @@ Total skills: **2**
 
 | Skill | One-liner | Category | Maturity |
 |---|---|---|---|
-| [ai-shifu-course-creator](./skills/ai-shifu-course-creator/SKILL.md) | Convert raw course material into optimized MarkdownFlow teaching scripts, deploy as live AI-Shifu courses, and query post-deployment analytics (progress, orders, costs, audiences). | course-authoring | beta |
-| [course-direction-advisor](./skills/course-direction-advisor/SKILL.md) | Advise on market-fit course directions from source materials with competitor analysis and GO/HOLD/REWORK/NO-GO decisions. | content-preprocessing | beta |
+| [AI-Shifu Course Creator（AI 师傅课程创作器）](./skills/ai-shifu-course-creator/SKILL.md) | Convert raw course material into optimized MarkdownFlow teaching scripts, deploy as live AI-Shifu courses, and query post-deployment analytics (progress, orders, costs, audiences). | course-authoring | beta |
+| [Course Direction Advisor（课程选题顾问）](./skills/course-direction-advisor/SKILL.md) | Advise on market-fit course directions from source materials with competitor analysis and GO/HOLD/REWORK/NO-GO decisions. | content-preprocessing | beta |

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Reusable AI-Shifu skills for course production, from topic selection to deployme
 
 ## Included Skills
 
-- `ai-shifu-course-creator`: convert raw course material into optimized MarkdownFlow teaching scripts and deploy them as live AI-Shifu courses through a five-phase pipeline (segmentation, orchestration, generation, optimization, deployment).
-- `course-direction-advisor`: turn source materials into evidence-bound, market-fit course-topic decisions with competitor analysis, pricing guidance, and GO/HOLD/REWORK/NO-GO recommendations.
+- **AI-Shifu Course Creator（AI 师傅课程创作器）**: convert raw course material into optimized MarkdownFlow teaching scripts and deploy them as live AI-Shifu courses through a five-phase pipeline (segmentation, orchestration, generation, optimization, deployment).
+- **Course Direction Advisor（课程选题顾问）**: turn source materials into evidence-bound, market-fit course-topic decisions with competitor analysis, pricing guidance, and GO/HOLD/REWORK/NO-GO recommendations.
 
-The course-creator skill includes runnable examples under `skills/ai-shifu-course-creator/examples/`.
+The AI-Shifu Course Creator（AI 师傅课程创作器） skill includes runnable examples under `skills/ai-shifu-course-creator/examples/`.
 
 ## Repository Layout
 
@@ -21,8 +21,8 @@ skills/
 
 ## Usage
 
-The skill keeps `SKILL.md` as the behavior source of truth.
-Core skill metadata lives in `skills/ai-shifu-course-creator/skill.yaml`.
+Each skill keeps `SKILL.md` as the behavior source of truth.
+The directory name is the stable machine slug; the `name` frontmatter field is the human-readable display name.
 
 ## Course Authoring & Deployment Paths
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,10 +6,10 @@
 
 ## 包含的 Skills
 
-- `ai-shifu-course-creator`：通过五阶段流水线（分段、编排、生成、优化、部署）将原始课程素材转换为优化后的可运行 MarkdownFlow 授课脚本，并部署为 AI 师傅平台上的在线课程。
-- `course-direction-advisor`：将素材转化为基于证据的、市场适配的课程选题决策，包含竞品分析、定价建议和 GO/HOLD/REWORK/NO-GO 推荐。
+- **AI-Shifu Course Creator（AI 师傅课程创作器）**：通过五阶段流水线（分段、编排、生成、优化、部署）将原始课程素材转换为优化后的可运行 MarkdownFlow 授课脚本，并部署为 AI 师傅平台上的在线课程。
+- **Course Direction Advisor（课程选题顾问）**：将素材转化为基于证据的、市场适配的课程选题决策，包含竞品分析、定价建议和 GO/HOLD/REWORK/NO-GO 推荐。
 
-course-creator skill 有可运行示例，位于 `skills/ai-shifu-course-creator/examples/`。
+AI-Shifu Course Creator（AI 师傅课程创作器） skill 有可运行示例，位于 `skills/ai-shifu-course-creator/examples/`。
 
 ## 仓库结构
 
@@ -22,7 +22,7 @@ skills/
 ## 使用说明
 
 skill 以 `SKILL.md` 作为行为定义。
-机器可读元数据位于 `skills/ai-shifu-course-creator/skill.yaml`。
+目录名是稳定的机器 slug；`name` frontmatter 字段是面向人的展示名。
 
 ## 课程生产与部署路径
 

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 RE_KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+RE_HUMAN_READABLE_NAME = re.compile(r"^\S[^\r\n<>]*$")
 RE_XML_TAG = re.compile(r"[<>]")
 RE_REF_PATH = re.compile(r"references/[A-Za-z0-9_./-]+\.md")
 FORBIDDEN_WORDS = {"claude", "anthropic"}
@@ -103,14 +104,15 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
     if not name:
         issues.add_error(f"{skill_md}: frontmatter 'name' field is required")
     else:
-        if not RE_KEBAB_CASE.match(name):
+        if RE_KEBAB_CASE.match(name):
             issues.add_error(
-                f"{skill_md}: frontmatter 'name' must be kebab-case, got '{name}'"
+                f"{skill_md}: frontmatter 'name' must be human-readable, "
+                f"got slug-like value '{name}'"
             )
-        if name != slug:
+        elif not RE_HUMAN_READABLE_NAME.match(name):
             issues.add_error(
-                f"{skill_md}: frontmatter 'name' ({name}) must match "
-                f"folder name ({slug})"
+                f"{skill_md}: frontmatter 'name' contains unsupported display "
+                f"name characters, got '{name}'"
             )
         name_lower = name.lower()
         for word in FORBIDDEN_WORDS:

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -104,10 +104,10 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
     if not name:
         issues.add_error(f"{skill_md}: frontmatter 'name' field is required")
     else:
-        if RE_KEBAB_CASE.match(name):
+        if name == slug:
             issues.add_error(
-                f"{skill_md}: frontmatter 'name' must be human-readable, "
-                f"got slug-like value '{name}'"
+                f"{skill_md}: frontmatter 'name' must be a human-readable "
+                f"display name, but it matches the folder slug '{name}'"
             )
         elif not RE_HUMAN_READABLE_NAME.match(name):
             issues.add_error(

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ai-shifu-course-creator
+name: AI-Shifu Course Creator（AI 师傅课程创作器）
 description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing Teaching Prompts (per-lesson) and Course Prompts (course-level) — both written in MarkdownFlow (MDF). Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Also covers post-deployment analytics on those courses — learner count, completion rate, stuck lessons, orders, revenue, ratings, credit consumption, audience profiles, and individual learner tracking. Trigger on any mention of AI-Shifu, AI师傅, MarkdownFlow, Teaching Prompt, Course Prompt authoring, course analytics, creator analytics, 学习人数, 完成率, 卡课节, 订单收入, 积分消耗, or learner progress.
 ---
 

--- a/skills/course-direction-advisor/SKILL.md
+++ b/skills/course-direction-advisor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: course-direction-advisor
+name: Course Direction Advisor（课程选题顾问）
 description: Turn user-provided source materials into market-fit course-topic decisions without exceeding the evidence boundary of the materials. Use when the user needs course topic selection, competitor analysis, pricing guidance, audience targeting, market positioning, or a decision on whether the material is strong and complete enough to support a course. Avoid when the topic is already fixed and the user only needs lesson breakdowns, scripts, or copy polishing.
 metadata:
   short-description: Select and validate market-fit course topics from source materials

--- a/templates/skill.yaml.template
+++ b/templates/skill.yaml.template
@@ -1,5 +1,5 @@
 schema_version: "1.0"
-name: "skill-name"
+name: "Human-Readable Skill Name（中文展示名）"
 slug: "skill-slug"
 one_liner: "One-sentence value proposition."
 description: "Longer description for indexing and search."


### PR DESCRIPTION
## Summary

- Add bilingual human-readable display names for both skills.
- Update the skill index, English and Chinese READMEs, and the skill template to use display names instead of raw slugs.
- Update metadata validation so `name` is treated as a human-readable display field while folder names remain stable machine slugs.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `git diff --check`
