### PR TITLE
feat: add SEO course description sync

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -545,7 +545,7 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
-1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`), a `course-description.md` SEO summary, a `course-prompt.md`, and `structure.json`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`. If `structure.json` is missing, create it before running `build`. Existing directories without `course-description.md` still build, but the platform description will be empty unless `--description` or `--description-file` is provided.
+1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`), a `course-description.md` SEO summary, a `course-prompt.md`, and `structure.json`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`. If `structure.json` is missing, create it before running `build`. Existing directories without `course-description.md` still build, but the platform description will be empty unless `--description` is provided.
 2. Run `build` → `import` (deploy) → `publish` as above.
 
 ### Version Sync Workflow

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -262,12 +262,12 @@ Run the full pipeline from raw material to a live deployed course.
 
 0. **Step 0 front guard (first, always)** — resolve new-vs-edit via `login` + `find-title`; if editing an existing course, `pull` it before authoring. See **## Step 0**.
 1. **Orchestration** drives Segmentation and Generation end-to-end, then runs cross-lesson gating to produce Teaching Prompts + course_index + variable table.
-2. **Optimization** audits and improves Orchestration's output, plus produces the Course Prompt.
+2. **Optimization** audits and improves Orchestration's output, plus produces the Course Prompt and SEO course description.
 3. **Deployment** writes the course directory, builds, imports, and publishes to the AI-Shifu platform.
 
 ### Path B: Author Only
 
-Run Segmentation through Optimization to produce optimized Teaching Prompts and a Course Prompt without deploying. Sub-paths:
+Run Segmentation through Optimization to produce optimized Teaching Prompts, a Course Prompt, and an SEO course description without deploying. Sub-paths:
 - **Segment only**: Segmentation alone for structured segments and manual review.
 - **Generate only**: Generation alone on pre-existing segments to produce Teaching Prompts.
 - **Optimize only**: Optimization alone to audit and improve existing Teaching Prompts.
@@ -538,14 +538,14 @@ All commands documented in `references/cli/cli-reference.md` (deployment: `build
 ### Deployment Workflow
 
 **From pipeline (Path A continuation):**
-1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), and required `structure.json`.
+1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-description.md` (the generated SEO description, based on the course topic, target learners, and learning outcomes; no author-side process notes), `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `references/course-prompt.md#fillable-template`), and required `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
 3. **Deploy**: Run `import --new --json-file <dir>/shifu-import.json` to upload the course onto the platform.
 4. **Publish**: Run `publish <shifu_bid>` to push the course to its public student-facing URL.
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
-1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`), a `course-prompt.md`, and `structure.json`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`. If `structure.json` is missing, create it before running `build`.
+1. Ensure course directory is ready with Teaching Prompt files (one MarkdownFlow file per lesson under `lessons/`), a `course-description.md` SEO summary, a `course-prompt.md`, and `structure.json`. If the Course Prompt is not yet authored, follow `references/course-prompt.md#fillable-template` (and `references/course-prompt.md#authoring-rules` for guidance) before running `build`. If `structure.json` is missing, create it before running `build`. Existing directories without `course-description.md` still build, but the platform description will be empty unless `--description` or `--description-file` is provided.
 2. Run `build` → `import` (deploy) → `publish` as above.
 
 ### Version Sync Workflow
@@ -563,9 +563,10 @@ Once the target is a download of an existing course, treat the platform draft as
 the source of truth:
 
 1. **`pull <shifu_bid> --course-dir <dir>`** — download the cloud draft into the
-   local dir (writes `README.md` / `course-prompt.md` / `lessons/lesson-NN.md` /
-   `structure.json` and records each lesson + course `revision` into `.shifu-sync.json`).
-2. **Edit locally** — change the lesson files / course prompt in place.
+   local dir (writes `README.md` / `course-description.md` / `course-prompt.md` /
+   `lessons/lesson-NN.md` / `structure.json` and records each lesson + course
+   `revision` into `.shifu-sync.json`).
+2. **Edit locally** — change the lesson files / course description / course prompt in place.
 3. **`status --course-dir <dir>`** — see what diverged: `behind` (cloud changed,
    pull again), `locally modified` (your pending edits), `new`/`deleted` on server.
 4. **Push** with `--course-dir` so the recorded baseline is used:

--- a/skills/ai-shifu-course-creator/examples/deploy-only.md
+++ b/skills/ai-shifu-course-creator/examples/deploy-only.md
@@ -11,6 +11,7 @@ A course directory with Teaching Prompts (one MarkdownFlow file per lesson) alre
 ```
 my-course/
   README.md
+  course-description.md
   course-prompt.md
   lessons/
     lesson-01.md

--- a/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
+++ b/skills/ai-shifu-course-creator/examples/end-to-end-deploy.md
@@ -33,6 +33,7 @@ Produces optimized Teaching Prompts (see `pipeline-full.md` for detailed output)
 ```
 my-course/
   README.md
+  course-description.md
   course-prompt.md
   structure.json
   lessons/
@@ -42,6 +43,8 @@ my-course/
 ```
 
 ### Step 2: Build Import File
+
+`course-description.md` contains the generated SEO/listing description for the course.
 
 ```bash
 python3 {skillDir}/scripts/shifu-cli.py build --course-dir ./my-course/ --title "Metric Drift Diagnosis"

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -135,7 +135,8 @@ status --course-dir ./course-a/ [--exit-code]         # Compare local vs cloud r
 
 - `pull` fetches the course detail, outline tree, every lesson's MarkdownFlow,
   and the course-level draft revision, writes them into the course directory
-  (`README.md`, `course-prompt.md`, `lessons/lesson-NN.md`, `structure.json`),
+  (`README.md`, `course-description.md`, `course-prompt.md`,
+  `lessons/lesson-NN.md`, `structure.json`),
   and records the cloud `revision` of each lesson + the course in
   `<course-dir>/.shifu-sync.json`. Any local file that diverges from the
   incoming cloud content is backed up to `<file>.local-<ts>.bak` first (unless
@@ -167,7 +168,7 @@ add-lesson <shifu_bid> --name "Name" --teaching-prompt-file lesson.md --parent-b
 ## Update Commands
 
 ```bash
-update-meta <shifu_bid> [--name "..."] [--description "..."] [--course-prompt-file prompt.md] [--course-dir ./course-a/]
+update-meta <shifu_bid> [--name "..."] [--description "..." | --description-file desc.md] [--course-prompt-file prompt.md] [--course-dir ./course-a/]
 update-lesson <shifu_bid> <outline_bid> --teaching-prompt-file lesson.md [--course-dir ./course-a/]
 rename-lesson <shifu_bid> <outline_bid> --name "New Name"
 reorder <shifu_bid> --order bid1,bid2,bid3
@@ -176,10 +177,12 @@ set-tts <shifu_bid> --enabled true|false [--course-dir ./course-a/]
 ```
 
 `update-meta` sends only the content fields you pass (`--name` / `--description`
-/ `--course-prompt-file`); it does **not** touch course attributes (model / price
-/ TTS / Ask / …) — the backend preserves any field left out. `rename-lesson`
-likewise changes only the name and no longer resets the lesson's learning
-permission.
+/ `--description-file` / `--course-prompt-file`); it does **not** touch course
+attributes (model / price / TTS / Ask / …) — the backend preserves any field
+left out. When `--course-dir` is supplied, a successful description update also
+writes `course-description.md` and records the new course metadata baseline in
+`.shifu-sync.json`. `rename-lesson` likewise changes only the name and no longer
+resets the lesson's learning permission.
 
 `set-access` sets one lesson's **learning permission** (`guest` = 无需登录 /
 `trial` = 试看·需登录 / `normal` = 需付费) without re-importing; it sends only
