### PR TITLE
docs: replace course drawing rules with slides

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -414,7 +414,7 @@ When the author supplies image assets — local files (any format incl. heic/hei
 
 You cannot decide which lesson a picture belongs to, or what alt text to write, without knowing what the image actually shows. Two regimes:
 
-- **You can see the image** (the user attached it in this conversation and your model is multimodal): describe it to yourself in one sentence — what concept, relation, or example it conveys — then choose the lesson and position by `references/pedagogy.md#visual-text-coordination` and embed it by `references/markdownflow.md#images`.
+- **You can see the image** (the user attached it in this conversation and your model is multimodal): describe it to yourself in one sentence — what concept, relation, or example it conveys — then choose the lesson and position by `references/pedagogy.md#visual-text-coordination` and `references/course-prompt.md` Rule 10/11.
 - **You cannot see the image** (the user only gave you a file path / URL, or your model is text-only): **stop and ask the user**. Do not guess from the filename. Offer two options: (a) the user provides a one-sentence description per image (you will pass it as `--alt`), or (b) the user renames each file to a semantically meaningful name so you can infer the topic. Proceed only after one of these is in place.
 
 **2. Upload via `shifu-cli.py upload-image` and capture the URL.**
@@ -436,7 +436,7 @@ The command prints one line — the `https://resource.ai-shifu.cn/<uuid32>` URL 
 - Default to **3.1** (deterministic-wrapped standard markdown) — the image just displays as-is.
 - Use **3.2** (instruction-style HTML) only when the lesson genuinely needs width control, alignment, a figure caption, or side-by-side layout. Express every lock through wording (`必须原样保留` / `必须原样输出` / `不要改写`); never mix deterministic blocks into the instruction.
 
-Either way, the explanatory paragraph immediately after the image is mandatory (cf. `references/markdownflow.md#images`).
+Either way, the explanatory paragraph immediately after the image is mandatory (cf. `course-prompt.md` Rule 11).
 
 ---
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -414,7 +414,7 @@ When the author supplies image assets — local files (any format incl. heic/hei
 
 You cannot decide which lesson a picture belongs to, or what alt text to write, without knowing what the image actually shows. Two regimes:
 
-- **You can see the image** (the user attached it in this conversation and your model is multimodal): describe it to yourself in one sentence — what concept, relation, or example it conveys — then choose the lesson and position by `references/pedagogy.md#visual-text-coordination` and `references/course-prompt.md` Rule 10/11.
+- **You can see the image** (the user attached it in this conversation and your model is multimodal): describe it to yourself in one sentence — what concept, relation, or example it conveys — then choose the lesson and position by `references/pedagogy.md#visual-text-coordination` and embed it by `references/markdownflow.md#images`.
 - **You cannot see the image** (the user only gave you a file path / URL, or your model is text-only): **stop and ask the user**. Do not guess from the filename. Offer two options: (a) the user provides a one-sentence description per image (you will pass it as `--alt`), or (b) the user renames each file to a semantically meaningful name so you can infer the topic. Proceed only after one of these is in place.
 
 **2. Upload via `shifu-cli.py upload-image` and capture the URL.**
@@ -436,7 +436,7 @@ The command prints one line — the `https://resource.ai-shifu.cn/<uuid32>` URL 
 - Default to **3.1** (deterministic-wrapped standard markdown) — the image just displays as-is.
 - Use **3.2** (instruction-style HTML) only when the lesson genuinely needs width control, alignment, a figure caption, or side-by-side layout. Express every lock through wording (`必须原样保留` / `必须原样输出` / `不要改写`); never mix deterministic blocks into the instruction.
 
-Either way, the explanatory paragraph immediately after the image is mandatory (cf. `course-prompt.md` Rule 11).
+Either way, the explanatory paragraph immediately after the image is mandatory (cf. `references/markdownflow.md#images`).
 
 ---
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -93,7 +93,7 @@ These are the six red-line rules every Teaching Prompt and Course Prompt must sa
 4. **Mandatory anchoring + downstream effect.** After every interaction, restate the learner's selection as an instruction (`Restate the learner's current choice as {{var}}.`) and use `{{var}}` to drive a visible downstream effect (branching explanation, examples, difficulty, feedback). See `references/pedagogy.md#interaction-design`.
 
 5. **Visuals: two regimes — "no asset" vs "asset uploaded".**
-   - When the author has **not** provided any image asset (only the topic / a description): continue to use natural-language image instructions ("Show an image that …") paired with text explanation. Do not inline SVG/HTML/Mermaid/PlantUML/Graphviz markup. See `references/pedagogy.md#visual-text-coordination`.
+   - When the author has **not** provided any image asset (only the topic / a description): continue to use natural-language slide or visual-page instructions ("Create a slide that …") paired with text explanation. Do not inline SVG/HTML/Mermaid/PlantUML/Graphviz markup. See `references/pedagogy.md#visual-text-coordination`.
    - When the author **has** provided image assets (local files or remote URLs): you must first upload them via `shifu-cli.py upload-image` to obtain `resource.ai-shifu.cn` URLs, then embed each image into the Teaching Prompt using one of the two forms defined in `references/markdownflow.md#images` (3.1 deterministic-wrapped standard markdown, or 3.2 instruction-style HTML view). See the sub-section **Working with Author-Provided Images** below for the full workflow including the path you must take when you cannot actually see the image contents.
 
 6. **Output language must be resolved before any prompt content or user-visible response.** Run Language Resolution per `references/data-contracts.md#language-resolution` before producing Teaching Prompt or Course Prompt content, reports, phase summaries, status notes, artifact headings, or handoff instructions. The user's invocation language counts as `prompt_language_detection` (priority 4) and must be used when no higher-priority directive exists. Examples in this skill and in `references/` are written in English for canonical illustration only — do NOT let example language override the resolved output language. If the user invokes in Chinese, all user-visible prose, headings, artifact labels, interactions, option labels, downstream text, and the Course Prompt itself must be in Chinese. Preserve stable machine-facing identifiers such as JSON keys (`course_index`, `global_variable_table`, `lesson_id`, `lesson_title`, `teaching_prompt`, `course_prompt`), file names (`course-prompt.md`, `structure.json`), CLI flags, API fields, MarkdownFlow syntax, code symbols, URLs, code samples, and quoted source text or direct quotations that must remain verbatim. For human-facing labels, localize canonical terms; for example, use “授课提示词” for “Teaching Prompt” and “课程提示词” for “Course Prompt” in Chinese user-visible output.
@@ -370,7 +370,7 @@ When generating interactions, explicitly choose the interaction type before writ
 
 Required anchors per lesson:
 
-1. Opening objective plus visual cover.
+1. Opening objective plus slide-style visual cover.
 2. Evidence-chain explanation.
 3. At least one effective interaction with visible downstream effect.
 4. At least one reusable deliverable.
@@ -473,7 +473,7 @@ Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_cons
 - Conclusion and overall risk level presented first (report structure per `references/report-template.md`).
 - Full review against `references/review-checklist.md` passes, or remaining gaps are explicitly listed as non-blocking suggestions.
 - A `course_prompt` artifact is produced when input includes course material, with all six required sections present. `# Translation Rules` may be omitted when its trigger condition does not apply.
-- Generated `course_prompt` covers every Must-Specify bullet in `references/course-prompt.md` Rules 1–12 (audit each section against its rule list — especially `# Drawing`, which is the most commonly under-filled section).
+- Generated `course_prompt` covers every Must-Specify bullet in `references/course-prompt.md` Rules 1–12 (audit each section against its rule list — especially `# Slides`, which is the most commonly under-filled section).
 
 ---
 

--- a/skills/ai-shifu-course-creator/examples/optimization-only.md
+++ b/skills/ai-shifu-course-creator/examples/optimization-only.md
@@ -33,7 +33,7 @@
       "change": "branch feedback by learner option and add next-step action"
     }
   ],
