### PR TITLE
fix: align AI-Shifu skill terminology

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -59,12 +59,15 @@ Field-level schemas with example JSON in `references/data-contracts.md#recommend
 
 Use this table for human-facing skill concept labels in user-visible prose, reports, artifact labels, and handoff instructions. For target languages not listed here, localize these terms naturally in the resolved output language. Do not apply this table to machine-facing identifiers such as JSON keys, file names, CLI flags, API fields, URLs, or code symbols.
 
-| Canonical term | en-US | zh-CN | Usage |
-|---|---|---|---|
-| `AI-Shifu` | AI-Shifu | AI 师傅 | Product name in human-facing prose. |
-| `Lesson` | Lesson | 节 / 课节 | Course lesson unit in human-facing prose. |
-| `Teaching Prompt` | Teaching Prompt | 授课提示词 | Per-lesson prompt artifact. |
-| `Course Prompt` | Course Prompt | 课程提示词 | Course-level prompt artifact. |
+| Canonical term | en-US | zh-CN | fr-FR | Usage |
+|---|---|---|---|---|
+| `AI-Shifu` | AI-Shifu | AI 师傅 | AI Shifu | Product name in human-facing prose. |
+| `Lesson` | Lesson | 节 / 课节 | Leçon | Course lesson unit in human-facing prose. |
+| `Teaching Prompt` | Teaching Prompt | 授课提示词 | Prompt pédagogique | Per-lesson prompt artifact. Use plural naturally when needed. |
+| `Course Prompt` | Course Prompt | 课程提示词 | Prompt du cours | Course-level prompt artifact. |
+| `Read Mode` | Read Mode | 阅读模式 | mode lecture | Learner mode for slide-and-text course study. |
+| `Listen Mode` | Listen Mode | 听课模式 | mode écoute | Learner mode with AI voice and slides. |
+| `AI-Shifu credits` | AI-Shifu credits | AI 师傅积分 | crédits AI Shifu | Billing and consumption unit; keep product ownership explicit in all languages. |
 
 ## Data & Statistics Routing (read this before answering any "numbers" question)
 
@@ -167,12 +170,12 @@ items; do not repeat questions whose answers are already clear.
 
 When any item is missing, ask only the corresponding questions for the missing
 items in the user's language. Resolve the usage scenario first; ask the
-listening-mode question only after the usage scenario or inferred format shows
+Listen Mode question only after the usage scenario or inferred format shows
 the course is not slide-only.
 
 Do not bypass this intake by inventing "conservative defaults" from a sparse
 topic or short brief. In particular, do not assume personalized AI self-study,
-thinking/self-check interactions, disabled listening mode, or a fixed chapter /
+thinking/self-check interactions, disabled Listen Mode, or a fixed chapter /
 lesson count before asking the relevant missing questions. Defaults below apply
 only after the user explicitly skips a question or asks you to continue without
 answering it.
@@ -223,11 +226,11 @@ Use the answers as course-design constraints:
   do not proactively design interaction blocks; during Orchestration, bypass
   interaction-specific pedagogical gates that require an interaction step or a
   deepening interaction.
-- If the resolved format is pure slides, disable listening mode and do not ask
-  the listening-mode question. Otherwise, the listening-mode question must
-  mention the extra AI-Shifu credit consumption, and listening mode is disabled
-  when unanswered; when explicitly enabled or disabled, carry that decision into
-  the deployment handoff.
+- If the resolved format is pure slides, disable Listen Mode and do not ask
+  the Listen Mode question. Otherwise, the Listen Mode question must mention the
+  extra AI-Shifu credit consumption, and Listen Mode is disabled when unanswered;
+  when explicitly enabled or disabled, carry that decision into the deployment
+  handoff.
 - Chapter and lesson counts constrain the outline. If the user explicitly skips
   this question, infer structure from source volume and existing
   lesson-granularity rules instead of inventing a fixed default.
@@ -248,7 +251,7 @@ Raw material
    │
    ▼
 Course Design Intake                     ← ask only for missing design constraints
-   │   (usage scenario, interaction purpose, listening mode, chapter/lesson count)
+   │   (usage scenario, interaction purpose, Listen Mode, chapter/lesson count)
    ▼
 Orchestration                            ← end-to-end driver
    ├── calls Segmentation                 (cleanup + semantic segmentation)
@@ -535,7 +538,7 @@ never resets attributes. `pull` writes the current attributes into
 reference** for you. Change attributes only when the user explicitly asks:
 `set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--course-dir <dir>]`
 for a lesson's permission; `set-tts <shifu_bid> --enabled true|false [--course-dir <dir>]`
-for course listening mode. Other course-level settings are changed in the
+for course Listen Mode. Other course-level settings are changed in the
 platform editor.
 
 **Editing an existing course → use granular non-destructive commands**

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -65,9 +65,9 @@ Use this table for human-facing skill concept labels in user-visible prose, repo
 | `Lesson` | Lesson | 节 / 课节 | Leçon | Course lesson unit in human-facing prose. |
 | `Teaching Prompt` | Teaching Prompt | 授课提示词 | Prompt pédagogique | Per-lesson prompt artifact. Use plural naturally when needed. |
 | `Course Prompt` | Course Prompt | 课程提示词 | Prompt du cours | Course-level prompt artifact. |
-| `Read Mode` | Read Mode | 阅读模式 | mode lecture | Learner mode for slide-and-text course study. |
-| `Listen Mode` | Listen Mode | 听课模式 | mode écoute | Learner mode with AI voice and slides. |
-| `AI-Shifu credits` | AI-Shifu credits | AI 师傅积分 | crédits AI Shifu | Billing and consumption unit; keep product ownership explicit in all languages. |
+| `Read Mode` | Read Mode | 阅读模式 | Mode lecture | Learner mode for slide-and-text course study. |
+| `Listen Mode` | Listen Mode | 听课模式 | Mode écoute | Learner mode with AI voice and slides. |
+| `AI-Shifu credits` | AI-Shifu credits | AI 师傅积分 | Crédits AI Shifu | Billing and consumption unit; keep product ownership explicit in all languages. |
 
 ## Data & Statistics Routing (read this before answering any "numbers" question)
 

--- a/skills/ai-shifu-course-creator/references/analytics/recipes.md
+++ b/skills/ai-shifu-course-creator/references/analytics/recipes.md
@@ -239,13 +239,13 @@ python3 scripts/shifu-cli.py credit-detail <bid> --scene 1203
 
 `--scene` accepts a comma-separated subset of `{1201, 1202, 1203}` (debug / preview / production). Combine with `--start` / `--end` to scope a window.
 
-### Recipe 11 — Slide-and-text only vs audio only
+### Recipe 11 — LLM-only vs TTS-only
 
 ```bash