@@ -227,14 +230,14 @@ import <shifu_bid> --json-file course.json
 import --new --json-file course.json
 
 # One-step build + import from course directory
-import <shifu_bid> --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
-import --new --course-dir ./course-a/ [--title "..."] [--chapter-name "..."]
+import <shifu_bid> --course-dir ./course-a/ [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
+import --new --course-dir ./course-a/ [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
 
 # Local build only (offline, generates shifu-import.json)
-build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--chapter-name "..."]
+build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
 ```
 
-The `build` command works entirely offline — it reads the course directory's Teaching Prompts (one MarkdownFlow file per lesson under `lessons/`) and the Course Prompt, then produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step.
+The `build` command works entirely offline — it reads the course directory's Teaching Prompts (one MarkdownFlow file per lesson under `lessons/`), the Course Prompt, and the SEO course description, then produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step. Description resolution order is `--description` -> `--description-file` -> `<course-dir>/course-description.md` -> empty string. `--description` and `--description-file` are mutually exclusive.
 
 **Course attributes are not pushed by default.** The skill manages course
 *content*; *attributes* (each lesson's learning permission / hidden state, and
@@ -242,7 +245,8 @@ course-level model/price/TTS/Ask/…) are left to the platform. `build`/`import`
 send only content (lesson MarkdownFlow + course name/description/system prompt),
 and the backend uses **PATCH semantics** — any field a write omits is preserved.
 So `update-lesson` (content only) and `update-meta` (only the `--name` /
-`--description` / `--course-prompt-file` you pass) never touch attributes.
+`--description` / `--description-file` / `--course-prompt-file` you pass) never
+touch attributes.
 
 `pull` still writes the attributes into `structure.json` (`access`/`hidden`) and
 `course-config.json` as a **read-only reference** for the agent. To change an
@@ -272,6 +276,7 @@ re-run). After a successful import the manifest is re-seeded via an automatic
 Build behavior:
 
 - **Course title** resolution order: `--title` CLI arg -> first heading in `README.md` -> directory name
+- **Course description** resolution order: `--description` CLI arg -> `--description-file` -> `course-description.md` -> empty string
 - **Chapter structure**: if `structure.json` exists, generates multi-chapter structure per its definition; otherwise creates a single chapter (named via `--chapter-name` or defaults to course title) containing all `lesson-*.md` files in sorted order
 - **Lesson title** resolution order: `title` field in `structure.json` -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -168,7 +168,7 @@ add-lesson <shifu_bid> --name "Name" --teaching-prompt-file lesson.md --parent-b
 ## Update Commands
 
 ```bash
-update-meta <shifu_bid> [--name "..."] [--description "..." | --description-file desc.md] [--course-prompt-file prompt.md] [--course-dir ./course-a/]
+update-meta <shifu_bid> [--name "..."] [--description "..."] [--course-prompt-file prompt.md] [--course-dir ./course-a/]
 update-lesson <shifu_bid> <outline_bid> --teaching-prompt-file lesson.md [--course-dir ./course-a/]
 rename-lesson <shifu_bid> <outline_bid> --name "New Name"
 reorder <shifu_bid> --order bid1,bid2,bid3
@@ -177,7 +177,7 @@ set-tts <shifu_bid> --enabled true|false [--course-dir ./course-a/]
 ```
 
 `update-meta` sends only the content fields you pass (`--name` / `--description`
-/ `--description-file` / `--course-prompt-file`); it does **not** touch course
+/ `--course-prompt-file`); it does **not** touch course
 attributes (model / price / TTS / Ask / …) — the backend preserves any field
 left out. When `--course-dir` is supplied, a successful description update also
 writes `course-description.md` and records the new course metadata baseline in
@@ -230,14 +230,14 @@ import <shifu_bid> --json-file course.json
 import --new --json-file course.json
 
 # One-step build + import from course directory
-import <shifu_bid> --course-dir ./course-a/ [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
-import --new --course-dir ./course-a/ [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
+import <shifu_bid> --course-dir ./course-a/ [--title "..."] [--description "..."] [--chapter-name "..."]
+import --new --course-dir ./course-a/ [--title "..."] [--description "..."] [--chapter-name "..."]
 
 # Local build only (offline, generates shifu-import.json)
-build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--description "..." | --description-file desc.md] [--chapter-name "..."]
+build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--description "..."] [--chapter-name "..."]
 ```
 
-The `build` command works entirely offline — it reads the course directory's Teaching Prompts (one MarkdownFlow file per lesson under `lessons/`), the Course Prompt, and the SEO course description, then produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step. Description resolution order is `--description` -> `--description-file` -> `<course-dir>/course-description.md` -> empty string. `--description` and `--description-file` are mutually exclusive.
+The `build` command works entirely offline — it reads the course directory's Teaching Prompts (one MarkdownFlow file per lesson under `lessons/`), the Course Prompt, and the SEO course description, then produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step. Description resolution order is `--description` -> `<course-dir>/course-description.md` -> empty string.
 
 **Course attributes are not pushed by default.** The skill manages course
 *content*; *attributes* (each lesson's learning permission / hidden state, and
@@ -245,7 +245,7 @@ course-level model/price/TTS/Ask/…) are left to the platform. `build`/`import`
 send only content (lesson MarkdownFlow + course name/description/system prompt),
 and the backend uses **PATCH semantics** — any field a write omits is preserved.
 So `update-lesson` (content only) and `update-meta` (only the `--name` /
-`--description` / `--description-file` / `--course-prompt-file` you pass) never
+`--description` / `--course-prompt-file` you pass) never
 touch attributes.
 
 `pull` still writes the attributes into `structure.json` (`access`/`hidden`) and
