### PR TITLE
chore: clarify skill commit requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@
 - Subject: use English Conventional Commits without scope parentheses, such as
   `type: summary`; do not use `type(scope): summary`.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
-- Classification: use `chore` for repository-maintenance-only instructions or
-  generated guidance updates like this file.
+- Classification: use `chore` for repository-maintenance-only instructions,
+  generated guidance updates like this file, or non-behavioral skill
+  maintenance.
 - Skill content changes affect skill behavior and capability: inside a skill
   directory, only changes limited to existing `README*` files count as
   documentation-only. Changes to `SKILL.md` (including its frontmatter),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@
 - Classification: use `chore` for repository-maintenance-only instructions,
   guidance updates like this file, or non-behavioral skill maintenance.
 - Skill content changes affect skill behavior and capability: inside a skill
-  directory, only changes limited to existing `README*` files count as
-  documentation-only. Changes to `SKILL.md` (including its frontmatter),
-  references, prompts, templates, examples, scripts, or other skill assets must
-  use `feat` when adding capability and `fix` when correcting behavior; do not
-  use `docs`.
+  directory, only changes limited to intentionally present `README*` files
+  count as documentation-only. Changes to `SKILL.md` (including its
+  frontmatter), references, prompts, templates, examples, scripts, or other
+  skill assets must use `feat` when adding capability and `fix` when correcting
+  behavior; do not use `docs`.
 
 Example:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,6 @@
 
 ## Git Commit Message Requirements
 
-All git commit message requirements live in this section. Other docs and
-agent-specific rule files may point here for title, body, and classification
-rules, but must not duplicate or redefine them.
-
-- Human-authored and coding-agent-authored commit messages must follow the
-  policy below. Existing workflow-generated bot commits are exempt unless the
-  workflow is being updated for this policy.
-- The local `commit-msg` hook is only a baseline Conventional Commits syntax
-  check. It does not enforce the `Changed:` / `Benefit:` body or the
-  classification rules below.
 - Subject: use English Conventional Commits without scope parentheses, such as
   `type: summary`; do not use `type(scope): summary`.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,39 @@
 # Repository Instructions
 
-## Git Commit Rule
+## Git Commit Message Requirements
 
-- Git commit messages must use Conventional Commits style, such as `feat:` and `fix:`.
+All git commit message requirements live in this section. Other docs and
+agent-specific rule files may point here for title, body, and classification
+rules, but must not duplicate or redefine them.
+
+- Human-authored and coding-agent-authored commit messages must follow the
+  policy below. Existing workflow-generated bot commits are exempt unless the
+  workflow is being updated for this policy.
+- The local `commit-msg` hook is only a baseline Conventional Commits syntax
+  check. It does not enforce the `Changed:` / `Benefit:` body or the
+  classification rules below.
+- Subject: use English Conventional Commits without scope parentheses, such as
+  `type: summary`; do not use `type(scope): summary`.
+- Body: include exactly two sections, `Changed:` and `Benefit:`.
+- Classification: use `chore` for repository-maintenance-only instruction or
+  generated guidance updates like this file.
+- Skill content changes affect skill behavior and capability: inside a skill
+  directory, only `README*` files count as documentation-only surfaces. Changes
+  to `SKILL.md`, frontmatter other than README metadata, references, prompts,
+  templates, examples, scripts, or other skill assets must use `feat` when
+  adding capability and `fix` when correcting behavior; do not use `docs`.
+
+Example:
+
+```text
+chore: centralize commit message requirements
+
+Changed:
+Moved repository commit message requirements into the root AGENTS.md file.
+
+Benefit:
+Contributors have one place to check the required commit title and body format.
+```
 
 ## Skill Content Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@
 - Classification: use `chore` for repository-maintenance-only instructions or
   generated guidance updates like this file.
 - Skill content changes affect skill behavior and capability: inside a skill
-  directory, only `README*` files count as documentation-only surfaces. Changes
-  to `SKILL.md` (including its frontmatter), references, prompts,
-  templates, examples, scripts, or other skill assets must use `feat` when
-  adding capability and `fix` when correcting behavior; do not use `docs`.
+  directory, only changes limited to existing `README*` files count as
+  documentation-only. Changes to `SKILL.md` (including its frontmatter),
+  references, prompts, templates, examples, scripts, or other skill assets must
+  use `feat` when adding capability and `fix` when correcting behavior; do not
+  use `docs`.
 
 Example:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@
 - Subject: use English Conventional Commits without scope parentheses, such as
   `type: summary`; do not use `type(scope): summary`.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
-- Classification: use `chore` for repository-maintenance-only instruction or
+- Classification: use `chore` for repository-maintenance-only instructions or
   generated guidance updates like this file.
 - Skill content changes affect skill behavior and capability: inside a skill
   directory, only `README*` files count as documentation-only surfaces. Changes
-  to `SKILL.md`, frontmatter other than README metadata, references, prompts,
+  to `SKILL.md` (including its frontmatter), references, prompts,
   templates, examples, scripts, or other skill assets must use `feat` when
   adding capability and `fix` when correcting behavior; do not use `docs`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@
   `type: summary`; do not use `type(scope): summary`.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
 - Classification: use `chore` for repository-maintenance-only instructions,
-  generated guidance updates like this file, or non-behavioral skill
-  maintenance.
+  guidance updates like this file, or non-behavioral skill maintenance.
 - Skill content changes affect skill behavior and capability: inside a skill
   directory, only changes limited to existing `README*` files count as
   documentation-only. Changes to `SKILL.md` (including its frontmatter),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Repository Instructions
-
-Claude-specific repository instructions live in @AGENTS.md.
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
-AGENTS.md
+# Repository Instructions
+
+Claude-specific repository instructions live in [AGENTS.md](./AGENTS.md).
+Follow that file for git commit message requirements, classification rules,
+and skill content rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,3 @@
 # Repository Instructions
 
-Claude-specific repository instructions live in [AGENTS.md](./AGENTS.md).
-Follow that file for git commit message requirements, classification rules,
-and skill content rules.
+Claude-specific repository instructions live in @AGENTS.md.


### PR DESCRIPTION
## Changed

- Expanded `AGENTS.md` with the full commit message title/body requirements copied from `ai-shifu`.
- Clarified this repository-specific classification rule: skill content outside `README*` files affects skill behavior/capability and should not be treated as docs-only.

## Benefit

- Contributors and coding agents can choose `feat`, `fix`, or `chore` consistently for skill changes.
- Non-README skill content changes are no longer mislabeled as documentation-only updates.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `git diff --check`