### PR TITLE
fix: use real course author names

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -413,7 +413,7 @@ Apply Optimization audits against the full constraint set:
 
 Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `references/course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six sections, their order, and every non-placeholder instruction; replace every `XXX` with course-specific content and render the result in the resolved output language.
 
-Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_constraints`, resolved target language per `references/data-contracts.md#language-resolution`, Segmentation visual cues) instead of re-asking the author. Do not duplicate per-lesson interaction logic or variable collection there — those belong in Teaching Prompts.
+Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_constraints`, resolved target language per `references/data-contracts.md#language-resolution`, Segmentation visual cues). Do not duplicate per-lesson interaction logic or variable collection there — those belong in Teaching Prompts.
 
 ### Validation
 

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -15,7 +15,7 @@ Do not move lesson-specific mechanics into `course-prompt.md`.
 
 1. Resolve the output language using [data-contracts.md#language-resolution](data-contracts.md#language-resolution).
 2. Copy the complete [Fillable Template](#fillable-template), preserving its six sections and their order.
-3. Replace every `XXX` from the [Placeholder Sources](#placeholder-sources). Use already-collected artifacts instead of asking the author again.
+3. Replace every `XXX` from the [Placeholder Sources](#placeholder-sources). Use already-collected artifacts.
 4. Render section headings and body text in the resolved output language. The English template is canonical structure, not a language default.
 5. Keep every non-placeholder instruction. Adapt wording only when needed to preserve the same rule in the resolved language.
 6. Confirm that no `XXX` remains and that the stated delivery mode matches the Course Design Intake.

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -74,7 +74,7 @@ You specialize in XXX and are a professional teacher in the field of XXX.
 
 | Placeholder | Source |
 | --- | --- |
-| Teacher name | Author choice; default to a course-specific persona name. |
+| Teacher name | Course author's real name. If unknown, ask the author. |
 | Specialty and teaching field | Dominant topic from Segmentation, cross-checked with `course_index` core questions. |
 | Course name | First heading in `README.md`. |
 | Mastery goal | Orchestration course-level goal aggregated from `course_index` core questions. |


### PR DESCRIPTION
## Summary

- Use the course author's real name for the Course Prompt teacher name.
- Ask the author when the real name is unknown.

## Root cause

The placeholder guidance defaulted to a course-specific persona name instead of sourcing the teacher identity from the course author.

## Benefit

Generated Course Prompts identify the real course author and avoid silently substituting a persona name.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated course creation guidance to use the author’s real name for the teacher placeholder.
  * Added instructions to ask the author when their name is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->