@@ -276,7 +276,7 @@ re-run). After a successful import the manifest is re-seeded via an automatic
 Build behavior:
 
 - **Course title** resolution order: `--title` CLI arg -> first heading in `README.md` -> directory name
-- **Course description** resolution order: `--description` CLI arg -> `--description-file` -> `course-description.md` -> empty string
+- **Course description** resolution order: `--description` CLI arg -> `course-description.md` -> empty string
 - **Chapter structure**: if `structure.json` exists, generates multi-chapter structure per its definition; otherwise creates a single chapter (named via `--chapter-name` or defaults to course title) containing all `lesson-*.md` files in sorted order
 - **Lesson title** resolution order: `title` field in `structure.json` -> filename derived (e.g., `lesson-01.md` -> "Lesson 01")
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -177,9 +177,10 @@ set-tts <shifu_bid> --enabled true|false [--course-dir ./course-a/]
 ```
 
 `update-meta` sends only the content fields you pass (`--name` / `--description`
-/ `--course-prompt-file`); it does **not** touch course
+/ `--course-prompt-file`), plus a locally modified `course-description.md` when
+`--course-dir` is supplied; it does **not** touch course
 attributes (model / price / TTS / Ask / …) — the backend preserves any field
-left out. When `--course-dir` is supplied, a successful description update also
+left out. When `--course-dir` is supplied, a successful description update
 writes `course-description.md` and records the new course metadata baseline in
 `.shifu-sync.json`. `rename-lesson` likewise changes only the name and no longer
 resets the lesson's learning permission.
@@ -245,7 +246,8 @@ course-level model/price/TTS/Ask/…) are left to the platform. `build`/`import`
 send only content (lesson MarkdownFlow + course name/description/system prompt),
 and the backend uses **PATCH semantics** — any field a write omits is preserved.
 So `update-lesson` (content only) and `update-meta` (only the `--name` /
-`--description` / `--course-prompt-file` you pass) never
+`--description` / `--course-prompt-file` you pass, plus a locally modified
+`course-description.md` with `--course-dir`) never
 touch attributes.
 
 `pull` still writes the attributes into `structure.json` (`access`/`hidden`) and

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -114,8 +114,9 @@ The `build` and `import --course-dir` commands map this file to
 Old course directories without `course-description.md` remain valid; they build
 with an empty platform description unless an explicit description flag is used.
 `pull` writes the current cloud description back to this file, and
-`update-meta --description --course-dir` refreshes it after a successful
-platform update.
+`update-meta --course-dir` pushes this file when it has a local content change;
+`update-meta --description --course-dir` also refreshes the file after a
+successful platform update.
 
 ## course-prompt.md
 

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -5,6 +5,7 @@
 ```
 <course>/
   README.md            # Course metadata (title from first heading)
+  course-description.md # SEO/listing description mapped to the platform description field
   course-prompt.md     # Course-level prompt (AI role and teaching style)
   course-config.json   # Course-level attributes (model/price/TTS/Ask/…) — round-tripped so import doesn't reset them
   shifu-import.json    # Generated import file (output of build)
@@ -73,7 +74,7 @@ Schema (abridged):
   "schema_version": 1,
   "shifu_bid": "a1b2c3…",
   "base_url": "https://app.ai-shifu.cn",
