### PR TITLE
fix: align set-tts with platform defaults

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -193,7 +193,7 @@ update-lesson <shifu_bid> <outline_bid> --teaching-prompt-file lesson.md [--cour
 rename-lesson <shifu_bid> <outline_bid> --name "New Name"
 reorder <shifu_bid> --order bid1,bid2,bid3
 set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--hidden true|false] [--course-dir ./course-a/]
-set-tts <shifu_bid> --enabled true|false [--course-dir ./course-a/]
+set-tts <shifu_bid> --enabled true|false [--speed SPEED] [--course-dir ./course-a/]
 ```
 
 `update-meta` sends only the content fields you pass (`--name` / `--description`
@@ -211,10 +211,15 @@ resets the lesson's learning permission.
 lesson's other fields untouched. With `--course-dir` it also writes the value
 into the `structure.json` reference.
 
-`set-tts` enables or disables course Listen Mode without re-importing; it
-sends only `tts_enabled` and leaves provider/model/voice/speed/pitch/emotion
-unchanged. With `--course-dir` it refreshes `course-config.json` and records the
-new course revision in `.shifu-sync.json`.
+`set-tts` enables or disables course Listen Mode without re-importing. Disabling
+sends only `tts_enabled=false` and leaves the stored provider/model/voice/speed
+unchanged. Enabling sends the full TTS settings the backend validates:
+`tts_enabled=true`, `tts_provider`, `tts_model`, `tts_voice_id`, `tts_speed`,
+plus normalized `tts_pitch=0` and `tts_emotion=""`. Provider, model, voice, and
+default speed come from platform defaults at `/tts/config` (the same fallback
+used by the AI-Shifu settings page); `--speed` is the only optional override.
+With `--course-dir` it refreshes `course-config.json` and records the new course
+revision in `.shifu-sync.json`.
 
 `update-lesson`, `update-meta`, and `set-tts` are version-aware when given `--course-dir`
 (a directory with a `.shifu-sync.json` from `pull`):

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -165,13 +165,13 @@ Ask / keywords / …), written by `pull` so the agent can see the current settin
 The course **name** lives in `README.md`, the SEO **description** in
 `course-description.md`, and the **system prompt** in `course-prompt.md`.
 The one exception: `set-tts --course-dir` refreshes this snapshot after changing
-`tts_enabled`.
+Listen Mode or its TTS provider/model/voice/speed settings.
 
 ```json
 {
   "model": "", "temperature": 0.3, "price": 0, "keywords": [], "avatar": "",
   "use_learner_language": false,
-  "tts_enabled": false, "tts_provider": "minimax", "tts_model": "", "tts_voice_id": "",
+  "tts_enabled": false, "tts_provider": "", "tts_model": "", "tts_voice_id": "",
   "tts_speed": 1.0, "tts_pitch": 0, "tts_emotion": "",
   "ask_enabled_status": 5101, "ask_model": "", "ask_temperature": 0.0,
   "ask_system_prompt": "", "ask_provider_config": {}

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1407,9 +1407,13 @@ def _tts_config_dict(tts_config):
     return tts_config if isinstance(tts_config, dict) else {}
 
 
+def _tts_list(value):
+    return value if isinstance(value, list) else []
+
+
 def _tts_providers_by_name(tts_config):
     providers = {}
-    for item in _tts_config_dict(tts_config).get("providers") or []:
+    for item in _tts_list(_tts_config_dict(tts_config).get("providers")):
         if not isinstance(item, dict):
             continue
         name = _tts_provider_name(item.get("name"))
@@ -1420,7 +1424,7 @@ def _tts_providers_by_name(tts_config):
 
 def _tts_model_options(tts_config):
     options = []
-    for item in _tts_config_dict(tts_config).get("model_options") or []:
+    for item in _tts_list(_tts_config_dict(tts_config).get("model_options")):
         if not isinstance(item, dict):
             continue
         provider = _tts_provider_name(item.get("provider"))
@@ -1456,18 +1460,15 @@ def _select_platform_tts_defaults(speed, tts_config):
         model = _string_tts_value(default_model_option.get("model"))
     elif providers:
         provider = next(iter(providers))
-        models = providers[provider].get("models")
-        if isinstance(models, list):
-            for item in models:
-                if isinstance(item, dict):
-                    model = _string_tts_value(item.get("value"))
-                    if model:
-                        break
+        for item in _tts_list(providers[provider].get("models")):
+            if isinstance(item, dict):
+                model = _string_tts_value(item.get("value"))
+                if model:
+                    break
 
     provider_config = providers.get(provider) or {}
-    raw_voices = provider_config.get("voices")
     voices = [
-        v for v in (raw_voices if isinstance(raw_voices, list) else [])
+        v for v in _tts_list(provider_config.get("voices"))
         if isinstance(v, dict) and _string_tts_value(v.get("value"))
     ]
     selectable_voices = _filter_tts_voices_for_model(provider, voices, model)

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1403,9 +1403,13 @@ def _tts_provider_name(value):
     return _string_tts_value(value).lower()
 
 
+def _tts_config_dict(tts_config):
+    return tts_config if isinstance(tts_config, dict) else {}
+
+
 def _tts_providers_by_name(tts_config):
     providers = {}
-    for item in (tts_config or {}).get("providers") or []:
+    for item in _tts_config_dict(tts_config).get("providers") or []:
         if not isinstance(item, dict):
             continue
         name = _tts_provider_name(item.get("name"))
@@ -1416,7 +1420,7 @@ def _tts_providers_by_name(tts_config):
 
 def _tts_model_options(tts_config):
     options = []
-    for item in (tts_config or {}).get("model_options") or []:
+    for item in _tts_config_dict(tts_config).get("model_options") or []:
         if not isinstance(item, dict):
             continue
         provider = _tts_provider_name(item.get("provider"))
@@ -1452,13 +1456,18 @@ def _select_platform_tts_defaults(speed, tts_config):
         model = _string_tts_value(default_model_option.get("model"))
     elif providers:
         provider = next(iter(providers))
-        models = providers[provider].get("models") or []
-        if models:
-            model = _string_tts_value(models[0].get("value"))
+        models = providers[provider].get("models")
+        if isinstance(models, list):
+            for item in models:
+                if isinstance(item, dict):
+                    model = _string_tts_value(item.get("value"))
+                    if model:
+                        break
 
     provider_config = providers.get(provider) or {}
+    raw_voices = provider_config.get("voices")
     voices = [
-        v for v in (provider_config.get("voices") or [])
+        v for v in (raw_voices if isinstance(raw_voices, list) else [])
         if isinstance(v, dict) and _string_tts_value(v.get("value"))
     ]
     selectable_voices = _filter_tts_voices_for_model(provider, voices, model)

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -5,6 +5,7 @@ import argparse
 import base64
 import hashlib
 import json
+import math
 import os
 import shutil
 import sys
@@ -1446,6 +1447,15 @@ def _filter_tts_voices_for_model(provider, voices, model):
     ]
 
 