-# Slide-and-text only
+# LLM only
 python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1101
 
-# Audio only
+# TTS only
 python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1102
 ```
 

--- a/skills/ai-shifu-course-creator/references/analytics/recipes.md
+++ b/skills/ai-shifu-course-creator/references/analytics/recipes.md
@@ -239,13 +239,13 @@ python3 scripts/shifu-cli.py credit-detail <bid> --scene 1203
 
 `--scene` accepts a comma-separated subset of `{1201, 1202, 1203}` (debug / preview / production). Combine with `--start` / `--end` to scope a window.
 
-### Recipe 11 — LLM-only vs TTS-only
+### Recipe 11 — Slide-and-text only vs audio only
 
 ```bash
-# LLM only
+# Slide-and-text only
 python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1101
 
-# TTS only
+# Audio only
 python3 scripts/shifu-cli.py credit-detail <bid> --usage-type 1102
 ```
 

--- a/skills/ai-shifu-course-creator/references/analytics/tables.md
+++ b/skills/ai-shifu-course-creator/references/analytics/tables.md
@@ -8,7 +8,7 @@ The 10 tables you can query, the fields each carries, the code/enum tables to tr
 |---|---|---|
 | `learn_progress_records` | Learner count / completion rate / stuck lesson / recent activity / **lessons completed per learner** | `user_bid`, `outline_item_bid`, `status` (601-608, see code table), `created_at` |
 | `learn_generated_blocks` | Content interaction count / likes / type popularity / **interactions per learner** / **follow-up Q&A replay** | `user_bid`, `progress_record_bid`, `outline_item_bid`, `type` (see code table), `role` (1 teacher/AI · 2 learner · 3 UI, **integer**), `status` (1 active / 0 history — **API auto-filters to 1**), `position` (block ordering within a `progress_record_bid`), `liked` (-1/0/1), `generated_content` (raw text, restricted — see `dsl.md`) |
-| `learn_lesson_feedbacks` | Lesson ratings / read-vs-listen mode preference / **avg rating per learner** | `user_bid`, `progress_record_bid`, `mode` (read/listen), `score` (1-5) |
+| `learn_lesson_feedbacks` | Lesson ratings / Read Mode vs Listen Mode preference / **avg rating per learner** | `user_bid`, `progress_record_bid`, `mode` (read/listen), `score` (1-5) |
 | `order_orders` | Enrolments / revenue / channel distribution / refund rate / **total spend per learner** | `user_bid`, `status` (501-505, see code table; **paid** = `502`), `payment_channel` (pingxx/stripe/alipay/wechatpay/…), `paid_price` |
 | `var_variable_values` | Learner profile distribution (goals / level / preferences) | `user_bid`, `variable_bid`, `value` (aggregate only — **do not select raw value**; see `privacy-and-presentation.md`) |
 | `shifu_user_archives` | Active learner count / archive rate | `user_bid`, `archived` (0 active / 1 archived) |
@@ -140,7 +140,7 @@ Completion rate counts `status = 603` only. "Participating learners" = `status >
 | `1102` | TTS speech synthesis |
 
 > **Common misclassification**: `usage_type = 1102` (TTS) has nothing to do with learner follow-up questions.