-  "course": {"revision": 42, "name": "…", "updated_at": "…", "updated_user_bid": "…"},
+  "course": {"revision": 42, "name": "…", "description": "…", "updated_at": "…", "updated_user_bid": "…"},
   "lessons": [
     {"file": "lessons/lesson-01.md", "outline_bid": "9a8b…", "name": "…",
      "parent_bid": "ch_001", "revision": 1187, "is_chapter": false,
@@ -94,6 +95,28 @@ edited since the last sync. See
 ## Lesson Files
 
 When `structure.json` is not present, `build` auto-discovers only `lesson-*.md` files (e.g., `lesson-01.md`, `lesson-02.md`) and ignores other filenames. When `structure.json` is present, lesson files are taken from `chapters[].lessons[].file` and any filename is accepted as long as it exists.
+
+## course-description.md
+
+Contains the learner-facing SEO/listing description for the course. Path A and
+Author Only outputs must generate this file from the course topic, target
+learners, and concrete learning outcomes; do not include author-side workflow
+notes.
+
+The `build` and `import --course-dir` commands map this file to
+`shifu.description` in `shifu-import.json`, which the CLI sends to the platform
+`description` field. Resolution order is:
+
+1. `--description`
+2. `--description-file`
+3. `<course-dir>/course-description.md`
+4. empty string
+
+Old course directories without `course-description.md` remain valid; they build
+with an empty platform description unless an explicit description flag is used.
+`pull` writes the current cloud description back to this file, and
+`update-meta --description` / `--description-file --course-dir` refreshes it
+after a successful platform update.
 
 ## course-prompt.md
 
@@ -139,7 +162,8 @@ Ask / keywords / …), written by `pull` so the agent can see the current settin
 **`build`/`import` do NOT send it.** The skill does not push course attributes by
 default — the backend preserves any attribute a write leaves out, so iterating
 content never resets model/price/TTS/Ask. The course **name** lives in
-`README.md` and the **system prompt** in `course-prompt.md`.
+`README.md`, the SEO **description** in `course-description.md`, and the
+**system prompt** in `course-prompt.md`.
 
 The exception is an explicit listening-mode update: `set-tts --course-dir`
 refreshes this snapshot after changing `tts_enabled`. It still does not make

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -108,15 +108,14 @@ The `build` and `import --course-dir` commands map this file to
 `description` field. Resolution order is:
 
 1. `--description`
-2. `--description-file`
-3. `<course-dir>/course-description.md`
-4. empty string
+2. `<course-dir>/course-description.md`
+3. empty string
 
 Old course directories without `course-description.md` remain valid; they build
 with an empty platform description unless an explicit description flag is used.
 `pull` writes the current cloud description back to this file, and
-`update-meta --description` / `--description-file --course-dir` refreshes it
-after a successful platform update.
+`update-meta --description --course-dir` refreshes it after a successful
+platform update.
 
 ## course-prompt.md
 

--- a/skills/ai-shifu-course-creator/references/cli/import-json-format.md
+++ b/skills/ai-shifu-course-creator/references/cli/import-json-format.md
@@ -35,6 +35,7 @@ The `build` command generates a `shifu-import.json` file that can be imported to
 ## Key Fields
 
 - `course_prompt`: Course-level AI role definition (from `course-prompt.md`). The CLI maps this to the platform API field `system_prompt` when calling `/shifus/<bid>/detail`.
+- `description`: Learner-facing SEO/listing description. For course-directory builds, the CLI resolves it from `--description`, then `--description-file`, then `course-description.md`, then empty string.
 - `type: 401`: Regular lesson node
 - `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MarkdownFlow content). Use `add-chapter` to create chapters, then pass the chapter BID as `--parent-bid` when creating lessons
 - `content`: The MarkdownFlow prompt content (this is the core teaching material)

--- a/skills/ai-shifu-course-creator/references/cli/import-json-format.md
+++ b/skills/ai-shifu-course-creator/references/cli/import-json-format.md
@@ -35,7 +35,7 @@ The `build` command generates a `shifu-import.json` file that can be imported to
 ## Key Fields
 
 - `course_prompt`: Course-level AI role definition (from `course-prompt.md`). The CLI maps this to the platform API field `system_prompt` when calling `/shifus/<bid>/detail`.
-- `description`: Learner-facing SEO/listing description. For course-directory builds, the CLI resolves it from `--description`, then `--description-file`, then `course-description.md`, then empty string.
+- `description`: Learner-facing SEO/listing description. For course-directory builds, the CLI resolves it from `--description`, then `course-description.md`, then empty string.
 - `type: 401`: Regular lesson node
 - `parent_bid`: Empty string = chapter (top-level container); non-empty = lesson (child node with MarkdownFlow content). Use `add-chapter` to create chapters, then pass the chapter BID as `--parent-bid` when creating lessons
 - `content`: The MarkdownFlow prompt content (this is the core teaching material)

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -86,6 +86,7 @@ Provide one of:
 2. `course_index` — `lesson_id`, `lesson_title`, `core_question`, `source_span_map`.
 3. `global_variable_table` — see [Variable Table](#variable-table).
 4. `course_prompt` — markdown string (runnable AI-Shifu course-level system prompt) following [course-prompt.md](course-prompt.md). Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`. Conditional section: `# Translation Rules`.
+5. `course_description` — SEO/listing description written to `course-description.md`; describe the course topic, target learners, and learning outcomes in learner-facing language. Do not include author-side workflow notes.
 
 ### `course_index` Schema (array, required)
 
@@ -101,6 +102,12 @@ Each item:
 - Six required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`.
 - Conditional `# Translation Rules` section per [course-prompt.md](course-prompt.md) `## Conditional Sections`.
 - Single source of truth at the course level; do not embed per-lesson interaction logic.
+
+### `course_description` (string, required)
+
+- One concise learner-facing SEO/listing description.
+- Base it on the course topic, target learners, and concrete learning outcomes.
+- Write it to `course-description.md`; the CLI maps it to the platform `description` field during build/import.
 
 ### Minimal Output Example
 
@@ -131,14 +138,15 @@ Each item:
       "effect_scope": "cross_lesson"
     }
   ],