+def _first_tts_model(provider_config):
+    for item in _tts_list((provider_config or {}).get("models")):
+        if isinstance(item, dict):
+            model = _string_tts_value(item.get("value"))
+            if model:
+                return model
+    return ""
+
+
 def _select_platform_tts_defaults(speed, tts_config):
     """Mirror the platform editor's default provider/model/voice selection."""
     providers = _tts_providers_by_name(tts_config)
@@ -1458,13 +1468,11 @@ def _select_platform_tts_defaults(speed, tts_config):
         provider = _tts_provider_name(default_model_option.get("provider"))
         # `value` is the UI select key; `model` is the API payload value.
         model = _string_tts_value(default_model_option.get("model"))
+        if not model:
+            model = _first_tts_model(providers.get(provider) or {})
     elif providers:
         provider = next(iter(providers))
-        for item in _tts_list(providers[provider].get("models")):
-            if isinstance(item, dict):
-                model = _string_tts_value(item.get("value"))
-                if model:
-                    break
+        model = _first_tts_model(providers[provider])
 
     provider_config = providers.get(provider) or {}
     voices = [
@@ -1500,6 +1508,8 @@ def _build_set_tts_payload(args, tts_config=None):
         speed = 1.0
     try:
         speed = float(speed)
+        if not math.isfinite(speed):
+            raise ValueError
     except (TypeError, ValueError):
         print(f"Error: invalid TTS speed: {speed!r}")
         sys.exit(1)
@@ -1508,7 +1518,7 @@ def _build_set_tts_payload(args, tts_config=None):
     if not provider:
         missing.append("tts_provider")
     provider_config = _tts_providers_by_name(tts_config or {}).get(provider) or {}
-    if provider_config.get("models") and not model:
+    if _tts_list(provider_config.get("models")) and not model:
         missing.append("tts_model")
     if not voice_id:
         missing.append("tts_voice_id")
@@ -1536,7 +1546,9 @@ def cmd_set_tts(args):
     course_dir = getattr(args, "course_dir", None)
 
     manifest = _load_sync(course_dir) if course_dir else None
-    tts_config = api_safe(base_url, token, "get", "/tts/config") or {}
+    tts_config = {}
+    if args.enabled == "true":
+        tts_config = api_safe(base_url, token, "get", "/tts/config") or {}
     payload = _build_set_tts_payload(args, tts_config)
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
                                 payload)

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1448,6 +1448,7 @@ def _select_platform_tts_defaults(speed, tts_config):
 
     if default_model_option:
         provider = _tts_provider_name(default_model_option.get("provider"))