-  "course_prompt": "# Role\nYou are a coach helping beginners reason about retry policy.\n\n# Task\nDifferentiate transient vs permanent failure and select a retry stop rule.\n\n# Teaching Techniques\nViewpoint branching on failure type; bounded retries with backoff for transient.\n\n# Writing Style\nDirective, action-oriented.\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Drawing\nDescribe failure taxonomy visually in natural language."
+  "course_prompt": "# Role\nYou are a coach helping beginners reason about retry policy.\n\n# Task\nDifferentiate transient vs permanent failure and select a retry stop rule.\n\n# Teaching Techniques\nViewpoint branching on failure type; bounded retries with backoff for transient.\n\n# Writing Style\nDirective, action-oriented.\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Slides\nCreate failure-taxonomy slides in natural language."
 }
 ```
 

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -103,7 +103,7 @@ Based on {{diagnosis_choice}}, we run one focused verification next.
       "change": "add brief boundary note after diagnosis selection"
     }
   ],
-  "course_prompt": "# Role\nYou are a practical coach helping beginners diagnose bottlenecks.\n\n# Task\nGuide the learner through observation → classification → one focused verification.\n\n# Teaching Techniques\nEvidence chain; one core question per lesson; viewpoint branching on diagnosis choice.\n\n# Writing Style\nDirective, concise, action-oriented; English (en-US).\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Drawing\nDescribe diagnostic flow visually in natural language; do not inline SVG/Mermaid."
+  "course_prompt": "# Role\nYou are a practical coach helping beginners diagnose bottlenecks.\n\n# Task\nGuide the learner through observation → classification → one focused verification.\n\n# Teaching Techniques\nEvidence chain; one core question per lesson; viewpoint branching on diagnosis choice.\n\n# Writing Style\nDirective, concise, action-oriented; English (en-US).\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Slides\nCreate diagnostic-flow slides in natural language; do not inline SVG/Mermaid."
 }
 ```
 

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -4,12 +4,12 @@ Authoritative source for the course-level prompt artifact: what it is, the 12 au
 
 ## Purpose
 