-  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Drawing\n- ..."
+  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Drawing\n- ...",
+  "course_description": "A practical course that helps beginner operators diagnose metric drift, identify likely causes, and choose one concrete fix."
 }
 ```
 
 ### Artifacts
 
-5. `deployed_course_url` — Platform URL of the deployed course.
-6. `shifu_bid` — Course BID on the AI-Shifu platform.
+6. `deployed_course_url` — Platform URL of the deployed course.
+7. `shifu_bid` — Course BID on the AI-Shifu platform.
 
 #### `deployment_result` (object, optional)
 
@@ -226,7 +234,7 @@ Resolve target language with this strict priority:
 - Learner-facing script text must follow resolved target language unless `bilingual_output` is true.
 - User-visible agent output must follow the resolved target language: chat replies, phase summaries, reports, headings, artifact labels, review notes, handoff instructions, and error explanations.
 - Human-facing labels for skill concepts must be localized in the resolved target language. For Chinese, use “授课提示词” for “Teaching Prompt” and “课程提示词” for “Course Prompt” in user-visible prose and headings.
-- Stable machine-facing identifiers and verbatim source material remain unchanged even when the surrounding prose is localized: JSON keys (`course_index`, `global_variable_table`, `lesson_id`, `lesson_title`, `lesson_teaching_prompts`, `teaching_prompt`, `course_prompt`), file names (`course-prompt.md`, `structure.json`), CLI commands and flags, API fields, code symbols, MarkdownFlow syntax, URLs, code samples, and quoted source text or direct quotations that must be preserved verbatim.
+- Stable machine-facing identifiers and verbatim source material remain unchanged even when the surrounding prose is localized: JSON keys (`course_index`, `global_variable_table`, `lesson_id`, `lesson_title`, `lesson_teaching_prompts`, `teaching_prompt`, `course_prompt`, `course_description`), file names (`course-description.md`, `course-prompt.md`, `structure.json`), CLI commands and flags, API fields, code symbols, MarkdownFlow syntax, URLs, code samples, and quoted source text or direct quotations that must be preserved verbatim.
 
 ## Fallback Output Extensions
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1088,7 +1088,8 @@ def cmd_status(args):
             local_description = desc_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             local_description = None
-        if local_description is None or local_description != manifest_description:
+        if (local_description is None
+                or local_description.strip() != manifest_description.strip()):
             course_locally_modified.append(COURSE_DESCRIPTION_NAME)
     elif manifest_description:
         course_locally_modified.append(COURSE_DESCRIPTION_NAME)
@@ -1338,13 +1339,20 @@ def cmd_update_meta(args):
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
     course_dir = getattr(args, "course_dir", None)
+    manifest = _load_sync(course_dir) if course_dir else None
     description = None
     if args.description is not None:
         description = _resolve_course_description(
+            course_dir=course_dir,
             description=args.description,
         )
+    elif course_dir and (Path(course_dir) / COURSE_DESCRIPTION_NAME).exists():
+        local_description = _resolve_course_description(course_dir=course_dir)
+        manifest_description = ((manifest or {}).get("course") or {}).get(
+            "description", "")
+        if manifest is None or local_description != manifest_description.strip():
+            description = local_description
 
-    manifest = _load_sync(course_dir) if course_dir else None
     intended = {"name": args.name, "description": description,
                 "course_prompt_file": args.course_prompt_file}
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -788,7 +788,7 @@ def _write_course_config(course_dir, cfg):
 def _read_text_file(path, *, label):
     try:
         return Path(path).read_text(encoding="utf-8").strip()
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         print(f"Error: cannot read {label}: {e}")
         sys.exit(1)
 
@@ -815,8 +815,7 @@ def _write_course_description(course_dir, description):
     path = Path(course_dir) / COURSE_DESCRIPTION_NAME
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
-    text = (description or "").strip()
-    tmp.write_text((text + "\n") if text else "", encoding="utf-8")
+    tmp.write_text(description or "", encoding="utf-8")
     tmp.replace(path)
 
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -735,6 +735,7 @@ def cmd_export(args):
 
 
 # ── Course Attributes (round-trip via structure.json + course-config.json) ──────
+COURSE_DESCRIPTION_NAME = "course-description.md"
 COURSE_CONFIG_NAME = "course-config.json"
 
 # Per-lesson learning-access type ("guest"/"trial"/"normal") <-> the Chinese the
@@ -742,8 +743,9 @@ COURSE_CONFIG_NAME = "course-config.json"
 ACCESS_TYPES = ("guest", "trial", "normal")
 
 # Course-level attributes that round-trip through course-config.json. The course
-# name lives in README.md and the system prompt in course-prompt.md, so they are
-# intentionally NOT duplicated here.
+# name lives in README.md, the SEO description in course-description.md, and the
+# system prompt in course-prompt.md, so they are intentionally NOT duplicated
+# here.
 COURSE_CONFIG_DEFAULTS = {
     "model": "", "temperature": 0.3, "price": 0, "keywords": [], "avatar": "",
     "use_learner_language": False,
@@ -780,6 +782,41 @@ def _write_course_config(course_dir, cfg):
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + "\n",
                    encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_text_file(path, *, label):
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError as e:
+        print(f"Error: cannot read {label}: {e}")
+        sys.exit(1)
+
+
+def _resolve_course_description(course_dir=None, description=None,
+                                description_file=None):
+    """Resolve course description precedence for build/import/update-meta."""
+    if description is not None and description_file is not None:
+        print("Error: --description and --description-file are mutually exclusive.")
+        sys.exit(1)
+    if description is not None:
+        return description
+    if description_file is not None:
+        return _read_text_file(description_file, label="--description-file")
+    if course_dir:
+        path = Path(course_dir) / COURSE_DESCRIPTION_NAME
+        if path.exists():
+            return _read_text_file(path, label=str(path))
+    return ""
+
+
+def _write_course_description(course_dir, description):
+    """Atomically write the local SEO description file."""
+    path = Path(course_dir) / COURSE_DESCRIPTION_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    text = (description or "").strip()
+    tmp.write_text((text + "\n") if text else "", encoding="utf-8")
     tmp.replace(path)
 
 
@@ -937,6 +974,12 @@ def _pull_into_dir(base_url, token, shifu_bid, course_dir, *, backup=True, force
             lines.insert(0, f"# {name}")
         readme.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
+    # course-description.md — cloud-authoritative SEO/course listing summary.
+    course_description = detail.get("description", "") or ""
+    desc_path = course_path / COURSE_DESCRIPTION_NAME
+    _backup_if_divergent(desc_path, course_description)
+    _write_course_description(course_dir, course_description)
+
     # course-prompt.md — cloud-authoritative system prompt.
     course_prompt = detail.get("system_prompt", "") or ""
     cp_path = course_path / "course-prompt.md"
@@ -982,6 +1025,7 @@ def _pull_into_dir(base_url, token, shifu_bid, course_dir, *, backup=True, force
         "course": {
             "revision": course_meta.get("revision"),
             "name": name,
+            "description": course_description,
             "updated_at": course_meta.get("updated_at"),
             "updated_user_bid": (course_meta.get("updated_user") or {}).get("user_bid"),
         },
@@ -1166,8 +1210,8 @@ def _auto_pull_overwrite(base_url, token, shifu_bid, course_dir, *, scope,
     elif scope == "import":
         backup_dir = course_path / f".conflict-backup-{ts}"
         backup_dir.mkdir(parents=True, exist_ok=True)
-        for rel in ("README.md", "course-prompt.md", "structure.json",
-                    COURSE_CONFIG_NAME):
+        for rel in ("README.md", COURSE_DESCRIPTION_NAME, "course-prompt.md",
+                    "structure.json", COURSE_CONFIG_NAME):
             src = course_path / rel
             if src.exists():
                 shutil.copy2(src, backup_dir / rel)
@@ -1279,9 +1323,17 @@ def cmd_update_meta(args):
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
     course_dir = getattr(args, "course_dir", None)
+    description = None
+    if (args.description is not None
+            or getattr(args, "description_file", None) is not None):
+        description = _resolve_course_description(
+            description=args.description,
+            description_file=getattr(args, "description_file", None),
+        )
 
     manifest = _load_sync(course_dir) if course_dir else None
-    intended = {"name": args.name, "description": args.description,
+    intended = {"name": args.name, "description": description,
+                "description_file": getattr(args, "description_file", None),
                 "course_prompt_file": args.course_prompt_file}
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
                                 intended)
@@ -1295,25 +1347,32 @@ def cmd_update_meta(args):
     payload = {}
     if args.name is not None:
         payload["name"] = args.name
-    if args.description is not None:
-        payload["description"] = args.description
+    if description is not None:
+        payload["description"] = description
     if args.course_prompt_file:
         with open(args.course_prompt_file, "r", encoding="utf-8") as f:
             payload["system_prompt"] = f.read().strip()
     if not payload:
         print("Nothing to update "
-              "(provide --name / --description / --course-prompt-file).")
+              "(provide --name / --description / --description-file / "
+              "--course-prompt-file).")
         return
 
     api(base_url, token, "post", f"/shifus/{shifu_bid}/detail", json=payload)
     print(f"Updated metadata for {shifu_bid}")
+
+    if course_dir and "description" in payload:
+        _write_course_description(course_dir, payload["description"])
 
     # Re-read the course-level revision (the detail POST response does not carry
     # it) and record it as the new baseline so subsequent edits compare cleanly.
     if manifest and manifest.get("shifu_bid") == shifu_bid:
         _update_course_manifest_after_push(
             base_url, token, shifu_bid, course_dir, manifest,
-            course_updates={"name": payload.get("name")})
+            course_updates={
+                "name": payload.get("name"),
+                "description": payload.get("description"),
+            })
 
 
 # ── Set TTS ───────────────────────────────────────────────────────────────────
@@ -1738,6 +1797,7 @@ def cmd_import(args):
             course_dir=args.course_dir,
             title=getattr(args, "title", None),
             description=getattr(args, "description", None),
+            description_file=getattr(args, "description_file", None),
             keywords=getattr(args, "keywords", None),
             chapter_name=getattr(args, "chapter_name", None),
         )
@@ -1765,6 +1825,7 @@ def _derive_lesson_title(filename):
 
 
 def _build_import_json(course_dir, title=None, description=None,
+                       description_file=None,
                        keywords=None, chapter_name=None, output_path=None):
     """Build import JSON from a local course directory. Returns the output file path."""
     lessons_dir = os.path.join(course_dir, "lessons")
@@ -1801,6 +1862,12 @@ def _build_import_json(course_dir, title=None, description=None,
                 title = first_line.lstrip("#").strip()
         if not title:
             title = Path(course_dir).name
+
+    description = _resolve_course_description(
+        course_dir=course_dir,
+        description=description,
+        description_file=description_file,
+    )
 
     # Load chapter structure from structure.json if exists,
     # otherwise auto-create a single chapter wrapping all lessons
@@ -1996,6 +2063,7 @@ def cmd_build(args):
         course_dir=args.course_dir,
         title=args.title,
         description=args.description,
+        description_file=args.description_file,
         keywords=args.keywords,
         chapter_name=args.chapter_name,
         output_path=args.output,
@@ -2468,6 +2536,8 @@ def build_parser():
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--name", default=None, help="New course name")
     p.add_argument("--description", default=None, help="New description")
+    p.add_argument("--description-file", default=None,
+                   help="File containing the new course description")
     p.add_argument("--course-prompt-file", default=None,
                    help="File containing course-level prompt")
     p.add_argument("--course-dir", default=None,
@@ -2557,6 +2627,8 @@ def build_parser():
                    help="Course title (only with --course-dir)")
     p.add_argument("--description", default=None,
                    help="Course description (only with --course-dir)")
+    p.add_argument("--description-file", default=None,
+                   help="Course description file (only with --course-dir)")
     p.add_argument("--keywords", default=None,
                    help="Keywords, comma-separated (only with --course-dir)")
     p.add_argument("--chapter-name", default=None,
@@ -2571,6 +2643,8 @@ def build_parser():
     p.add_argument("--chapter-name", default=None,
                    help="Chapter name (default: same as course title)")
     p.add_argument("--description", default=None, help="Course description")
+    p.add_argument("--description-file", default=None,
+                   help="Course description file")
     p.add_argument("--keywords", default=None, help="Keywords (comma-separated)")
 
     # ── publish ──

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1079,8 +1079,23 @@ def cmd_status(args):
     _collect(tree if isinstance(tree, list) else [tree])
 
     behind, locally_modified, deleted_remote = [], [], []
+    course_locally_modified = []
     manifest_bids = set()
     uptodate = 0
+
+    desc_path = Path(course_dir) / COURSE_DESCRIPTION_NAME
+    manifest_course = manifest.get("course") or {}
+    manifest_description = manifest_course.get("description") or ""
+    if desc_path.exists():
+        try:
+            local_description = desc_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            local_description = None
+        if local_description is None or local_description != manifest_description:
+            course_locally_modified.append(COURSE_DESCRIPTION_NAME)
+    elif manifest_description:
+        course_locally_modified.append(COURSE_DESCRIPTION_NAME)
+
     # Reuse one connection for the per-lesson draft-meta lookups — on a remote
     # API the TCP/TLS handshake dominates, so pooling roughly halves wall time
     # for multi-lesson courses (same pattern as cmd_list / cmd_find_title).
@@ -1136,6 +1151,11 @@ def cmd_status(args):
         print("\nLocally modified (will be pushed on next update-lesson / import):")
         for entry in locally_modified:
             print(f"  {entry.get('file')}   {entry.get('name', '')}")
+    if course_locally_modified:
+        print("\nCourse metadata locally modified "
+              "(will be pushed on next update-meta / import):")
+        for relfile in course_locally_modified:
+            print(f"  {relfile}   description")
     if new_remote:
         print("\nNew on server (not in local manifest — run `pull`):")
         for b in new_remote:
@@ -1148,9 +1168,11 @@ def cmd_status(args):
 
     # A locally-modified working tree counts as diverged too, so `status
     # --exit-code` can guard import/push automation against unsynced edits.
