### PR TITLE
fix: add lesson to translation glossary

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -62,6 +62,7 @@ Use this table for human-facing skill concept labels in user-visible prose, repo
 | Canonical term | en-US | zh-CN | Usage |
 |---|---|---|---|
 | `AI-Shifu` | AI-Shifu | AI 师傅 | Product name in human-facing prose. |
+| `Lesson` | Lesson | 节 / 课节 | Course lesson unit in human-facing prose. |
 | `Teaching Prompt` | Teaching Prompt | 授课提示词 | Per-lesson prompt artifact. |
 | `Course Prompt` | Course Prompt | 课程提示词 | Course-level prompt artifact. |
 


### PR DESCRIPTION
## Summary

- Add `Lesson` to the AI-Shifu Course Creator canonical term translation table.
- Document the zh-CN translation as `节 / 课节` for human-facing prose.

## Validation

- `git diff --check`
- `python3 scripts/validate_skill_quality.py skills/ai-shifu-course-creator`