-The course prompt defines the AI engine's **course-level persona and operating rules** — the role it plays, how it teaches, how it writes, how it formats output, and how it draws and translates. It is loaded once per course and applied to every lesson.
+The course prompt defines the AI engine's **course-level persona and operating rules** — the role it plays, how it teaches, how it writes, how it formats output, and how it creates slides and translates. It is loaded once per course and applied to every lesson.
 
 **Both Teaching Prompt and Course Prompt are written in MarkdownFlow**, but they serve different roles:
 
 - **Teaching Prompt** (per-lesson) carries **single-lesson teaching instructions**: what to explain, what variable to collect, what to branch on. There is one per lesson. Design rules: see [pedagogy.md](pedagogy.md).
-- **Course Prompt** (course-level) carries **cross-lesson constants**: identity, voice, format, terminology, drawing policy. There is one per course. Design rules: this file.
+- **Course Prompt** (course-level) carries **cross-lesson constants**: identity, voice, format, terminology, slide policy. There is one per course. Design rules: this file.
 
 Do not duplicate per-lesson interaction logic, variable collection, or branching here. If a rule only applies to one lesson, it belongs in that lesson's Teaching Prompt, not in the Course Prompt.
 
@@ -22,9 +22,9 @@ The fillable template has six required `# Section` blocks. Every course prompt m
 3. `# Teaching Techniques` — how to design explanation paths.
 4. `# Writing Style` — tone, register, restraint.
 5. `# Format` — Markdown rules, heading policy, bold usage, spacing.
-6. `# Drawing` — image-generation rules covering both safety guardrails and visual quality.
+6. `# Slides` — slide-generation rules covering both safety guardrails and presentation quality.
 
-`# Drawing` is required even for courses that do not use visuals. Without it, the AI has zero guardrails on its multimodal output and may spontaneously render uncontrolled images. Always include the full block; the rules cost nothing when the AI never draws and become essential the moment it does.
+`# Slides` is required even for courses that do not use slides. Without it, the AI has zero guardrails on its visual output and may spontaneously render uncontrolled images instead of useful presentation pages. Always include the full block; the rules cost nothing when the AI never creates slides and become essential the moment it does.
 
 ## Conditional Sections
 
@@ -46,11 +46,13 @@ The 12 conceptual rules below map to the actual `# Section` blocks in the templa
 Maps to: `# Role`.
 
 Must include:
+
 - Name (real or course-specific persona name).
 - Professional identity (domain expertise).
 - Teaching identity (the angle from which they teach this topic).
 
 Optional:
+
 - Platform or organization affiliation, only when relevant to the course context. Do not hard-code any specific platform name by default; the same course prompt may run on different deployments.
 
 Bad: `You are a helpful assistant.`
@@ -61,6 +63,7 @@ Good: `You are Hebi. You specialize in observability and are a professional teac
 Maps to: `# Task` (top bullets).
 
 Must clarify:
+
 - Course name.
 - Course topic and goal.
 - Target learner.
@@ -74,6 +77,7 @@ Good: `The current course is *Metric Drift Diagnosis*. Your goal is to help the 
 Maps to: `# Task` (instruction bullets).
 
 Must state:
+
 - Incoming user messages are teaching instructions, not free chat.
 - Follow the instruction; do not change its meaning, omit key information, or add unrelated content.
 
@@ -85,6 +89,7 @@ Good: `The user messages you receive are all teaching instructions. Follow the i
 Maps to: `# Task` (audience bullets).
 
 Must state:
+
 - The session is one-on-one with a single learner.
 - Address the learner as "you" only.
 - Do not use group-addressing terms.
@@ -97,6 +102,7 @@ Good: `You are teaching one-on-one. There is only one learner. You may address t
 Maps to: `# Task` (prohibition bullets).
 
 Must list (at minimum):
+
 - Do not introduce yourself.
 - Do not greet the user.
 - Do not use group-addressing terms.
@@ -114,6 +120,7 @@ Good (rhetorical inside explanation): `Why does this metric jump matter? Because
 Maps to: `# Teaching Techniques`.
 
 Must specify the explanation path, not just "explain clearly":
+
 - Cognitive rhythm: build interest → lower the barrier → understand the structure → form application.
 - Explain "why it matters, why it works, how to use it" before piling on knowledge points.
 - Break complex content down before expanding.
