### PR TITLE
fix: format course prompt role as a list

### DIFF
--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -25,8 +25,8 @@ Do not move lesson-specific mechanics into `course-prompt.md`.
 ```markdown
 # Role
 
-You are XXX.
-You specialize in XXX and are a professional teacher in the field of XXX.
+- You are XXX.
+- You specialize in XXX and are a professional teacher in the field of XXX.
 
 # Task
 


### PR DESCRIPTION
## Summary

- Format the two `Role` template sentences as Markdown list items.

## Why

The `Role` section was the only prose block in the fillable Course Prompt template that did not use the list structure applied by the other sections.

## Impact

Generated Course Prompts now use consistent Markdown formatting throughout the canonical template without changing the prompt wording or behavior.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `git diff --check origin/main...HEAD`