-    diverged = bool(behind or new_remote or deleted_remote or locally_modified) or (
-        cloud_course_rev is not None and local_course_rev is not None
-        and cloud_course_rev > local_course_rev)
+    diverged = bool(
+        behind or new_remote or deleted_remote or locally_modified
+        or course_locally_modified
+    ) or (cloud_course_rev is not None and local_course_rev is not None
+          and cloud_course_rev > local_course_rev)
     if getattr(args, "exit_code", False) and diverged:
         sys.exit(1)
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1082,7 +1082,9 @@ def cmd_status(args):
 
     desc_path = Path(course_dir) / COURSE_DESCRIPTION_NAME
     manifest_course = manifest.get("course") or {}
-    manifest_description = manifest_course.get("description") or ""
+    manifest_description = manifest_course.get("description")
+    if manifest_description is None:
+        manifest_description = ""
     if desc_path.exists():
         try:
             local_description = desc_path.read_text(encoding="utf-8")
@@ -1346,11 +1348,14 @@ def cmd_update_meta(args):
             course_dir=course_dir,
             description=args.description,
         )
-    elif course_dir and (Path(course_dir) / COURSE_DESCRIPTION_NAME).exists():
+    elif (manifest and manifest.get("shifu_bid") == shifu_bid and course_dir
+          and (Path(course_dir) / COURSE_DESCRIPTION_NAME).exists()):
         local_description = _resolve_course_description(course_dir=course_dir)
         manifest_description = ((manifest or {}).get("course") or {}).get(
-            "description", "")
-        if manifest is None or local_description != manifest_description.strip():
+            "description")
+        if manifest_description is None:
+            manifest_description = ""
+        if local_description != manifest_description.strip():
             description = local_description
 
     intended = {"name": args.name, "description": description,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -796,9 +796,6 @@ def _read_text_file(path, *, label):
 def _resolve_course_description(course_dir=None, description=None,
                                 description_file=None):
     """Resolve course description precedence for build/import/update-meta."""
-    if description is not None and description_file is not None:
-        print("Error: --description and --description-file are mutually exclusive.")
-        sys.exit(1)
     if description is not None:
         return description
     if description_file is not None:
@@ -2534,9 +2531,10 @@ def build_parser():
                        help="Update course metadata")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--name", default=None, help="New course name")