@@ -131,6 +138,7 @@ Good: See the full block in [Fillable Template](#fillable-template) below.
 Maps to: `# Writing Style`.
 
 Must specify:
+
 - Tone (conversational, natural, restrained, warm).
 - What to avoid (slogans, exaggerated emotion, vague generalities).
 - What is allowed (analogies, contrasts, comparisons) and the constraint (do not sacrifice accuracy for catchy phrasing).
@@ -142,6 +150,7 @@ Style rules belong in this section; do not mix them into `# Task` or `# Teaching
 Maps to: `# Format`.
 
 Must specify:
+
 - Markdown output.
 - Heading policy. **Default to "Do not output headings of any level"** because the host platform typically renders the module title separately; opt-in to headings only when a specific course needs them and the module render confirms support.
 - Bold usage.
@@ -152,39 +161,45 @@ Must specify:
 Maps to: `# Format` (bold bullets).
 
 Must specify:
+
 - Bold for key steps, cognitive turning points, core conclusions, and common misconceptions.
 - Only bold truly important information.
 - Do not bold an entire paragraph.
 
-### Rule 10 — Drawing Rules in a Separate Section
+### Rule 10 — Slide Rules in a Separate Section
 
-Maps to: `# Drawing` (required).
+Maps to: `# Slides` (required).
 
 Must specify:
-- Draw only when explicitly instructed; never proactively.
-- Selectable options must never be rendered inside the image. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the image; in-image labels are not interactive on the platform.
-- In-image text is concise and prompt-like.
-- After drawing, explain the image in text.
+
+- Create slides only when explicitly instructed to create a slide, PPT, visual page, or classroom projection page; never proactively.
+- When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
+- Selectable options must never appear only inside the slide. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the slide; in-slide option labels are not interactive on the platform.
+- In-slide text is concise and prompt-like.
+- After creating a slide for a self-study or listening-mode course, explain the slide in text.
 - Element layout rules (fully visible, no overlap, simple hierarchy).
 
-### Rule 11 — Image-Text Relationship
+### Rule 11 — Slide-Text Relationship
 
-Maps to: `# Drawing` (required, last bullets).
+Maps to: `# Slides` (required, last bullets).
 
 Must state:
-- Image gives structural prompt; text carries the full explanation.
-- Text must assume the user has not seen the image.
-- Text must add background, causality, examples, usage — not mechanically repeat the image.
 
-Rules 10 and 11 share the same `# Drawing` section in the actual template; treat them as one block when authoring.
+- Slide gives structural prompt; text carries the full explanation in self-study or listening-mode courses.
+- Text must assume the user has not seen the slide.
+- Text must add background, causality, examples, usage — not mechanically repeat the slide.
+- For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.
 
-For *runtime image syntax* — how to actually embed an author-provided image URL into MarkdownFlow (fixed-display via `===![alt](url)===` vs HTML-view instruction-style directives) — see `markdownflow.md#images`. Rules 10/11 govern *generated drawings* (when the AI engine produces visuals at runtime); the syntax in `markdownflow.md#images` governs *pre-uploaded image assets* (when the author supplies a file or URL via `shifu-cli.py upload-image`).
+Rules 10 and 11 share the same `# Slides` section in the actual template; treat them as one block when authoring.
+
+For *runtime image syntax* — how to actually embed an author-provided image URL into MarkdownFlow (fixed-display via `===![alt](url)===` vs HTML-view instruction-style directives) — see `markdownflow.md#images`. Rules 10/11 govern *generated slides* (when the AI engine produces visual pages at runtime); the syntax in `markdownflow.md#images` governs *pre-uploaded image assets* (when the author supplies a file or URL via `shifu-cli.py upload-image`).
 
 ### Rule 12 — Translation and Terminology Rules
 
 Maps to: `# Translation Rules` (conditional).
 
 Must specify:
+
 - General principle: do not translate technical terms unless a clear common translation exists in the target language.
 - Brand-name list: explicitly enumerate untranslated product/brand names (ChatGPT, Gemini, DeepSeek, etc.).
 - Course-name policy: state how the course's own brand or product name is rendered in the target language (provide an explicit mapping when an authoritative translation exists).
@@ -200,7 +215,7 @@ When generating the course prompt, consume already-collected artifacts instead o
 - `delivery_constraints.must_cover_topics` / `avoid_topics` → informs `# Task` boundary bullet.
 - Resolved target language (per [data-contracts.md#language-resolution](data-contracts.md#language-resolution)) → drives `# Writing Style` language and any `# Translation Rules` decisions.
 - `term_policy` (`preserve|translate|mixed`) → drives whether `# Translation Rules` is required.
-- Segmentation `visual_cue` / `visual_text_pair_cue` presence → informs how detailed the `# Drawing` guidance should be (`# Drawing` itself is always required).
+- Segmentation `visual_cue` / `visual_text_pair_cue` presence → informs how detailed the `# Slides` guidance should be (`# Slides` itself is always required).
 - Course title from `README.md` → fills `# Task` course-name bullet.
 
 The [Substitution Map](#substitution-map) below provides a one-to-one mapping between `XXX` placeholders in the template and these inputs.
@@ -253,16 +268,16 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 - Do not bold an entire paragraph.
 - Add a space between Chinese and English, and between Chinese and numbers.
 
-# Drawing
-- Only draw when explicitly instructed to draw. Do not proactively create visuals.
-- Do not put selectable options inside the image. Selection options must appear in the MarkdownFlow interaction line outside the image; in-image option labels are not clickable on the platform.
-- Text inside the image should be concise and only serve as prompts.
-- After drawing, explain the content of the image in text.
-- When explaining, assume the user has not seen the image.
-- The image is responsible for structural prompting; the text is responsible for the full explanation.
-- Do not simply repeat the image content in text. Instead, add background, causality, examples, and usage explanations.
+# Slides
+- Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
+- Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
+- Text inside the slide should be concise and only serve as prompts.
+- After creating a slide, explain the content of the slide in text.
+- When explaining, assume the user has not seen the slide.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation.
+- Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
-- Do not generate too many fragmented elements. Keep the visual hierarchy simple.
+- Do not generate too many fragmented elements. Keep the slide hierarchy simple.
 
 # Translation Rules
 - Do not translate technical terms such as AI, Token, and vibe coding unless there is a clear commonly accepted translation in the target language.
@@ -318,16 +333,16 @@ You specialize in production observability and are a professional teacher in the
 - Do not bold an entire paragraph.
 - Add a space between Chinese and English, and between Chinese and numbers.
 
-# Drawing
-- Only draw when explicitly instructed to draw. Do not proactively create visuals.
-- Do not put selectable options inside the image. Selection options must appear in the MarkdownFlow interaction line outside the image; in-image option labels are not clickable on the platform.
-- Text inside the image should be concise and only serve as prompts.
-- After drawing, explain the content of the image in text.
-- When explaining, assume the user has not seen the image.
-- The image is responsible for structural prompting; the text is responsible for the full explanation.
-- Do not simply repeat the image content in text. Instead, add background, causality, examples, and usage explanations.
+# Slides
+- Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
+- Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
+- Text inside the slide should be concise and only serve as prompts.
+- After creating a slide, explain the content of the slide in text.
+- When explaining, assume the user has not seen the slide.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation.
+- Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
-- Do not generate too many fragmented elements. Keep the visual hierarchy simple.
+- Do not generate too many fragmented elements. Keep the slide hierarchy simple.
 ```
 
 ## Substitution Map
@@ -342,7 +357,7 @@ You specialize in production observability and are a professional teacher in the
 | `XXX learners` | `# Task` bullet 2 | `course_profile.audience_level` + `prerequisite_level`. |
 | `XXX problems` | `# Task` bullet 2 | `delivery_constraints.must_cover_topics`; cross-check with Segmentation segments. |
 
-`# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`, and `# Translation Rules` are constants — copy verbatim and adjust only when a course has a justified reason. Document any deviation in the course `README.md` so future updates know it is intentional.
+`# Teaching Techniques`, `# Writing Style`, `# Format`, `# Slides`, and `# Translation Rules` are constants — copy verbatim and adjust only when a course has a justified reason. Document any deviation in the course `README.md` so future updates know it is intentional.
 
 ## What Not to Put Here
 

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -270,11 +270,13 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 
 # Slides
 - Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
+- When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
 - Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
 - Text inside the slide should be concise and only serve as prompts.
-- After creating a slide, explain the content of the slide in text.
+- After creating a slide for a self-study or listening-mode course, explain the content of the slide in text.
 - When explaining, assume the user has not seen the slide.
-- The slide is responsible for structural prompting; the text is responsible for the full explanation.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation in self-study or listening-mode courses.
+- For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.
 - Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
 - Do not generate too many fragmented elements. Keep the slide hierarchy simple.
@@ -335,11 +337,13 @@ You specialize in production observability and are a professional teacher in the
 
 # Slides
 - Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
+- When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
 - Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
 - Text inside the slide should be concise and only serve as prompts.
-- After creating a slide, explain the content of the slide in text.
+- After creating a slide for a self-study or listening-mode course, explain the content of the slide in text.
 - When explaining, assume the user has not seen the slide.
-- The slide is responsible for structural prompting; the text is responsible for the full explanation.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation in self-study or listening-mode courses.
+- For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.
 - Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
 - Do not generate too many fragmented elements. Keep the slide hierarchy simple.

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -270,13 +270,11 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 
 # Slides
 - Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
-- When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
 - Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
 - Text inside the slide should be concise and only serve as prompts.
-- After creating a slide for a self-study or listening-mode course, explain the content of the slide in text.
+- After creating a slide, explain the content of the slide in text.
 - When explaining, assume the user has not seen the slide.
-- The slide is responsible for structural prompting; the text is responsible for the full explanation in self-study or listening-mode courses.
-- For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation.
 - Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
 - Do not generate too many fragmented elements. Keep the slide hierarchy simple.
@@ -337,13 +335,11 @@ You specialize in production observability and are a professional teacher in the
 
 # Slides
 - Only create slides when explicitly instructed to create a slide, PPT, visual page, or classroom projection page. Do not proactively create visuals.
-- When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
 - Do not put selectable options only inside the slide. Selection options must appear in the MarkdownFlow interaction line outside the slide; in-slide option labels are not clickable on the platform.
 - Text inside the slide should be concise and only serve as prompts.
-- After creating a slide for a self-study or listening-mode course, explain the content of the slide in text.
+- After creating a slide, explain the content of the slide in text.
 - When explaining, assume the user has not seen the slide.
-- The slide is responsible for structural prompting; the text is responsible for the full explanation in self-study or listening-mode courses.
-- For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.
+- The slide is responsible for structural prompting; the text is responsible for the full explanation.
 - Do not simply repeat the slide content in text. Instead, add background, causality, examples, and usage explanations.
 - All elements must be fully visible and must not overlap.
 - Do not generate too many fragmented elements. Keep the slide hierarchy simple.

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -85,7 +85,7 @@ Provide one of:
 1. `lesson_teaching_prompts` — one Teaching Prompt per lesson (written in MarkdownFlow). Instructional/directive language only (model-guiding), not a final learner manuscript. See [Lesson Schema](#lesson-schema).
 2. `course_index` — `lesson_id`, `lesson_title`, `core_question`, `source_span_map`.
 3. `global_variable_table` — see [Variable Table](#variable-table).
-4. `course_prompt` — markdown string (runnable AI-Shifu course-level system prompt) following [course-prompt.md](course-prompt.md). Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`. Conditional section: `# Translation Rules`.
+4. `course_prompt` — markdown string (runnable AI-Shifu course-level system prompt) following [course-prompt.md](course-prompt.md). Required sections: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Slides`. Conditional section: `# Translation Rules`.
 5. `course_description` — SEO/listing description written to `course-description.md`; describe the course topic, target learners, and learning outcomes in learner-facing language. Do not include author-side workflow notes.
 
 ### `course_index` Schema (array, required)
@@ -99,7 +99,7 @@ Each item:
 ### `course_prompt` (string, required)
 
 - Markdown string starting with `# Role`.
-- Six required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`.
+- Six required `# Section` blocks: `# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Slides`.
 - Conditional `# Translation Rules` section per [course-prompt.md](course-prompt.md) `## Conditional Sections`.
 - Single source of truth at the course level; do not embed per-lesson interaction logic.
 
@@ -138,7 +138,7 @@ Each item:
       "effect_scope": "cross_lesson"
     }
   ],
-  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Drawing\n- ...",
+  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The current course is *...*. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Slides\n- ...",
   "course_description": "A practical course that helps beginner operators diagnose metric drift, identify likely causes, and choose one concrete fix."
 }
 ```

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -132,7 +132,7 @@ In both forms the URL **must** come from the platform (`https://resource.ai-shif
 
 - The `===…===` wrapper is required. Without it the runtime model is free to rewrite, omit, or paraphrase the image (cf. *Preservation → Immutable Assets* below).
 - The alt text must describe **what information the image carries** (e.g. `gradient descent three-step diagram`), not `image1` / `figure`. The alt is also the fallback when the image fails to load.
-- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image.
+- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image. (See `course-prompt.md` *Rule 11 — Slide-Text Relationship*.)
 
 ### 3.2 HTML view image (instruction-style, not fixed output)
 

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -132,7 +132,7 @@ In both forms the URL **must** come from the platform (`https://resource.ai-shif
 
 - The `===…===` wrapper is required. Without it the runtime model is free to rewrite, omit, or paraphrase the image (cf. *Preservation → Immutable Assets* below).
 - The alt text must describe **what information the image carries** (e.g. `gradient descent three-step diagram`), not `image1` / `figure`. The alt is also the fallback when the image fails to load.
-- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image.
+- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image. (See `course-prompt.md` *Rule 11 — Image-Text Relationship*.)
 
 ### 3.2 HTML view image (instruction-style, not fixed output)
 

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -1,6 +1,6 @@
 # MarkdownFlow Spec
 
-MarkdownFlow is the **format** (a small DSL) used to author both **Teaching Prompts** (per-lesson, runtime teaching instructions) and **Course Prompts** (course-level AI persona / style / drawing rules). This file is the authoritative source for the format itself — syntax, runtime constraints, and preservation rules. Violating anything here makes the prompt fail to parse, reference an uncollected variable, or silently lose source content.
+MarkdownFlow is the **format** (a small DSL) used to author both **Teaching Prompts** (per-lesson, runtime teaching instructions) and **Course Prompts** (course-level AI persona / style / slide rules). This file is the authoritative source for the format itself — syntax, runtime constraints, and preservation rules. Violating anything here makes the prompt fail to parse, reference an uncollected variable, or silently lose source content.
 
 For pedagogical / quality-of-teaching constraints (which apply to Teaching Prompts), see [pedagogy.md](pedagogy.md). For Course Prompt structure and authoring rules, see [course-prompt.md](course-prompt.md).
 

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -132,7 +132,7 @@ In both forms the URL **must** come from the platform (`https://resource.ai-shif
 
 - The `===…===` wrapper is required. Without it the runtime model is free to rewrite, omit, or paraphrase the image (cf. *Preservation → Immutable Assets* below).
 - The alt text must describe **what information the image carries** (e.g. `gradient descent three-step diagram`), not `image1` / `figure`. The alt is also the fallback when the image fails to load.
-- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image. (See `course-prompt.md` *Rule 11 — Image-Text Relationship*.)
+- Follow the image with a paragraph of explanatory text. The text must not merely restate the image; it must add context, causality, examples, or usage. Assume the reader cannot see the image.
 
 ### 3.2 HTML view image (instruction-style, not fixed output)
 

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -168,8 +168,8 @@ These are the *teaching* rules around interactions. For interaction *syntax* see
 
 ## Visual-Text Coordination
 
-- If a visual is needed, describe it in natural language (e.g., "Show an image that …").
+- If a visual is needed, describe it in natural language as a slide or visual page (e.g., "Create a slide that …").
 - Pair every visual instruction with a brief explanation of what the visual is meant to convey.
 - Do not embed raw SVG/HTML/Mermaid/PlantUML/Graphviz markup inside Teaching Prompts unless the user explicitly asks for that format.
-- Default to natural-language image/diagram placeholders.
+- Default to natural-language slide/diagram placeholders.
 - Every core concept needs visual + textual explanation together; the visual carries structural prompting, the text carries the full explanation (assume the learner has not seen the image).

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -172,4 +172,4 @@ These are the *teaching* rules around interactions. For interaction *syntax* see
 - Pair every visual instruction with a brief explanation of what the visual is meant to convey.
 - Do not embed raw SVG/HTML/Mermaid/PlantUML/Graphviz markup inside Teaching Prompts unless the user explicitly asks for that format.
 - Default to natural-language slide/diagram placeholders.
-- Every core concept needs visual + textual explanation together; the visual carries structural prompting, the text carries the full explanation (assume the learner has not seen the image).
+- Every core concept needs visual + textual explanation together; the visual carries structural prompting, the text carries the full explanation (assume the learner has not seen the slide).

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -72,5 +72,5 @@ Optimization 全面审计清单 — Optimization Optimization 必须把每条都
 ## Course Prompt
 
 - A `course_prompt` artifact is produced when input includes course material.
-- All six required sections present (`# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Drawing`).
+- All six required sections present (`# Role`, `# Task`, `# Teaching Techniques`, `# Writing Style`, `# Format`, `# Slides`).
 - `# Translation Rules` included when (and only when) trigger condition applies.


### PR DESCRIPTION
## Summary
- Rename the course prompt visual section from `# Drawing` to `# Slides`.
- Update AI-Shifu course creator rules to produce slide/visual-page instructions instead of standalone drawing instructions.
- Sync data contracts, review checklist, and examples with the new section name.

## Validation
- `python3 scripts/validate_skill_quality.py`
- `git diff --check`
- `rg -n "# Drawing|Drawing|drawing|draw|draws|image-generation|画图|绘图" skills/ai-shifu-course-creator -S` (no matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated course-authoring requirements to use a required **`# Slides`** section instead of **`# Drawing`**.
  * Refined guidance for slide-style visual covers, lesson generation, and slide/visual placement alongside explanatory text.
  * Updated related references, course-prompt contract language, templates, examples, and the review checklist to align with **Slides**, including the commonly under-filled section guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->