-> Follow-ups trigger LLM calls (`usage_type = 1101`); TTS is for AI-narrated audio (triggered when learners switch to listen mode). They are independent paths.
+> Follow-ups trigger LLM calls (`usage_type = 1101`); TTS records Listen Mode audio generation. They are independent paths.
 > To measure follow-up question volume, query `learn_generated_blocks(type = 321)`.
 
 ## `bill_daily_usage_metrics.usage_scene`

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -191,7 +191,7 @@ resets the lesson's learning permission.
 lesson's other fields untouched. With `--course-dir` it also writes the value
 into the `structure.json` reference.
 
-`set-tts` enables or disables course listening mode without re-importing; it
+`set-tts` enables or disables course Listen Mode without re-importing; it
 sends only `tts_enabled` and leaves provider/model/voice/speed/pitch/emotion
 unchanged. With `--course-dir` it refreshes `course-config.json` and records the
 new course revision in `.shifu-sync.json`.
@@ -253,7 +253,7 @@ touch attributes.
 `pull` still writes the attributes into `structure.json` (`access`/`hidden`) and
 `course-config.json` as a **read-only reference** for the agent. To change an
 attribute, do it explicitly: `set-access` for a lesson's permission, `set-tts`
-for course listening mode, or the platform editor for other course-level
+for course Listen Mode, or the platform editor for other course-level
 settings.
 
 > **Iterating an existing course:** prefer the non-destructive granular commands

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -183,6 +183,6 @@ refreshes this snapshot after changing `tts_enabled`. It still does not make
 To change a single lesson's permission, use
 `shifu-cli.py set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--hidden true|false] [--course-dir <dir>]`
 (passing `--course-dir` also updates the `structure.json` reference). To change