-    p.add_argument("--description", default=None, help="New description")
-    p.add_argument("--description-file", default=None,
-                   help="File containing the new course description")
+    desc_group = p.add_mutually_exclusive_group()
+    desc_group.add_argument("--description", default=None, help="New description")
+    desc_group.add_argument("--description-file", default=None,
+                            help="File containing the new course description")
     p.add_argument("--course-prompt-file", default=None,
                    help="File containing course-level prompt")
     p.add_argument("--course-dir", default=None,
@@ -2624,10 +2622,11 @@ def build_parser():
                    help="Course directory (builds JSON then imports)")
     p.add_argument("--title", default=None,
                    help="Course title (only with --course-dir)")
-    p.add_argument("--description", default=None,
-                   help="Course description (only with --course-dir)")
-    p.add_argument("--description-file", default=None,
-                   help="Course description file (only with --course-dir)")
+    desc_group = p.add_mutually_exclusive_group()
+    desc_group.add_argument("--description", default=None,
+                            help="Course description (only with --course-dir)")
+    desc_group.add_argument("--description-file", default=None,
+                            help="Course description file (only with --course-dir)")
     p.add_argument("--keywords", default=None,
                    help="Keywords, comma-separated (only with --course-dir)")
     p.add_argument("--chapter-name", default=None,
@@ -2641,9 +2640,10 @@ def build_parser():
     p.add_argument("--title", default=None, help="Course title")
     p.add_argument("--chapter-name", default=None,
                    help="Chapter name (default: same as course title)")
-    p.add_argument("--description", default=None, help="Course description")
-    p.add_argument("--description-file", default=None,
-                   help="Course description file")
+    desc_group = p.add_mutually_exclusive_group()
+    desc_group.add_argument("--description", default=None, help="Course description")
+    desc_group.add_argument("--description-file", default=None,
+                            help="Course description file")
     p.add_argument("--keywords", default=None, help="Keywords (comma-separated)")
 
     # ── publish ──

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -793,13 +793,10 @@ def _read_text_file(path, *, label):
         sys.exit(1)
 
 
-def _resolve_course_description(course_dir=None, description=None,
-                                description_file=None):
+def _resolve_course_description(course_dir=None, description=None):
     """Resolve course description precedence for build/import/update-meta."""
     if description is not None:
         return description
-    if description_file is not None:
-        return _read_text_file(description_file, label="--description-file")
     if course_dir:
         path = Path(course_dir) / COURSE_DESCRIPTION_NAME
         if path.exists():
@@ -1342,16 +1339,13 @@ def cmd_update_meta(args):
     shifu_bid = args.shifu_bid
     course_dir = getattr(args, "course_dir", None)
     description = None
-    if (args.description is not None
-            or getattr(args, "description_file", None) is not None):
+    if args.description is not None:
         description = _resolve_course_description(
             description=args.description,
-            description_file=getattr(args, "description_file", None),
         )
 
     manifest = _load_sync(course_dir) if course_dir else None
     intended = {"name": args.name, "description": description,
-                "description_file": getattr(args, "description_file", None),
                 "course_prompt_file": args.course_prompt_file}
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
                                 intended)
