### PR TITLE
fix: standardize listen mode terminology

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -194,8 +194,8 @@ flow is complete.
    learner context for adaptive teaching; ask before teaching to trigger
    thinking or break old assumptions; self-check learning effect at the end of
    each lesson. Choosing none means no interactions.
-3. If the course is not slide-only, should listening mode be enabled so AI voice
-   teaches the course? When asking, also state that listening mode consumes more
+3. If the course is not slide-only, should Listen Mode be enabled so AI voice
+   teaches the course? When asking, also state that Listen Mode consumes more
    AI-Shifu credits. If the user does not answer, default to disabled.
 4. How many chapters and lessons should the course have?
 

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -165,7 +165,7 @@ content never resets model/price/TTS/Ask. The course **name** lives in
 `README.md`, the SEO **description** in `course-description.md`, and the
 **system prompt** in `course-prompt.md`.
 
-The exception is an explicit listening-mode update: `set-tts --course-dir`
+The exception is an explicit Listen Mode update: `set-tts --course-dir`
 refreshes this snapshot after changing `tts_enabled`. It still does not make
 `build` or `import` push course-level attributes.
 

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -178,7 +178,7 @@ Must specify:
 - When a visual is requested, create a presentation-style slide page rather than a standalone illustration.
 - Selectable options must never appear only inside the slide. Choice options live in the MarkdownFlow `?[%{{var}} A | B | C]` line outside the slide; in-slide option labels are not interactive on the platform.
 - In-slide text is concise and prompt-like.
-- After creating a slide for a self-study or listening-mode course, explain the slide in text.
+- After creating a slide for a self-study or Listen Mode course, explain the slide in text.
 - Element layout rules (fully visible, no overlap, simple hierarchy).
 
 ### Rule 11 — Slide-Text Relationship
@@ -187,7 +187,7 @@ Maps to: Slides section (required, last bullets).
 
 Must state:
 
-- Slide gives structural prompt; text carries the full explanation in self-study or listening-mode courses.
+- Slide gives structural prompt; text carries the full explanation in self-study or Listen Mode courses.
 - Text must assume the user has not seen the slide.
 - Text must add background, causality, examples, usage — not mechanically repeat the slide.
 - For pure classroom-slide courses, keep the slide self-contained and avoid extra AI narration unless the Teaching Prompt explicitly asks for presenter notes.


### PR DESCRIPTION
## Summary
- Normalize remaining AI-Shifu docs references from listening mode/listening-mode to Listen Mode.
- Keep the change scoped to terminology only.

## Validation
- python3 scripts/validate_skill_quality.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology to use **“Listen Mode”** consistently across course-creation guidance and related references.
  * Clarified that **Listen Mode uses more AI-Shifu credits** when users choose it.
  * Updated course configuration guidance to reflect the latest **Listen Mode** update wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->