+        # `value` is the UI select key; `model` is the API payload value.
         model = _string_tts_value(default_model_option.get("model"))
     elif providers:
         provider = next(iter(providers))
@@ -1467,7 +1468,12 @@ def _select_platform_tts_defaults(speed, tts_config):
     )
 
     if speed is None:
-        speed = (provider_config.get("speed") or {}).get("default")
+        speed_config = provider_config.get("speed")
+        speed = (
+            speed_config.get("default")
+            if isinstance(speed_config, dict)
+            else speed_config
+        )
 
     return provider, model, voice_id, speed
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -742,7 +742,7 @@ ACCESS_TYPES = ("guest", "trial", "normal")
 COURSE_CONFIG_DEFAULTS = {
     "model": "", "temperature": 0.3, "price": 0, "keywords": [], "avatar": "",
     "use_learner_language": False,
-    "tts_enabled": False, "tts_provider": "minimax", "tts_model": "",
+    "tts_enabled": False, "tts_provider": "", "tts_model": "",
     "tts_voice_id": "", "tts_speed": 1.0, "tts_pitch": 0, "tts_emotion": "",
     "ask_enabled_status": 5101, "ask_model": "", "ask_temperature": 0.0,
     "ask_system_prompt": "", "ask_provider_config": {},
@@ -1393,24 +1393,143 @@ def cmd_update_meta(args):
 
 
 # ── Set Listen Mode ────────────────────────────────────────────────────────────
+def _string_tts_value(value):
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _tts_provider_name(value):
+    return _string_tts_value(value).lower()
+
+
+def _tts_providers_by_name(tts_config):
+    providers = {}
+    for item in (tts_config or {}).get("providers") or []:
+        if not isinstance(item, dict):
+            continue
+        name = _tts_provider_name(item.get("name"))
+        if name:
+            providers[name] = item
+    return providers
+
+
+def _tts_model_options(tts_config):
+    options = []
+    for item in (tts_config or {}).get("model_options") or []:
+        if not isinstance(item, dict):
+            continue
+        provider = _tts_provider_name(item.get("provider"))
+        value = _string_tts_value(item.get("value"))
+        if provider and value:
+            options.append(item)
+    return options
+
+
+def _filter_tts_voices_for_model(provider, voices, model):
+    if _tts_provider_name(provider) != "volcengine":
+        return voices
+    model_key = _string_tts_value(model)
+    if not model_key:
+        return voices
+    return [
+        v for v in voices
+        if _string_tts_value(v.get("resource_id")) == model_key
+    ]
+
+
+def _select_platform_tts_defaults(speed, tts_config):
+    """Mirror the platform editor's default provider/model/voice selection."""
+    providers = _tts_providers_by_name(tts_config)
+    model_options = _tts_model_options(tts_config)
+    default_model_option = model_options[0] if model_options else None
+    provider = ""
+    model = ""
+
+    if default_model_option:
+        provider = _tts_provider_name(default_model_option.get("provider"))
+        model = _string_tts_value(default_model_option.get("model"))
+    elif providers:
+        provider = next(iter(providers))
+        models = providers[provider].get("models") or []
+        if models:
+            model = _string_tts_value(models[0].get("value"))
+
+    provider_config = providers.get(provider) or {}
+    voices = [
+        v for v in (provider_config.get("voices") or [])
+        if isinstance(v, dict) and _string_tts_value(v.get("value"))
+    ]
+    selectable_voices = _filter_tts_voices_for_model(provider, voices, model)
+    voice_id = (
+        _string_tts_value(selectable_voices[0].get("value"))
+        if selectable_voices else ""
+    )
+
+    if speed is None:
+        speed = (provider_config.get("speed") or {}).get("default")
+
+    return provider, model, voice_id, speed
+
+
+def _build_set_tts_payload(args, tts_config=None):
+    enabled = args.enabled == "true"
+    payload = {"tts_enabled": enabled}
+    if not enabled:
+        return payload
+
+    provider, model, voice_id, speed = _select_platform_tts_defaults(
+        args.speed, tts_config or {})
+    if speed is None:
+        speed = 1.0
+    try:
+        speed = float(speed)
+    except (TypeError, ValueError):
+        print(f"Error: invalid TTS speed: {speed!r}")
+        sys.exit(1)
+
+    missing = []
+    if not provider:
+        missing.append("tts_provider")
+    provider_config = _tts_providers_by_name(tts_config or {}).get(provider) or {}
+    if provider_config.get("models") and not model:
+        missing.append("tts_model")
+    if not voice_id:
+        missing.append("tts_voice_id")
+    if missing:
+        print("Error: platform defaults did not provide complete TTS settings.")
+        print(f"  Missing: {', '.join(missing)}")
+        print("  Retry after the platform TTS config endpoint is available.")
+        sys.exit(1)
+
+    payload.update({
+        "tts_provider": provider,
+        "tts_model": model,
+        "tts_voice_id": voice_id,
+        "tts_speed": speed,
+        "tts_pitch": 0,
+        "tts_emotion": "",
+    })
+    return payload
+
+
 def cmd_set_tts(args):
     """Enable or disable course Listen Mode without changing other attributes."""
     base_url, token = resolve_auth(args)
     shifu_bid = args.shifu_bid
-    enabled = args.enabled == "true"
     course_dir = getattr(args, "course_dir", None)
 
     manifest = _load_sync(course_dir) if course_dir else None
-    intended = {"tts_enabled": enabled}
+    tts_config = api_safe(base_url, token, "get", "/tts/config") or {}
+    payload = _build_set_tts_payload(args, tts_config)
     _check_course_meta_conflict(base_url, token, shifu_bid, course_dir, manifest,
-                                intended)
+                                payload)
 