@@ -1372,8 +1366,7 @@ def cmd_update_meta(args):
             payload["system_prompt"] = f.read().strip()
     if not payload:
         print("Nothing to update "
-              "(provide --name / --description / --description-file / "
-              "--course-prompt-file).")
+              "(provide --name / --description / --course-prompt-file).")
         return
 
     api(base_url, token, "post", f"/shifus/{shifu_bid}/detail", json=payload)
@@ -1815,7 +1808,6 @@ def cmd_import(args):
             course_dir=args.course_dir,
             title=getattr(args, "title", None),
             description=getattr(args, "description", None),
-            description_file=getattr(args, "description_file", None),
             keywords=getattr(args, "keywords", None),
             chapter_name=getattr(args, "chapter_name", None),
         )
@@ -1843,7 +1835,6 @@ def _derive_lesson_title(filename):
 
 
 def _build_import_json(course_dir, title=None, description=None,
-                       description_file=None,
                        keywords=None, chapter_name=None, output_path=None):
     """Build import JSON from a local course directory. Returns the output file path."""
     lessons_dir = os.path.join(course_dir, "lessons")
@@ -1884,7 +1875,6 @@ def _build_import_json(course_dir, title=None, description=None,
     description = _resolve_course_description(
         course_dir=course_dir,
         description=description,
-        description_file=description_file,
     )
 
     # Load chapter structure from structure.json if exists,
@@ -2081,7 +2071,6 @@ def cmd_build(args):
         course_dir=args.course_dir,
         title=args.title,
         description=args.description,
-        description_file=args.description_file,
         keywords=args.keywords,
         chapter_name=args.chapter_name,
         output_path=args.output,
@@ -2553,10 +2542,7 @@ def build_parser():
                        help="Update course metadata")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--name", default=None, help="New course name")
-    desc_group = p.add_mutually_exclusive_group()
-    desc_group.add_argument("--description", default=None, help="New description")
-    desc_group.add_argument("--description-file", default=None,
-                            help="File containing the new course description")
+    p.add_argument("--description", default=None, help="New description")
     p.add_argument("--course-prompt-file", default=None,
                    help="File containing course-level prompt")
     p.add_argument("--course-dir", default=None,
@@ -2644,11 +2630,8 @@ def build_parser():
                    help="Course directory (builds JSON then imports)")
     p.add_argument("--title", default=None,
                    help="Course title (only with --course-dir)")
-    desc_group = p.add_mutually_exclusive_group()
-    desc_group.add_argument("--description", default=None,
-                            help="Course description (only with --course-dir)")
-    desc_group.add_argument("--description-file", default=None,
-                            help="Course description file (only with --course-dir)")
+    p.add_argument("--description", default=None,
+                   help="Course description (only with --course-dir)")
     p.add_argument("--keywords", default=None,
                    help="Keywords, comma-separated (only with --course-dir)")
     p.add_argument("--chapter-name", default=None,
@@ -2662,10 +2645,7 @@ def build_parser():
     p.add_argument("--title", default=None, help="Course title")
     p.add_argument("--chapter-name", default=None,
                    help="Chapter name (default: same as course title)")
-    desc_group = p.add_mutually_exclusive_group()
-    desc_group.add_argument("--description", default=None, help="Course description")
-    desc_group.add_argument("--description-file", default=None,
-                            help="Course description file")
+    p.add_argument("--description", default=None, help="Course description")
     p.add_argument("--keywords", default=None, help="Keywords (comma-separated)")
 
     # ── publish ──


### PR DESCRIPTION
## Summary
- add `course-description.md` as first-class AI-Shifu course metadata
- sync course descriptions through pull, build/import, and update-meta flows
- document description generation and CLI override behavior across skill references and examples

## Validation
- focused temp-course build checks for default `course-description.md`, `--description`, `--description-file`, and mutual-exclusion failure
- monkeypatched `update-meta --description-file --course-dir` sync check
- `python3 -m py_compile /Users/sunner/src/skills/skills/ai-shifu-course-creator/scripts/shifu-cli.py`
- `python3 scripts/validate_skill_quality.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `course-description.md` as a standard course asset for the learner-facing SEO/listing description.
  * Updated CLI description handling: `--description` takes priority, otherwise uses `course-description.md` when building/importing.

* **Bug Fixes**
  * Improved round-trip syncing: `pull` writes the cloud description to `course-description.md`, and status now flags local divergence for this metadata.

* **Documentation**
  * Updated the course directory spec, CLI reference, deployment/end-to-end examples, and data contracts to include the new artifact and its precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->