-course listening mode, use
+course Listen Mode, use
 `shifu-cli.py set-tts <shifu_bid> --enabled true|false [--course-dir <dir>]`.
 Other course-level attributes are changed in the platform editor.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1399,9 +1399,9 @@ def cmd_update_meta(args):
             })
 
 
-# ── Set TTS ───────────────────────────────────────────────────────────────────
+# ── Set Listen Mode ────────────────────────────────────────────────────────────
 def cmd_set_tts(args):
-    """Enable or disable course listening mode without changing other attributes."""
+    """Enable or disable course Listen Mode without changing other attributes."""
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
     enabled = args.enabled == "true"
@@ -1412,11 +1412,11 @@ def cmd_set_tts(args):
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
                                 intended)
 
-    # Send only the TTS switch. Provider/model/voice/speed/pitch/emotion remain
+    # Send only the Listen Mode switch. Provider/model/voice/speed/pitch/emotion remain
     # whatever the platform currently stores.
     api(base_url, token, "post", f"/shifus/{shifu_bid}/detail",
         json={"tts_enabled": enabled})
-    print(f"Set course {shifu_bid} TTS -> "
+    print(f"Set course {shifu_bid} Listen Mode -> "
           f"{'enabled' if enabled else 'disabled'}")
 
     if manifest and manifest.get("shifu_bid") == shifu_bid:
@@ -2611,10 +2611,10 @@ def build_parser():
 
     # ── set-tts ──
     p = sub.add_parser("set-tts", parents=[parent_parser],
-                       help="Enable or disable course listening mode (TTS)")
+                       help="Enable or disable course Listen Mode")
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--enabled", required=True, choices=["true", "false"],
-                   help="true=enable listening mode, false=disable it")
+                   help="true=enable Listen Mode, false=disable it")
     p.add_argument("--course-dir", default=None,
                    help=f"Also refresh local {COURSE_CONFIG_NAME} and sync manifest")
 
@@ -2716,7 +2716,7 @@ def build_parser():
                         "(1201 debug / 1202 preview / 1203 production)")
     p.add_argument("--usage-type", dest="usage_type",
                    help="Comma-separated usage_type codes, e.g. 1101,1102 "
-                        "(1101 LLM / 1102 TTS)")
+                        "(1101 slide-and-text / 1102 audio)")
     p.add_argument("--limit", type=int, default=None,
                    help="Row count cap, 1..1000 (default 100 server-side)")
     p.add_argument("--offset", type=int, default=None,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2716,7 +2716,7 @@ def build_parser():
                         "(1201 debug / 1202 preview / 1203 production)")
     p.add_argument("--usage-type", dest="usage_type",
                    help="Comma-separated usage_type codes, e.g. 1101,1102 "
-                        "(1101 slide-and-text / 1102 audio)")
+                        "(1101 LLM / 1102 TTS)")
     p.add_argument("--limit", type=int, default=None,
                    help="Row count cap, 1..1000 (default 100 server-side)")
     p.add_argument("--offset", type=int, default=None,


### PR DESCRIPTION
## Summary
- Add AI-Shifu course creator glossary entries for the terms used by the skill, including Listen Mode and AI-Shifu credits.
- Align user-facing Listen Mode and audio wording across the skill docs, analytics recipes, CLI reference, and CLI help.
- Keep technical TTS terminology only in lower-level usage type and attribute contexts.

## Validation
- `python3 scripts/validate_skill_quality.py`
- `python3 -m compileall skills/ai-shifu-course-creator/scripts/shifu-cli.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Listen Mode guidance across course design, deployment, and CLI references.
  * Updated credit usage examples and labels to distinguish slide/text-only and audio-only flows.
  * Improved analytics documentation wording for usage types and learner feedback metrics.
  * Standardized terminology and capitalization for Listen Mode throughout the docs and command help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->