-    # Send only the Listen Mode switch. Provider/model/voice/speed/pitch/emotion remain
-    # whatever the platform currently stores.
-    api(base_url, token, "post", f"/shifus/{shifu_bid}/detail",
-        json={"tts_enabled": enabled})
+    # Disabling sends only the switch. Enabling sends the full TTS settings that
+    # the backend now validates strictly, matching the platform editor payload.
+    api(base_url, token, "post", f"/shifus/{shifu_bid}/detail", json=payload)
     print(f"Set course {shifu_bid} Listen Mode -> "
-          f"{'enabled' if enabled else 'disabled'}")
+          f"{'enabled' if payload['tts_enabled'] else 'disabled'}")
 
     if manifest and manifest.get("shifu_bid") == shifu_bid:
         fresh_detail = api_safe(base_url, token, "get",
@@ -2608,6 +2727,8 @@ def build_parser():
     p.add_argument("shifu_bid", help="Course BID")
     p.add_argument("--enabled", required=True, choices=["true", "false"],
                    help="true=enable Listen Mode, false=disable it")
+    p.add_argument("--speed", type=float, default=None,
+                   help="Override the platform default TTS speed")
     p.add_argument("--course-dir", default=None,
                    help=f"Also refresh local {COURSE_CONFIG_NAME} and sync manifest")
 


### PR DESCRIPTION
## Summary
- Remove the obsolete `set-tts` provider/model/voice CLI options from the AI-Shifu course creator CLI and reference docs.
- Derive the enabling payload from `/tts/config`, matching the platform's default provider, model, voice, and speed behavior.
- Keep `--speed` as the only optional TTS override and refresh local course config snapshots after version-aware writes.

## Validation
- `python3 skills/ai-shifu-course-creator/scripts/shifu-cli.py set-tts --help`
- `python3 -m compileall skills/ai-shifu-course-creator/scripts/shifu-cli.py`
- `python3 scripts/validate_skill_quality.py`
- `git diff --check`
- Payload check against the current ai-shifu.cn TTS config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `--speed` setting to the TTS command when enabling Listen Mode.
  * Listen Mode now uses a complete set of TTS values when turned on, with defaults pulled from the platform.

* **Bug Fixes**
  * Improved Listen Mode disable behavior so it only switches the feature off without overwriting existing saved TTS settings.
  * Updated default course TTS values to better match the current configuration format.

* **Documentation**
  * Refreshed CLI and course configuration docs to reflect the new TTS behavior and example settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->