### PR TITLE
fix: align course skill contracts and examples

### DIFF
--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -357,6 +357,45 @@ def validate_segment_example(
             )
 
 
+def validate_global_variable_example(
+    variable: dict[str, object], md_file: Path, issues: IssueBag
+) -> None:
+    required = {"name", "collected_in", "used_in", "effect_scope"}
+    missing = sorted(required - variable.keys())
+    if missing:
+        issues.add_error(
+            f"{md_file}: global variable example {variable.get('name')} "
+            f"is missing required fields: {', '.join(missing)}"
+        )
+        return
+
+    if not isinstance(variable["name"], str) or not variable["name"].strip():
+        issues.add_error(
+            f"{md_file}: global variable example name must be a non-empty string"
+        )
+    if (
+        not isinstance(variable["collected_in"], str)
+        or not variable["collected_in"].strip()
+    ):
+        issues.add_error(
+            f"{md_file}: global variable example collected_in must be a "
+            "non-empty string"
+        )
+    used_in = variable["used_in"]
+    if not isinstance(used_in, list) or any(
+        not isinstance(item, str) or not item.strip() for item in used_in
+    ):
+        issues.add_error(
+            f"{md_file}: global variable example used_in must be an array "
+            "of non-empty strings"
+        )
+    if variable["effect_scope"] != "cross_lesson":
+        issues.add_error(
+            f"{md_file}: global variable examples must use "
+            "effect_scope 'cross_lesson'"
+        )
+
+
 def course_prompt_template_lines(
     skill_dir: Path, issues: IssueBag
 ) -> list[str]:
@@ -490,10 +529,9 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                     "segment_type" in value or "core_point" in value
                 ):
                     validate_segment_example(value, md_file, issues)
-                if "effect_scope" in value and value["effect_scope"] != "cross_lesson":
-                    issues.add_error(
-                        f"{md_file}: global variable examples must use "
-                        "effect_scope 'cross_lesson'"
+                if {"collected_in", "used_in", "effect_scope"} & value.keys():
+                    validate_global_variable_example(
+                        value, md_file, issues
                     )
 
         for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -520,9 +520,9 @@ def validate_course_prompt_example(
     for required_line in prompt_template_lines:
         if "XXX" in required_line:
             filled_line_pattern = (
-                "^"
+                r"^[ \t]*"
                 + re.escape(required_line).replace("XXX", r"[^\n]+")
-                + "$"
+                + r"[ \t]*$"
             )
             if not re.search(filled_line_pattern, prompt, re.MULTILINE):
                 issues.add_error(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections.abc import Generator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -287,7 +288,7 @@ def validate_anchors(skill_dir: Path, issues: IssueBag) -> None:
                     )
 
 
-def walk_json(value: object):
+def walk_json(value: object) -> Generator[object, None, None]:
     """Yield every nested JSON value, including the root."""
     yield value
     if isinstance(value, dict):

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -42,6 +42,7 @@ ANCHOR_SCAN_GLOBS = ("SKILL.md", "references/**/*.md", "examples/**/*.md")
 MAX_DESCRIPTION_LEN = 1024
 MIN_DESCRIPTION_LEN_RECOMMENDED = 50
 MAX_COMPATIBILITY_LEN = 500
+SEGMENT_TYPES = {"concept", "example", "code", "image", "exercise", "transition"}
 TRANSFER_SIGNAL_KEYS = {
     "learner_hook",
     "evidence_type",
@@ -307,6 +308,32 @@ def validate_segment_example(
             f"is missing required fields: {', '.join(missing)}"
         )
         return
+
+    segment_id = segment["segment_id"]
+    if not isinstance(segment_id, str) or not segment_id.strip():
+        issues.add_error(
+            f"{md_file}: segment example segment_id must be a non-empty string"
+        )
+
+    segment_type = segment["segment_type"]
+    if not isinstance(segment_type, str) or segment_type not in SEGMENT_TYPES:
+        issues.add_error(
+            f"{md_file}: segment example {segment_id} has invalid segment_type "
+            f"{segment_type!r}; expected one of {', '.join(sorted(SEGMENT_TYPES))}"
+        )
+
+    core_point = segment["core_point"]
+    if not isinstance(core_point, str) or not core_point.strip():
+        issues.add_error(
+            f"{md_file}: segment example {segment_id} core_point must be a "
+            "non-empty string"
+        )
+
+    if not isinstance(segment["preserve_block"], bool):
+        issues.add_error(
+            f"{md_file}: segment example {segment_id} preserve_block must be "
+            "a boolean"
+        )
 
     source_span = segment["source_span"]
     if not isinstance(source_span, dict):

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -300,7 +300,10 @@ def walk_json(value: object) -> Generator[object, None, None]:
 
 
 def validate_segment_example(
-    segment: dict[str, object], md_file: Path, issues: IssueBag
+    segment: dict[str, object],
+    source_texts: dict[str, str],
+    md_file: Path,
+    issues: IssueBag,
 ) -> None:
     missing = sorted(SEGMENT_REQUIRED_KEYS - segment.keys())
     if missing:
@@ -361,6 +364,18 @@ def validate_segment_example(
                 f"{md_file}: segment example {segment['segment_id']} source_span "
                 "must contain source_id and valid start/end offsets"
             )
+        else:
+            source_text = source_texts.get(source_id)
+            if source_text is None:
+                issues.add_error(
+                    f"{md_file}: segment example {segment_id} source_span "
+                    f"references unknown string source {source_id!r}"
+                )
+            elif end > len(source_text):
+                issues.add_error(
+                    f"{md_file}: segment example {segment_id} source_span end "
+                    f"{end} exceeds {source_id!r} length {len(source_text)}"
+                )
 
     transfer_signals = segment["transfer_signals"]
     if not isinstance(transfer_signals, dict) or not transfer_signals:
@@ -559,6 +574,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
         else []
     )
     for md_file, content in example_contents:
+        parsed_payloads: list[object] = []
         for match in RE_JSON_FENCE.finditer(content):
             try:
                 payload = json.loads(match.group("body"))
@@ -572,12 +588,23 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                     f"{exc.msg}"
                 )
                 continue
+            parsed_payloads.append(payload)
 
+        source_texts: dict[str, str] = {}
+        for payload in parsed_payloads:
+            if isinstance(payload, dict):
+                source_texts.update(
+                    {
+                        key: value
+                        for key, value in payload.items()
+                        if isinstance(value, str)
+                    }
+                )
             for value in walk_json(payload):
                 if not isinstance(value, dict):
                     continue
                 if SEGMENT_REQUIRED_KEYS & value.keys() and "block_id" not in value:
-                    validate_segment_example(value, md_file, issues)
+                    validate_segment_example(value, source_texts, md_file, issues)
                 if {"collected_in", "used_in", "effect_scope"} & value.keys():
                     validate_global_variable_example(
                         value, md_file, issues

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -525,9 +525,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             for value in walk_json(payload):
                 if not isinstance(value, dict):
                     continue
-                if "segment_id" in value and (
-                    "segment_type" in value or "core_point" in value
-                ):
+                if "segment_id" in value and "block_id" not in value:
                     validate_segment_example(value, md_file, issues)
                 if {"collected_in", "used_in", "effect_scope"} & value.keys():
                     validate_global_variable_example(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -380,6 +380,66 @@ def course_prompt_template_lines(skill_dir: Path) -> list[str]:
     ]
 
 
+def validate_course_prompt_example(
+    prompt: str,
+    prompt_template_lines: list[str],
+    md_file: Path,
+    issues: IssueBag,
+) -> None:
+    if "XXX" in prompt:
+        issues.add_error(
+            f"{md_file}: Course Prompt example contains unresolved XXX"
+        )
+
+    heading_matches = list(re.finditer(r"^# [^#\n].*$", prompt, re.MULTILINE))
+    if len(heading_matches) != 6:
+        issues.add_error(
+            f"{md_file}: Course Prompt example must contain exactly six "
+            f"top-level sections, found {len(heading_matches)}"
+        )
+        return
+
+    for index, heading in enumerate(heading_matches):
+        body_start = heading.end()
+        body_end = (
+            heading_matches[index + 1].start()
+            if index + 1 < len(heading_matches)
+            else len(prompt)
+        )
+        if not prompt[body_start:body_end].strip():
+            issues.add_error(
+                f"{md_file}: Course Prompt example section "
+                f"{heading.group(0)} must not be empty"
+            )
+
+    headings = [match.group(0).strip() for match in heading_matches]
+    english_headings = [
+        line for line in prompt_template_lines if line.startswith("# ")
+    ]
+    if headings != english_headings:
+        # Localized examples cannot be compared to English instructions by exact
+        # text. Their six-section shape and resolved placeholders are still
+        # validated above; semantic localization remains a human review concern.
+        return
+
+    for required_prefix in (
+        "- You are ",
+        "- You specialize in ",
+        "- The current course is ",
+    ):
+        if required_prefix not in prompt:
+            issues.add_error(
+                f"{md_file}: Course Prompt example is missing filled "
+                f"placeholder line beginning with: {required_prefix}"
+            )
+    for required_line in prompt_template_lines:
+        if required_line not in prompt:
+            issues.add_error(
+                f"{md_file}: Course Prompt example is missing template "
+                f"instruction: {required_line}"
+            )
+
+
 def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
     """Keep executable examples aligned with their documented contracts."""
     examples_dir = skill_dir / "examples"
@@ -414,27 +474,9 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                     )
 
         for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):
-            prompt = match.group("body")
-            if "XXX" in prompt:
-                issues.add_error(
-                    f"{md_file}: Course Prompt example contains unresolved XXX"
-                )
-            for required_prefix in (
-                "- You are ",
-                "- You specialize in ",
-                "- The current course is ",
-            ):
-                if required_prefix not in prompt:
-                    issues.add_error(
-                        f"{md_file}: Course Prompt example is missing filled "
-                        f"placeholder line beginning with: {required_prefix}"
-                    )
-            for required_line in prompt_template_lines:
-                if required_line not in prompt:
-                    issues.add_error(
-                        f"{md_file}: Course Prompt example is missing template "
-                        f"instruction: {required_line}"
-                    )
+            validate_course_prompt_example(
+                match.group("body"), prompt_template_lines, md_file, issues
+            )
 
 
 def main() -> int:

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -659,6 +659,11 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                             continue
                         span_map = lesson.get("source_span_map")
                         if not isinstance(span_map, list):
+                            issues.add_error(
+                                f"{md_file}: course_index lesson "
+                                f"{lesson.get('lesson_id')!r} source_span_map "
+                                "must be an array"
+                            )
                             continue
                         lesson_id = lesson.get("lesson_id")
                         for map_index, source_span in enumerate(span_map):

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -65,6 +65,7 @@ TRANSFER_SIGNAL_KEYS = {
     "interaction_intent_cue",
     "compare_cue",
 }
+SOURCE_TEXT_KEYS = {"course_material"}
 
 
 @dataclass
@@ -625,7 +626,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
         for payload_index, payload in enumerate(parsed_payloads):
             if isinstance(payload, dict):
                 for key, value in payload.items():
-                    if isinstance(value, str):
+                    if key in SOURCE_TEXT_KEYS and isinstance(value, str):
                         source_candidates.setdefault(key, []).append(
                             (payload_index, value)
                         )

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -314,6 +314,49 @@ def source_texts_for_payload(
     return source_texts
 
 
+def validate_source_span_example(
+    source_span: object,
+    owner: str,
+    source_texts: dict[str, str],
+    md_file: Path,
+    issues: IssueBag,
+) -> None:
+    if not isinstance(source_span, dict):
+        issues.add_error(f"{md_file}: {owner} must be an object")
+        return
+
+    source_id = source_span.get("source_id")
+    start = source_span.get("start")
+    end = source_span.get("end")
+    valid_offsets = (
+        isinstance(source_id, str)
+        and bool(source_id)
+        and isinstance(start, int)
+        and not isinstance(start, bool)
+        and start >= 0
+        and isinstance(end, int)
+        and not isinstance(end, bool)
+        and end > start
+    )
+    if not valid_offsets:
+        issues.add_error(
+            f"{md_file}: {owner} must contain source_id and valid "
+            "start/end offsets"
+        )
+        return
+
+    source_text = source_texts.get(source_id)
+    if source_text is None:
+        issues.add_error(
+            f"{md_file}: {owner} references unknown string source {source_id!r}"
+        )
+    elif end > len(source_text):
+        issues.add_error(
+            f"{md_file}: {owner} end {end} exceeds {source_id!r} length "
+            f"{len(source_text)}"
+        )
+
+
 def validate_segment_example(
     segment: dict[str, object],
     source_texts: dict[str, str],
@@ -354,43 +397,13 @@ def validate_segment_example(
             "a boolean"
         )
 
-    source_span = segment["source_span"]
-    if not isinstance(source_span, dict):
-        issues.add_error(
-            f"{md_file}: segment example {segment['segment_id']} source_span "
-            "must be an object"
-        )
-    else:
-        source_id = source_span.get("source_id")
-        start = source_span.get("start")
-        end = source_span.get("end")
-        valid_offsets = (
-            isinstance(source_id, str)
-            and bool(source_id)
-            and isinstance(start, int)
-            and not isinstance(start, bool)
-            and start >= 0
-            and isinstance(end, int)
-            and not isinstance(end, bool)
-            and end > start
-        )
-        if not valid_offsets:
-            issues.add_error(
-                f"{md_file}: segment example {segment['segment_id']} source_span "
-                "must contain source_id and valid start/end offsets"
-            )
-        else:
-            source_text = source_texts.get(source_id)
-            if source_text is None:
-                issues.add_error(
-                    f"{md_file}: segment example {segment_id} source_span "
-                    f"references unknown string source {source_id!r}"
-                )
-            elif end > len(source_text):
-                issues.add_error(
-                    f"{md_file}: segment example {segment_id} source_span end "
-                    f"{end} exceeds {source_id!r} length {len(source_text)}"
-                )
+    validate_source_span_example(
+        segment["source_span"],
+        f"segment example {segment_id} source_span",
+        source_texts,
+        md_file,
+        issues,
+    )
 
     transfer_signals = segment["transfer_signals"]
     if not isinstance(transfer_signals, dict) or not transfer_signals:
@@ -634,6 +647,24 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                         if isinstance(segment, dict):
                             validate_segment_example(
                                 segment, source_texts, md_file, issues
+                            )
+                course_index = value.get("course_index")
+                if isinstance(course_index, list):
+                    for lesson in course_index:
+                        if not isinstance(lesson, dict):
+                            continue
+                        span_map = lesson.get("source_span_map")
+                        if not isinstance(span_map, list):
+                            continue
+                        lesson_id = lesson.get("lesson_id")
+                        for map_index, source_span in enumerate(span_map):
+                            validate_source_span_example(
+                                source_span,
+                                f"course_index lesson {lesson_id!r} "
+                                f"source_span_map[{map_index}]",
+                                source_texts,
+                                md_file,
+                                issues,
                             )
                 variables = value.get("global_variable_table")
                 if isinstance(variables, list):

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -495,6 +495,15 @@ def validate_course_prompt_example(
         line for line in prompt_template_lines if line.startswith("# ")
     ]
     if headings != english_headings:
+        common_headings = set(headings) & set(english_headings)
+        if common_headings:
+            missing_headings = sorted(set(english_headings) - set(headings))
+            unexpected_headings = sorted(set(headings) - set(english_headings))
+            issues.add_error(
+                f"{md_file}: Course Prompt example headings do not match "
+                f"the template; missing: {', '.join(missing_headings) or 'none'}; "
+                f"unexpected: {', '.join(unexpected_headings) or 'none'}"
+            )
         # Localized examples cannot be compared to English instructions by exact
         # text. Their six-section shape and resolved placeholders are still
         # validated above; semantic localization remains a human review concern.

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -645,17 +645,36 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             for value in walk_json(payload):
                 if not isinstance(value, dict):
                     continue
-                segments = value.get("structured_segments_json")
-                if isinstance(segments, list):
-                    for segment in segments:
-                        if isinstance(segment, dict):
+                if "structured_segments_json" in value:
+                    segments = value["structured_segments_json"]
+                    if not isinstance(segments, list):
+                        issues.add_error(
+                            f"{md_file}: structured_segments_json must be an array"
+                        )
+                    else:
+                        for segment_index, segment in enumerate(segments):
+                            if not isinstance(segment, dict):
+                                issues.add_error(
+                                    f"{md_file}: structured_segments_json"
+                                    f"[{segment_index}] must be an object"
+                                )
+                                continue
                             validate_segment_example(
                                 segment, source_texts, md_file, issues
                             )
-                course_index = value.get("course_index")
-                if isinstance(course_index, list):
-                    for lesson in course_index:
+                if "course_index" in value:
+                    course_index = value["course_index"]
+                    if not isinstance(course_index, list):
+                        issues.add_error(
+                            f"{md_file}: course_index must be an array"
+                        )
+                        course_index = []
+                    for lesson_index, lesson in enumerate(course_index):
                         if not isinstance(lesson, dict):
+                            issues.add_error(
+                                f"{md_file}: course_index[{lesson_index}] "
+                                "must be an object"
+                            )
                             continue
                         span_map = lesson.get("source_span_map")
                         if not isinstance(span_map, list):
@@ -675,10 +694,20 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                                 md_file,
                                 issues,
                             )
-                variables = value.get("global_variable_table")
-                if isinstance(variables, list):
-                    for variable in variables:
-                        if isinstance(variable, dict):
+                if "global_variable_table" in value:
+                    variables = value["global_variable_table"]
+                    if not isinstance(variables, list):
+                        issues.add_error(
+                            f"{md_file}: global_variable_table must be an array"
+                        )
+                    else:
+                        for variable_index, variable in enumerate(variables):
+                            if not isinstance(variable, dict):
+                                issues.add_error(
+                                    f"{md_file}: global_variable_table"
+                                    f"[{variable_index}] must be an object"
+                                )
+                                continue
                             validate_global_variable_example(
                                 variable, md_file, issues
                             )

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -440,9 +440,13 @@ def validate_global_variable_example(
         )
         return
 
-    if not isinstance(variable["name"], str) or not variable["name"].strip():
+    variable_name = variable["name"]
+    if not isinstance(variable_name, str) or not re.fullmatch(
+        r"\w+", variable_name
+    ):
         issues.add_error(
-            f"{md_file}: global variable example name must be a non-empty string"
+            f"{md_file}: global variable example name must contain only "
+            "letters, numbers, and underscores"
         )
     if (
         not isinstance(variable["collected_in"], str)

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -395,7 +395,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             except json.JSONDecodeError as exc:
                 issues.add_error(
                     f"{md_file}: invalid JSON example near line "
-                    f"{content.count(chr(10), 0, match.start()) + exc.lineno}: "
+                    f"{content.count(chr(10), 0, match.start('body')) + exc.lineno}: "
                     f"{exc.msg}"
                 )
                 continue

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -504,7 +504,7 @@ def validate_course_prompt_example(
                 f"{md_file}: Course Prompt example headings are out of order; "
                 f"expected: {', '.join(english_headings)}"
             )
-        elif english_headings and len(common_headings) >= len(english_headings) - 1:
+        elif english_headings and len(common_headings) >= len(english_headings) - 2:
             missing_headings = sorted(english_heading_set - heading_set)
             unexpected_headings = sorted(heading_set - english_heading_set)
             issues.add_error(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -603,15 +603,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
         (md_file, md_file.read_text(encoding="utf-8"))
         for md_file in sorted(examples_dir.glob("**/*.md"))
     ]
-    has_course_prompt_artifacts = any(
-        RE_COURSE_PROMPT_ARTIFACT.search(content)
-        for _, content in example_contents
-    )
-    prompt_template_lines = (
-        course_prompt_template_lines(skill_dir, issues)
-        if has_course_prompt_artifacts
-        else []
-    )
+    prompt_template_lines = course_prompt_template_lines(skill_dir, issues)
     for md_file, content in example_contents:
         parsed_payloads: list[object] = []
         for match in RE_JSON_FENCE.finditer(content):
@@ -682,6 +674,19 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                             validate_global_variable_example(
                                 variable, md_file, issues
                             )
+                if "course_prompt" in value:
+                    course_prompt = value["course_prompt"]
+                    if isinstance(course_prompt, str):
+                        validate_course_prompt_example(
+                            course_prompt,
+                            prompt_template_lines,
+                            md_file,
+                            issues,
+                        )
+                    else:
+                        issues.add_error(
+                            f"{md_file}: course_prompt example must be a string"
+                        )
 
         for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):
             validate_course_prompt_example(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -455,7 +455,7 @@ def course_prompt_template_lines(
     return [
         line.strip()
         for line in match.group("body").splitlines()
-        if line.strip() and "XXX" not in line
+        if line.strip()
     ]
 
 
@@ -517,18 +517,19 @@ def validate_course_prompt_example(
         # validated above; semantic localization remains a human review concern.
         return
 
-    for required_prefix in (
-        "- You are ",
-        "- You specialize in ",
-        "- The current course is ",
-    ):
-        if required_prefix not in prompt:
-            issues.add_error(
-                f"{md_file}: Course Prompt example is missing filled "
-                f"placeholder line beginning with: {required_prefix}"
-            )
     for required_line in prompt_template_lines:
-        if required_line not in prompt:
+        if "XXX" in required_line:
+            filled_line_pattern = (
+                "^"
+                + re.escape(required_line).replace("XXX", r"[^\n]+")
+                + "$"
+            )
+            if not re.search(filled_line_pattern, prompt, re.MULTILINE):
+                issues.add_error(
+                    f"{md_file}: Course Prompt example is missing filled "
+                    f"placeholder line matching template: {required_line}"
+                )
+        elif required_line not in prompt:
             issues.add_error(
                 f"{md_file}: Course Prompt example is missing template "
                 f"instruction: {required_line}"

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -496,10 +496,17 @@ def validate_course_prompt_example(
         line for line in prompt_template_lines if line.startswith("# ")
     ]
     if headings != english_headings:
-        common_headings = set(headings) & set(english_headings)
-        if common_headings:
-            missing_headings = sorted(set(english_headings) - set(headings))
-            unexpected_headings = sorted(set(headings) - set(english_headings))
+        heading_set = set(headings)
+        english_heading_set = set(english_headings)
+        common_headings = heading_set & english_heading_set
+        if heading_set == english_heading_set:
+            issues.add_error(
+                f"{md_file}: Course Prompt example headings are out of order; "
+                f"expected: {', '.join(english_headings)}"
+            )
+        elif english_headings and len(common_headings) >= len(english_headings) - 1:
+            missing_headings = sorted(english_heading_set - heading_set)
+            unexpected_headings = sorted(heading_set - english_heading_set)
             issues.add_error(
                 f"{md_file}: Course Prompt example headings do not match "
                 f"the template; missing: {', '.join(missing_headings) or 'none'}; "

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -43,6 +43,14 @@ MAX_DESCRIPTION_LEN = 1024
 MIN_DESCRIPTION_LEN_RECOMMENDED = 50
 MAX_COMPATIBILITY_LEN = 500
 SEGMENT_TYPES = {"concept", "example", "code", "image", "exercise", "transition"}
+SEGMENT_REQUIRED_KEYS = {
+    "segment_id",
+    "segment_type",
+    "core_point",
+    "preserve_block",
+    "source_span",
+    "transfer_signals",
+}
 TRANSFER_SIGNAL_KEYS = {
     "learner_hook",
     "evidence_type",
@@ -293,15 +301,7 @@ def walk_json(value: object):
 def validate_segment_example(
     segment: dict[str, object], md_file: Path, issues: IssueBag
 ) -> None:
-    required = {
-        "segment_id",
-        "segment_type",
-        "core_point",
-        "preserve_block",
-        "source_span",
-        "transfer_signals",
-    }
-    missing = sorted(required - segment.keys())
+    missing = sorted(SEGMENT_REQUIRED_KEYS - segment.keys())
     if missing:
         issues.add_error(
             f"{md_file}: segment example {segment.get('segment_id')} "
@@ -561,7 +561,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             for value in walk_json(payload):
                 if not isinstance(value, dict):
                     continue
-                if "segment_id" in value and "block_id" not in value:
+                if SEGMENT_REQUIRED_KEYS & value.keys() and "block_id" not in value:
                     validate_segment_example(value, md_file, issues)
                 if {"collected_in", "used_in", "effect_scope"} & value.keys():
                     validate_global_variable_example(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -563,9 +563,12 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             try:
                 payload = json.loads(match.group("body"))
             except json.JSONDecodeError as exc:
+                error_line = (
+                    content.count("\n", 0, match.start("body")) + exc.lineno
+                )
                 issues.add_error(
                     f"{md_file}: invalid JSON example near line "
-                    f"{content.count(chr(10), 0, match.start('body')) + exc.lineno}: "
+                    f"{error_line}: "
                     f"{exc.msg}"
                 )
                 continue

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -513,13 +513,20 @@ def validate_course_prompt_example(
     if headings != english_headings:
         heading_set = set(headings)
         english_heading_set = set(english_headings)
-        common_headings = heading_set & english_heading_set
+        english_instruction_lines = [
+            line
+            for line in prompt_template_lines
+            if not line.startswith("# ") and "XXX" not in line
+        ]
+        has_english_instructions = any(
+            line in prompt for line in english_instruction_lines
+        )
         if heading_set == english_heading_set:
             issues.add_error(
                 f"{md_file}: Course Prompt example headings are out of order; "
                 f"expected: {', '.join(english_headings)}"
             )
-        elif english_headings and len(common_headings) >= len(english_headings) - 2:
+        elif english_headings and has_english_instructions:
             missing_headings = sorted(english_heading_set - heading_set)
             unexpected_headings = sorted(heading_set - english_heading_set)
             issues.add_error(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -530,6 +530,9 @@ def validate_course_prompt_example(
 
 def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
     """Keep executable examples aligned with their documented contracts."""
+    if skill_dir.name != "ai-shifu-course-creator":
+        return
+
     examples_dir = skill_dir / "examples"
     if not examples_dir.is_dir():
         return

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -357,13 +357,22 @@ def validate_segment_example(
             )
 
 
-def course_prompt_template_lines(skill_dir: Path) -> list[str]:
+def course_prompt_template_lines(
+    skill_dir: Path, issues: IssueBag
+) -> list[str]:
     template_file = skill_dir / "references" / "course-prompt.md"
     if not template_file.is_file():
+        issues.add_error(
+            f"{skill_dir}: Course Prompt examples require "
+            "references/course-prompt.md"
+        )
         return []
     content = template_file.read_text(encoding="utf-8")
     marker = "## Fillable Template"
     if marker not in content:
+        issues.add_error(
+            f"{template_file}: missing required section '{marker}'"
+        )
         return []
     template_section = content.split(marker, 1)[1]
     match = re.search(
@@ -372,6 +381,9 @@ def course_prompt_template_lines(skill_dir: Path) -> list[str]:
         re.MULTILINE | re.DOTALL,
     )
     if not match:
+        issues.add_error(
+            f"{template_file}: missing markdown code block under '{marker}'"
+        )
         return []
     return [
         line.strip()
@@ -446,9 +458,20 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
     if not examples_dir.is_dir():
         return
 
-    prompt_template_lines = course_prompt_template_lines(skill_dir)
-    for md_file in sorted(examples_dir.glob("**/*.md")):
-        content = md_file.read_text(encoding="utf-8")
+    example_contents = [
+        (md_file, md_file.read_text(encoding="utf-8"))
+        for md_file in sorted(examples_dir.glob("**/*.md"))
+    ]
+    has_course_prompt_artifacts = any(
+        RE_COURSE_PROMPT_ARTIFACT.search(content)
+        for _, content in example_contents
+    )
+    prompt_template_lines = (
+        course_prompt_template_lines(skill_dir, issues)
+        if has_course_prompt_artifacts
+        else []
+    )
+    for md_file, content in example_contents:
         for match in RE_JSON_FENCE.finditer(content):
             try:
                 payload = json.loads(match.group("body"))

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -299,6 +299,21 @@ def walk_json(value: object) -> Generator[object, None, None]:
             yield from walk_json(child)
 
 
+def source_texts_for_payload(
+    payload_index: int,
+    source_candidates: dict[str, list[tuple[int, str]]],
+) -> dict[str, str]:
+    """Select the closest source value for one example output payload."""
+    source_texts: dict[str, str] = {}
+    for source_id, candidates in source_candidates.items():
+        preceding = [item for item in candidates if item[0] <= payload_index]
+        if preceding:
+            source_texts[source_id] = max(preceding, key=lambda item: item[0])[1]
+        else:
+            source_texts[source_id] = min(candidates, key=lambda item: item[0])[1]
+    return source_texts
+
+
 def validate_segment_example(
     segment: dict[str, object],
     source_texts: dict[str, str],
@@ -597,25 +612,36 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                 continue
             parsed_payloads.append(payload)
 
-        source_texts: dict[str, str] = {}
-        for payload in parsed_payloads:
+        source_candidates: dict[str, list[tuple[int, str]]] = {}
+        for payload_index, payload in enumerate(parsed_payloads):
             if isinstance(payload, dict):
-                source_texts.update(
-                    {
-                        key: value
-                        for key, value in payload.items()
-                        if isinstance(value, str)
-                    }
-                )
+                for key, value in payload.items():
+                    if isinstance(value, str):
+                        source_candidates.setdefault(key, []).append(
+                            (payload_index, value)
+                        )
+
+        for payload_index, payload in enumerate(parsed_payloads):
+            source_texts = source_texts_for_payload(
+                payload_index, source_candidates
+            )
             for value in walk_json(payload):
                 if not isinstance(value, dict):
                     continue
-                if SEGMENT_REQUIRED_KEYS & value.keys() and "block_id" not in value:
-                    validate_segment_example(value, source_texts, md_file, issues)
-                if {"collected_in", "used_in", "effect_scope"} & value.keys():
-                    validate_global_variable_example(
-                        value, md_file, issues
-                    )
+                segments = value.get("structured_segments_json")
+                if isinstance(segments, list):
+                    for segment in segments:
+                        if isinstance(segment, dict):
+                            validate_segment_example(
+                                segment, source_texts, md_file, issues
+                            )
+                variables = value.get("global_variable_table")
+                if isinstance(variables, list):
+                    for variable in variables:
+                        if isinstance(variable, dict):
+                            validate_global_variable_example(
+                                variable, md_file, issues
+                            )
 
         for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):
             validate_course_prompt_example(

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -512,6 +512,7 @@ def validate_course_prompt_example(
     prompt_template_lines: list[str],
     md_file: Path,
     issues: IssueBag,
+    is_localized: bool = False,
 ) -> None:
     if "XXX" in prompt:
         issues.add_error(
@@ -546,20 +547,12 @@ def validate_course_prompt_example(
     if headings != english_headings:
         heading_set = set(headings)
         english_heading_set = set(english_headings)
-        english_instruction_lines = [
-            line
-            for line in prompt_template_lines
-            if not line.startswith("# ") and "XXX" not in line
-        ]
-        has_english_instructions = any(
-            line in prompt for line in english_instruction_lines
-        )
         if heading_set == english_heading_set:
             issues.add_error(
                 f"{md_file}: Course Prompt example headings are out of order; "
                 f"expected: {', '.join(english_headings)}"
             )
-        elif english_headings and has_english_instructions:
+        elif english_headings and not is_localized:
             missing_headings = sorted(english_heading_set - heading_set)
             unexpected_headings = sorted(heading_set - english_heading_set)
             issues.add_error(
@@ -623,6 +616,7 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             parsed_payloads.append(payload)
 
         source_candidates: dict[str, list[tuple[int, str]]] = {}
+        target_language_candidates: list[tuple[int, str]] = []
         for payload_index, payload in enumerate(parsed_payloads):
             if isinstance(payload, dict):
                 for key, value in payload.items():
@@ -630,10 +624,23 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                         source_candidates.setdefault(key, []).append(
                             (payload_index, value)
                         )
+                    if key == "target_language" and isinstance(value, str):
+                        target_language_candidates.append((payload_index, value))
 
         for payload_index, payload in enumerate(parsed_payloads):
             source_texts = source_texts_for_payload(
                 payload_index, source_candidates
+            )
+            target_language = source_texts_for_payload(
+                payload_index,
+                (
+                    {"target_language": target_language_candidates}
+                    if target_language_candidates
+                    else {}
+                ),
+            ).get("target_language")
+            is_localized = bool(target_language) and not (
+                target_language.lower().startswith("en")
             )
             for value in walk_json(payload):
                 if not isinstance(value, dict):
@@ -683,15 +690,24 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                             prompt_template_lines,
                             md_file,
                             issues,
+                            is_localized=is_localized,
                         )
                     else:
                         issues.add_error(
                             f"{md_file}: course_prompt example must be a string"
                         )
 
+        artifact_is_localized = bool(target_language_candidates) and all(
+            not language.lower().startswith("en")
+            for _, language in target_language_candidates
+        )
         for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):
             validate_course_prompt_example(
-                match.group("body"), prompt_template_lines, md_file, issues
+                match.group("body"),
+                prompt_template_lines,
+                md_file,
+                issues,
+                is_localized=artifact_is_localized,
             )
 
 

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -6,6 +6,7 @@ Only uses Python standard library — no pyyaml dependency required.
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from dataclasses import dataclass, field
@@ -23,6 +24,15 @@ RE_MD_ANCHOR_REF = re.compile(
 RE_HEADING = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
 RE_SLUG_STRIP = re.compile(r"[^\w\- ]")
 RE_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+RE_JSON_FENCE = re.compile(
+    r"^```json[ \t]*\n(?P<body>.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+RE_COURSE_PROMPT_ARTIFACT = re.compile(
+    r"^### Course Prompt Artifact[ \t]*$.*?"
+    r"^```markdown[ \t]*\n(?P<body>.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
 FORBIDDEN_WORDS = {"claude", "anthropic"}
 
 # Doc surface scanned for cross-file anchor links. Local-only dirs
@@ -32,6 +42,19 @@ ANCHOR_SCAN_GLOBS = ("SKILL.md", "references/**/*.md", "examples/**/*.md")
 MAX_DESCRIPTION_LEN = 1024
 MIN_DESCRIPTION_LEN_RECOMMENDED = 50
 MAX_COMPATIBILITY_LEN = 500
+TRANSFER_SIGNAL_KEYS = {
+    "learner_hook",
+    "evidence_type",
+    "visual_cue",
+    "concept_conflict",
+    "boundary_cue",
+    "action_cue",
+    "density_cue",
+    "quote_cue",
+    "visual_text_pair_cue",
+    "interaction_intent_cue",
+    "compare_cue",
+}
 
 
 @dataclass
@@ -192,6 +215,7 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
             )
 
     validate_anchors(skill_dir, issues)
+    validate_example_contracts(skill_dir, issues)
 
 
 def github_heading_slugs(md_file: Path) -> set[str]:
@@ -251,6 +275,165 @@ def validate_anchors(skill_dir: Path, issues: IssueBag) -> None:
                     issues.add_error(
                         f"{md_file}: broken anchor -> {ref[0]}#{ref[1]} "
                         f"(no matching heading in {target.name})"
+                    )
+
+
+def walk_json(value: object):
+    """Yield every nested JSON value, including the root."""
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_json(child)
+
+
+def validate_segment_example(
+    segment: dict[str, object], md_file: Path, issues: IssueBag
+) -> None:
+    required = {
+        "segment_id",
+        "segment_type",
+        "core_point",
+        "preserve_block",
+        "source_span",
+        "transfer_signals",
+    }
+    missing = sorted(required - segment.keys())
+    if missing:
+        issues.add_error(
+            f"{md_file}: segment example {segment.get('segment_id')} "
+            f"is missing required fields: {', '.join(missing)}"
+        )
+        return
+
+    source_span = segment["source_span"]
+    if not isinstance(source_span, dict):
+        issues.add_error(
+            f"{md_file}: segment example {segment['segment_id']} source_span "
+            "must be an object"
+        )
+    else:
+        source_id = source_span.get("source_id")
+        start = source_span.get("start")
+        end = source_span.get("end")
+        valid_offsets = (
+            isinstance(source_id, str)
+            and bool(source_id)
+            and isinstance(start, int)
+            and not isinstance(start, bool)
+            and start >= 0
+            and isinstance(end, int)
+            and not isinstance(end, bool)
+            and end > start
+        )
+        if not valid_offsets:
+            issues.add_error(
+                f"{md_file}: segment example {segment['segment_id']} source_span "
+                "must contain source_id and valid start/end offsets"
+            )
+
+    transfer_signals = segment["transfer_signals"]
+    if not isinstance(transfer_signals, dict) or not transfer_signals:
+        issues.add_error(
+            f"{md_file}: segment example {segment['segment_id']} "
+            "transfer_signals must be a non-empty object"
+        )
+    else:
+        unknown_keys = sorted(transfer_signals.keys() - TRANSFER_SIGNAL_KEYS)
+        if unknown_keys:
+            issues.add_error(
+                f"{md_file}: segment example {segment['segment_id']} uses "
+                f"unknown transfer signal keys: {', '.join(unknown_keys)}"
+            )
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in transfer_signals.values()
+        ):
+            issues.add_error(
+                f"{md_file}: segment example {segment['segment_id']} transfer "
+                "signal values must be non-empty strings"
+            )
+
+
+def course_prompt_template_lines(skill_dir: Path) -> list[str]:
+    template_file = skill_dir / "references" / "course-prompt.md"
+    if not template_file.is_file():
+        return []
+    content = template_file.read_text(encoding="utf-8")
+    marker = "## Fillable Template"
+    if marker not in content:
+        return []
+    template_section = content.split(marker, 1)[1]
+    match = re.search(
+        r"^```markdown[ \t]*\n(?P<body>.*?)^```[ \t]*$",
+        template_section,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return []
+    return [
+        line.strip()
+        for line in match.group("body").splitlines()
+        if line.strip() and "XXX" not in line
+    ]
+
+
+def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
+    """Keep executable examples aligned with their documented contracts."""
+    examples_dir = skill_dir / "examples"
+    if not examples_dir.is_dir():
+        return
+
+    prompt_template_lines = course_prompt_template_lines(skill_dir)
+    for md_file in sorted(examples_dir.glob("**/*.md")):
+        content = md_file.read_text(encoding="utf-8")
+        for match in RE_JSON_FENCE.finditer(content):
+            try:
+                payload = json.loads(match.group("body"))
+            except json.JSONDecodeError as exc:
+                issues.add_error(
+                    f"{md_file}: invalid JSON example near line "
+                    f"{content.count(chr(10), 0, match.start()) + exc.lineno}: "
+                    f"{exc.msg}"
+                )
+                continue
+
+            for value in walk_json(payload):
+                if not isinstance(value, dict):
+                    continue
+                if "segment_id" in value and (
+                    "segment_type" in value or "core_point" in value
+                ):
+                    validate_segment_example(value, md_file, issues)
+                if "effect_scope" in value and value["effect_scope"] != "cross_lesson":
+                    issues.add_error(
+                        f"{md_file}: global variable examples must use "
+                        "effect_scope 'cross_lesson'"
+                    )
+
+        for match in RE_COURSE_PROMPT_ARTIFACT.finditer(content):
+            prompt = match.group("body")
+            if "XXX" in prompt:
+                issues.add_error(
+                    f"{md_file}: Course Prompt example contains unresolved XXX"
+                )
+            for required_prefix in (
+                "- You are ",
+                "- You specialize in ",
+                "- The current course is ",
+            ):
+                if required_prefix not in prompt:
+                    issues.add_error(
+                        f"{md_file}: Course Prompt example is missing filled "
+                        f"placeholder line beginning with: {required_prefix}"
+                    )
+            for required_line in prompt_template_lines:
+                if required_line not in prompt:
+                    issues.add_error(
+                        f"{md_file}: Course Prompt example is missing template "
+                        f"instruction: {required_line}"
                     )
 
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -66,6 +66,7 @@ Some concepts span multiple references files. Use this table to locate the autho
 
 Use these optional controls across all phases:
 
+- `course_author_name` (string): course author's real name for the Course Prompt role.
 - `course_profile` (json): audience and pedagogical parameters.
 - `delivery_constraints` (json): platform limits, topic policy, and non-negotiable fragments.
 - `target_language` (BCP-47 string, e.g. `zh-CN` / `en-US` / `fr-FR`): explicit output language; takes priority over prompt-language detection. Full priority order in `references/data-contracts.md#language-resolution`.
@@ -430,7 +431,7 @@ Apply Optimization audits against the full constraint set:
 
 Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `references/course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six sections, their order, and every non-placeholder instruction; replace every `XXX` with course-specific content and render the result in the resolved output language.
 
-Auto-fill placeholders from existing artifacts (`course_profile`, `delivery_constraints`, resolved target language per `references/data-contracts.md#language-resolution`, Segmentation visual cues). Do not duplicate per-lesson interaction logic or variable collection there — those belong in Teaching Prompts.
+Auto-fill placeholders from existing artifacts (`course_author_name`, `course_profile`, `delivery_constraints`, resolved target language per `references/data-contracts.md#language-resolution`, Segmentation visual cues). The Role must use the course author's real name; if `course_author_name` is missing, ask the author instead of inventing a persona. Do not duplicate per-lesson interaction logic or variable collection there — those belong in Teaching Prompts.
 
 ### Validation
 

--- a/skills/ai-shifu-course-creator/examples/fallback-mode.md
+++ b/skills/ai-shifu-course-creator/examples/fallback-mode.md
@@ -30,7 +30,7 @@ Output includes uncertainty markers and rerun hints; preserved blocks survive ev
       "segment_type": "concept",
       "core_point": "Retry stop conditions differ across sources.",
       "preserve_block": false,
-      "source_span": {"source_id": "course_material", "start": 0, "end": 95},
+      "source_span": {"source_id": "course_material", "start": 0, "end": 96},
       "transfer_signals": {
         "concept_conflict": "The sources disagree on whether retries stop at a fixed count or when the queue drains.",
         "boundary_cue": "Do not choose a stop condition until the authoritative policy is confirmed."

--- a/skills/ai-shifu-course-creator/examples/fallback-mode.md
+++ b/skills/ai-shifu-course-creator/examples/fallback-mode.md
@@ -42,7 +42,7 @@ Output includes uncertainty markers and rerun hints; preserved blocks survive ev
       "segment_type": "image",
       "core_point": "Failure matrix image preserved",
       "preserve_block": true,
-      "source_span": {"source_id": "course_material", "start": 96, "end": 132},
+      "source_span": {"source_id": "course_material", "start": 104, "end": 130},
       "transfer_signals": {
         "visual_cue": "Preserve the failure matrix as the visual comparison surface.",
         "visual_text_pair_cue": "Explain which cells support each proposed retry boundary."

--- a/skills/ai-shifu-course-creator/examples/fallback-mode.md
+++ b/skills/ai-shifu-course-creator/examples/fallback-mode.md
@@ -77,6 +77,10 @@ Pipeline produces partial but runnable output:
       "lesson_id": "L03",
       "lesson_title": "Choose a Classification Axis",
       "core_question": "When should you prefer latency tiers over contention classes?",
+      "source_span_map": [
+        {"source_id": "course_material", "start": 0, "end": 32},
+        {"source_id": "course_material", "start": 34, "end": 72}
+      ],
       "uncertainty": "medium"
     }
   ],

--- a/skills/ai-shifu-course-creator/examples/fallback-mode.md
+++ b/skills/ai-shifu-course-creator/examples/fallback-mode.md
@@ -29,7 +29,12 @@ Output includes uncertainty markers and rerun hints; preserved blocks survive ev
       "segment_id": "S10",
       "segment_type": "concept",
       "core_point": "Retry stop conditions differ across sources.",
-      "source_span": {"start": 0, "end": 95},
+      "preserve_block": false,
+      "source_span": {"source_id": "course_material", "start": 0, "end": 95},
+      "transfer_signals": {
+        "concept_conflict": "The sources disagree on whether retries stop at a fixed count or when the queue drains.",
+        "boundary_cue": "Do not choose a stop condition until the authoritative policy is confirmed."
+      },
       "uncertainty": "high"
     },
     {
@@ -37,7 +42,12 @@ Output includes uncertainty markers and rerun hints; preserved blocks survive ev
       "segment_type": "image",
       "core_point": "Failure matrix image preserved",
       "preserve_block": true,
-      "source_span": {"start": 96, "end": 132}
+      "source_span": {"source_id": "course_material", "start": 96, "end": 132},
+      "transfer_signals": {
+        "visual_cue": "Preserve the failure matrix as the visual comparison surface.",
+        "visual_text_pair_cue": "Explain which cells support each proposed retry boundary."
+      },
+      "uncertainty": "low"
     }
   ],
   "rerun_hints": [

--- a/skills/ai-shifu-course-creator/examples/generation-only.md
+++ b/skills/ai-shifu-course-creator/examples/generation-only.md
@@ -39,7 +39,7 @@ Structured segments provided:
 {
   "lesson_id": "L02",
   "lesson_title": "Verify the Fix",
-  "teaching_prompt": "Choose the fastest signal that proves the fix works.\n---\n?[p95 latency trend | error-rate slope | lock-wait drop]\n---\nAfter the learner answers, use the selected signal as the first verification checkpoint.",
+  "teaching_prompt": "Ask the learner to recall a recent fix and name the first signal they checked afterward.\n\nCreate a comparison slide with three columns: p95 latency trend, error-rate slope, and lock-wait drop. For each column, show the expected movement after a successful fix and one misleading interpretation.\n\nExplain that a useful verification signal must respond to the changed mechanism, move within the observation window, and have a clear failure threshold.\n\nAsk the learner to choose the fastest signal that proves the fix works.\n---\n?[p95 latency trend | error-rate slope | lock-wait drop]\n---\nAfter the learner answers, use the selected signal as the first verification checkpoint and explain why the other two signals are secondary for that case.\n\nHave the learner write a one-sentence verification rule containing the signal, expected movement, observation window, and stop condition. Close by restating that a fix is not complete until its expected effect is observed.",
   "used_variables": [],
   "depends_on_lessons": ["L01"]
 }
@@ -48,11 +48,19 @@ Structured segments provided:
 Rendered `teaching_prompt` value:
 
 ```md
-Choose the fastest signal that proves the fix works.
+Ask the learner to recall a recent fix and name the first signal they checked afterward.
+
+Create a comparison slide with three columns: p95 latency trend, error-rate slope, and lock-wait drop. For each column, show the expected movement after a successful fix and one misleading interpretation.
+
+Explain that a useful verification signal must respond to the changed mechanism, move within the observation window, and have a clear failure threshold.
+
+Ask the learner to choose the fastest signal that proves the fix works.
 ---
 ?[p95 latency trend | error-rate slope | lock-wait drop]
 ---
-After the learner answers, use the selected signal as the first verification checkpoint.
+After the learner answers, use the selected signal as the first verification checkpoint and explain why the other two signals are secondary for that case.
+
+Have the learner write a one-sentence verification rule containing the signal, expected movement, observation window, and stop condition. Close by restating that a fix is not complete until its expected effect is observed.
 ```
 
 ## Degraded Input

--- a/skills/ai-shifu-course-creator/examples/optimization-only.md
+++ b/skills/ai-shifu-course-creator/examples/optimization-only.md
@@ -58,7 +58,7 @@ The `course_prompt` string is the complete content below.
 
 # Task
 
-- The current course is *Safe Retry Policy*. Your goal is to help the user distinguish transient from permanent failures and choose a matching retry stop rule.
+- The current course is *Safe Retry Policy*. Your goal is to help the user master distinguishing transient from permanent failures and choosing a matching retry stop rule.
 - Teach one-on-one, address the learner only as "you", and do not use group-addressing terms such as "everyone", "class", or "students".
 - Do not introduce yourself.
 - Do not greet the user.

--- a/skills/ai-shifu-course-creator/examples/optimization-only.md
+++ b/skills/ai-shifu-course-creator/examples/optimization-only.md
@@ -8,6 +8,7 @@
 {
   "existing_teaching_prompt": "## Objective\nUnderstand retry policy.\n---\n?[%{{answer}} yes | no]\n---\nGreat job.",
   "course_material": "Learner must differentiate transient vs permanent failure and choose a matching retry stop rule.",
+  "course_author_name": "Priya Shah",
   "optimization_constraints": {
     "max_interactions": 4,
     "require_branching_feedback": true
@@ -32,8 +33,7 @@
       "issue_class": "interaction_no_branching",
       "change": "remove the throwaway variable, branch feedback by learner option, and add next-step action"
     }
-  ],
-  "course_prompt": "# Role\nYou are a coach helping beginners reason about retry policy.\n\n# Task\nDifferentiate transient vs permanent failure and select a retry stop rule.\n\n# Teaching Techniques\nViewpoint branching on failure type; bounded retries with backoff for transient.\n\n# Writing Style\nDirective, action-oriented.\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Slides\nCreate failure-taxonomy slides in natural language."
+  ]
 }
 ```
 
@@ -46,6 +46,58 @@ If the learner chooses transient failure, apply bounded retries with backoff.
 If the learner chooses permanent failure, stop retries and open a corrective task.
 ```
 
+### Course Prompt Artifact
+
+The `course_prompt` string is the complete content below.
+
+```markdown
+# Role
+
+- You are Priya Shah.
+- You specialize in reliability engineering and are a professional teacher in the field of retry policy design.
+
+# Task
+
+- The current course is *Safe Retry Policy*. Your goal is to help the user distinguish transient from permanent failures and choose a matching retry stop rule.
+- Teach one-on-one, address the learner only as "you", and do not use group-addressing terms such as "everyone", "class", or "students".
+- Do not introduce yourself.
+- Do not greet the user.
+- Do not proactively guide the user to the next step at the end.
+
+# Teaching Techniques
+
+- Design the explanation path according to cognitive learning patterns, following the rhythm of "build interest → lower the barrier → understand the structure → form application".
+- Do not simply pile up knowledge points. First explain "why it matters, why it works, and how to use it".
+- When dealing with complex content, break it down before expanding.
+- Prefer clear structures, such as binary distinctions, three-layer structures, step-by-step paths, and comparison relationships.
+- Use concrete scenarios, real examples, analogies, and before-and-after comparisons.
+- When the user may misunderstand something, correct the misconception first, then continue the explanation.
+- Each paragraph should serve a clear function: defining the problem, breaking down the structure, explaining the mechanism, or providing application.
+- If a summary is needed, prefer giving a clear judgment, an application scenario, or an actionable understanding.
+
+# Writing Style
+
+- Use a conversational, natural, and engaging tone, like a clear-minded person explaining something face to face.
+- Keep the language restrained, clear, and warm.
+- You may use analogies, contrasts, and comparisons, but do not sacrifice accuracy for catchy phrasing.
+
+# Format
+
+- Output in Markdown format.
+- Do not output headings of any level, such as #, ##, or ###.
+- Use bold formatting for key steps, cognitive turning points, core conclusions, and common misconceptions.
+- Only bold truly important information. Do not bold an entire paragraph.
+- Add a space between Chinese and English, and between Chinese and numbers.
+
+# Slides
+
+- Only create a slide, PPT, visual page, or classroom projection page when the instruction explicitly requests one. Do not proactively create visuals.
+- Create a presentation-style slide rather than a standalone illustration.
+- In-slide option labels must not be interactive.
+- Keep in-slide text concise and prompt-like. Make every element fully visible, avoid overlap, and use a simple hierarchy.
+- Treat the slide as a structural prompt and follow it with a complete text explanation that assumes the learner has not seen the slide. Add background, causality, examples, and usage instead of repeating the slide.
+```
+
 ## Degraded Input
 
 Degraded-input handling for this phase (missing source material, high-risk report, minimal safe edits): see `examples/fallback-mode.md` → Optimization Fallback.
@@ -56,3 +108,4 @@ Degraded-input handling for this phase (missing source material, high-risk repor
 - Coverage and meaning are closer to source material.
 - Runtime safety fixes are applied first.
 - Edits stay minimal and avoid broad rewrites.
+- The Course Prompt preserves the complete fillable template with course-specific placeholders resolved.

--- a/skills/ai-shifu-course-creator/examples/optimization-only.md
+++ b/skills/ai-shifu-course-creator/examples/optimization-only.md
@@ -9,6 +9,7 @@
   "existing_teaching_prompt": "## Objective\nUnderstand retry policy.\n---\n?[%{{answer}} yes | no]\n---\nGreat job.",
   "course_material": "Learner must differentiate transient vs permanent failure and choose a matching retry stop rule.",
   "course_author_name": "Priya Shah",
+  "target_language": "en-US",
   "optimization_constraints": {
     "max_interactions": 4,
     "require_branching_feedback": true

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -76,7 +76,7 @@
       "lesson_id": "L01",
       "lesson_title": "Observe and Classify",
       "core_question": "Which signal separates symptom from root cause?",
-      "source_span_map": [{"source_id": "course_material", "start": 0, "end": 78}]
+      "source_span_map": [{"source_id": "course_material", "start": 0, "end": 71}]
     }
   ],
   "global_variable_table": [

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -36,7 +36,7 @@
       "segment_type": "concept",
       "core_point": "Metric drift signals a systemic shift, not just noise.",
       "preserve_block": false,
-      "source_span": {"source_id": "course_material", "start": 0, "end": 42},
+      "source_span": {"source_id": "course_material", "start": 0, "end": 39},
       "transfer_signals": {
         "learner_hook": "Start from a metric that changed unexpectedly.",
         "visual_cue": "Show a baseline metric line followed by a sustained shift.",

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -7,6 +7,7 @@
 ```json
 {
   "course_material": "Module transcript: observe metric drift, classify causes, apply one fix, review impact.",
+  "course_author_name": "Maya Chen",
   "generation_constraints": {
     "persona": "practical coach",
     "lesson_granularity": "short"
@@ -35,14 +36,24 @@
       "segment_type": "concept",
       "core_point": "Metric drift signals a systemic shift, not just noise.",
       "preserve_block": false,
-      "source_span": {"start": 0, "end": 42}
+      "source_span": {"source_id": "course_material", "start": 0, "end": 42},
+      "transfer_signals": {
+        "learner_hook": "Start from a metric that changed unexpectedly.",
+        "visual_cue": "Show a baseline metric line followed by a sustained shift.",
+        "visual_text_pair_cue": "Explain how persistence separates drift from random noise."
+      }
     },
     {
       "segment_id": "S02",
       "segment_type": "concept",
       "core_point": "Classify causes before applying fixes.",
       "preserve_block": false,
-      "source_span": {"start": 43, "end": 78}
+      "source_span": {"source_id": "course_material", "start": 43, "end": 78},
+      "transfer_signals": {
+        "concept_conflict": "Jumping to a fix before classifying the cause can hide the real bottleneck.",
+        "interaction_intent_cue": "Ask the learner to choose the highest-signal diagnostic check.",
+        "action_cue": "Run one focused verification before applying a fix."
+      }
     }
   ],
   "preserve_block_index": [],
@@ -79,12 +90,20 @@
 }
 ```
 
-```md
+```markdown
+Ask the learner to recall a production metric that changed unexpectedly and state what made the change look meaningful rather than random.
+
+Create a slide that shows a stable baseline followed by a sustained metric shift, with three diagnostic branches: workload shape, lock wait, and cache hit ratio.
+
+Explain that persistence separates drift from noise, while classification prevents the learner from applying a plausible fix to the wrong cause.
+
 Ask the learner to identify the highest-signal diagnostic step for the drifting metric.
 ---
 ?[%{{diagnosis_choice}} check workload shape | check lock wait | check cache hit ratio]
 ---
-The learner's diagnosis choice is {{diagnosis_choice}}. Based on it, run one focused verification next.
+The learner's diagnosis choice is {{diagnosis_choice}}. Based on it, run one focused verification before suggesting a fix, and carry the choice into the next lesson's worked example.
+
+Have the learner write a one-sentence verification plan naming the signal, expected movement, and stop condition. Close by summarizing the sequence: observe, classify, verify, then fix.
 ```
 
 ## Optimization Output
@@ -101,13 +120,66 @@ The learner's diagnosis choice is {{diagnosis_choice}}. Based on it, run one foc
       "issue_class": "explanation_clarity",
       "change": "add brief boundary note after diagnosis selection"
     }
-  ],
-  "course_prompt": "# Role\nYou are a practical coach helping beginners diagnose bottlenecks.\n\n# Task\nGuide the learner through observation → classification → one focused verification.\n\n# Teaching Techniques\nEvidence chain; one core question per lesson; viewpoint branching on diagnosis choice.\n\n# Writing Style\nDirective, concise, action-oriented; English (en-US).\n\n# Format\nMarkdownFlow; `?[]` interactions on standalone lines.\n\n# Slides\nCreate diagnostic-flow slides in natural language; do not inline SVG/Mermaid."
+  ]
 }
+```
+
+### Course Prompt Artifact
+
+The `course_prompt` string is the complete content below; no template instruction
+is summarized or replaced by an ellipsis.
+
+```markdown
+# Role
+
+- You are Maya Chen.
+- You specialize in production observability and are a professional teacher in the field of metric drift diagnosis.
+
+# Task
+
+- The current course is *Metric Drift Diagnosis*. Your goal is to help the user master an observe, classify, verify, and fix workflow for production metric drift.
+- Teach one-on-one, address the learner only as "you", and do not use group-addressing terms such as "everyone", "class", or "students".
+- Do not introduce yourself.
+- Do not greet the user.
+- Do not proactively guide the user to the next step at the end.
+
+# Teaching Techniques
+
+- Design the explanation path according to cognitive learning patterns, following the rhythm of "build interest → lower the barrier → understand the structure → form application".
+- Do not simply pile up knowledge points. First explain "why it matters, why it works, and how to use it".
+- When dealing with complex content, break it down before expanding.
+- Prefer clear structures, such as binary distinctions, three-layer structures, step-by-step paths, and comparison relationships.
+- Use concrete scenarios, real examples, analogies, and before-and-after comparisons.
+- When the user may misunderstand something, correct the misconception first, then continue the explanation.
+- Each paragraph should serve a clear function: defining the problem, breaking down the structure, explaining the mechanism, or providing application.
+- If a summary is needed, prefer giving a clear judgment, an application scenario, or an actionable understanding.
+
+# Writing Style
+
+- Use a conversational, natural, and engaging tone, like a clear-minded person explaining something face to face.
+- Keep the language restrained, clear, and warm.
+- You may use analogies, contrasts, and comparisons, but do not sacrifice accuracy for catchy phrasing.
+
+# Format
+
+- Output in Markdown format.
+- Do not output headings of any level, such as #, ##, or ###.
+- Use bold formatting for key steps, cognitive turning points, core conclusions, and common misconceptions.
+- Only bold truly important information. Do not bold an entire paragraph.
+- Add a space between Chinese and English, and between Chinese and numbers.
+
+# Slides
+
+- Only create a slide, PPT, visual page, or classroom projection page when the instruction explicitly requests one. Do not proactively create visuals.
+- Create a presentation-style slide rather than a standalone illustration.
+- In-slide option labels must not be interactive.
+- Keep in-slide text concise and prompt-like. Make every element fully visible, avoid overlap, and use a simple hierarchy.
+- Treat the slide as a structural prompt and follow it with a complete text explanation that assumes the learner has not seen the slide. Add background, causality, examples, and usage instead of repeating the slide.
 ```
 
 ## Acceptance Notes
 
 - All four phases executed end-to-end.
 - One core question per lesson, every learner-answer variable has a corresponding variable-backed interaction and metadata entry.
+- The Course Prompt preserves all six sections and every non-placeholder template instruction.
 - Optimization pass found no blockers, only enhancement suggestions.

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -48,7 +48,7 @@
       "segment_type": "concept",
       "core_point": "Classify causes before applying fixes.",
       "preserve_block": false,
-      "source_span": {"source_id": "course_material", "start": 43, "end": 78},
+      "source_span": {"source_id": "course_material", "start": 41, "end": 71},
       "transfer_signals": {
         "concept_conflict": "Jumping to a fix before classifying the cause can hide the real bottleneck.",
         "interaction_intent_cue": "Ask the learner to choose the highest-signal diagnostic check.",

--- a/skills/ai-shifu-course-creator/examples/segmentation-only.md
+++ b/skills/ai-shifu-course-creator/examples/segmentation-only.md
@@ -34,7 +34,7 @@
       "segment_type": "concept",
       "core_point": "Idempotency is the precondition for safe retries.",
       "preserve_block": false,
-      "source_span": {"source_id": "course_material", "start": 0, "end": 118},
+      "source_span": {"source_id": "course_material", "start": 0, "end": 67},
       "transfer_signals": {
         "concept_conflict": "Retries are unsafe unless repeated execution is idempotent.",
         "interaction_intent_cue": "Ask the learner to identify the failure caused by retrying a non-idempotent operation."

--- a/skills/ai-shifu-course-creator/examples/segmentation-only.md
+++ b/skills/ai-shifu-course-creator/examples/segmentation-only.md
@@ -45,7 +45,7 @@
       "segment_type": "code",
       "core_point": "Retry call example",
       "preserve_block": true,
-      "source_span": {"source_id": "course_material", "start": 119, "end": 156},
+      "source_span": {"source_id": "course_material", "start": 68, "end": 97},
       "transfer_signals": {
         "evidence_type": "Executable retry example that must remain unchanged.",
         "action_cue": "Use the preserved call to test whether repeated execution is safe."

--- a/skills/ai-shifu-course-creator/examples/segmentation-only.md
+++ b/skills/ai-shifu-course-creator/examples/segmentation-only.md
@@ -34,14 +34,22 @@
       "segment_type": "concept",
       "core_point": "Idempotency is the precondition for safe retries.",
       "preserve_block": false,
-      "source_span": {"start": 0, "end": 118}
+      "source_span": {"source_id": "course_material", "start": 0, "end": 118},
+      "transfer_signals": {
+        "concept_conflict": "Retries are unsafe unless repeated execution is idempotent.",
+        "interaction_intent_cue": "Ask the learner to identify the failure caused by retrying a non-idempotent operation."
+      }
     },
     {
       "segment_id": "S02",
       "segment_type": "code",
       "core_point": "Retry call example",
       "preserve_block": true,
-      "source_span": {"start": 119, "end": 156}
+      "source_span": {"source_id": "course_material", "start": 119, "end": 156},
+      "transfer_signals": {
+        "evidence_type": "Executable retry example that must remain unchanged.",
+        "action_cue": "Use the preserved call to test whether repeated execution is safe."
+      }
     }
   ],
   "preserve_block_index": [

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -17,6 +17,9 @@ Provide one of:
 - Lesson granularity preference (`short`, `medium`, `long`).
 - Tone constraints.
 - Non-negotiable source fragments.
+- `course_author_name` (string): the course author's real name for the Course
+  Prompt role. If absent when a Course Prompt must be generated, ask the author
+  instead of inventing a persona name.
 - `course_profile` object.
 - `delivery_constraints` object.
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`).
@@ -52,6 +55,7 @@ Provide one of:
 ```json
 {
   "course_material": "long transcript or merged markdown",
+  "course_author_name": "Author-provided real name",
   "generation_constraints": {
     "persona": "hands-on mentor",
     "lesson_granularity": "short"
@@ -107,7 +111,13 @@ Each item:
 - Base it on the course topic, target learners, and concrete learning outcomes.
 - Write it to `course-description.md`; the CLI maps it to the platform `description` field during build/import.
 
-### Minimal Output Example
+### Minimal Structured Artifact Excerpt
+
+This excerpt shows the JSON-shaped artifacts without abbreviating the required
+Course Prompt into an invalid pseudo-prompt. The complete `course_prompt` string
+must be a fully filled six-section artifact with no ellipsis standing in for
+template instructions; see the runnable example in
+[`examples/pipeline-full.md#course-prompt-artifact`](../examples/pipeline-full.md#course-prompt-artifact).
 
 ```json
 {
@@ -136,7 +146,6 @@ Each item:
       "effect_scope": "cross_lesson"
     }
   ],
-  "course_prompt": "# Role\nYou are ...\n\n# Task\n- The learner goal is {{learner_goal}}. When the learner goal is UNKNOWN, use the course default examples; otherwise adapt course-wide examples to it. ...\n\n# Teaching Techniques\n- ...\n\n# Writing Style\n- ...\n\n# Format\n- ...\n\n# Slides\n- ...",
   "course_description": "A practical course that helps beginner operators diagnose metric drift, identify likely causes, and choose one concrete fix."
 }
 ```
@@ -167,8 +176,28 @@ Each item in the Segmentation output (consumed by Orchestration and Generation):
 - `segment_type` (string enum, required) — one of `concept`, `example`, `code`, `image`, `exercise`, `transition`; semantics in [pedagogy.md#segment-types](pedagogy.md#segment-types).
 - `core_point` (string, required) — the single teachable point this segment carries.
 - `preserve_block` (boolean, required) — `true` for code/image/table/required-quote blocks that must reach the lesson verbatim per [markdownflow.md#preservation](markdownflow.md#preservation).
-- `source_span` (string, required) — traceable reference back to the source material.
-- `transfer_signals` (object, required) — downstream teaching-quality cues; field names and meanings defined in [pedagogy.md#transfer-signals](pedagogy.md#transfer-signals).
+- `source_span` (object, required) — traceable source location with `source_id`
+  (string), `start` (non-negative integer, inclusive character offset), and `end`
+  (integer greater than `start`, exclusive character offset). Use the same object
+  shape as entries in `course_index.source_span_map`.
+- `transfer_signals` (object, required) — downstream teaching-quality cues. Use
+  only the canonical keys below, include every cue that applies to the segment,
+  and omit inapplicable keys rather than inventing content. Each included value
+  is a concise string:
+  - `learner_hook`
+  - `evidence_type`
+  - `visual_cue`
+  - `concept_conflict`
+  - `boundary_cue`
+  - `action_cue`
+  - `density_cue`
+  - `quote_cue`
+  - `visual_text_pair_cue`
+  - `interaction_intent_cue`
+  - `compare_cue`
+
+  The teaching meaning of these cues is defined in
+  [pedagogy.md#transfer-signals](pedagogy.md#transfer-signals).
 
 For segmentation rules and methodology see [pedagogy.md#segmentation-methodology](pedagogy.md#segmentation-methodology).
 
@@ -179,9 +208,9 @@ For segmentation rules and methodology see [pedagogy.md#segmentation-methodology
 - `name` (string, required) — the variable name as referenced in `{{var}}` / `?[%{{var}} ...]`; new variable names should use the resolved output language and be composed of letters, numbers, and underscores.
 - `collected_in` (string, required) — `lesson_id` where the variable is first collected.
 - `used_in` (array of strings, required) — every lesson that references the variable through `{{var}}`, plus reserved value `course_prompt` when `course-prompt.md` references it. Include `collected_in` only if that same lesson also references `{{var}}` after collecting it.
-- `effect_scope` (string enum: `local|cross_lesson`, required).
+- `effect_scope` (string constant: `cross_lesson`, required).
 
-Only named variables belong in `global_variable_table`. No-variable `?[...]` interactions do not create table entries. Use named variables only when the learner's answer must be used outside the current lesson; lesson-local branching, examples, feedback, summaries, and inputs stay no-variable. A variable referenced from `course-prompt.md` has `effect_scope: "cross_lesson"` because the Course Prompt can influence more than one lesson; still list `course_prompt` in `used_in` whenever `course-prompt.md` references the variable. For variable *syntax and runtime substitution semantics* (`{{var}}` → stored value or `UNKNOWN`) see [markdownflow.md#variables](markdownflow.md#variables); for variable *strategy and pacing* see [pedagogy.md#variable-strategy](pedagogy.md#variable-strategy).
+Only named variables belong in `global_variable_table`. No-variable `?[...]` interactions do not create table entries. Use named variables only when the learner's answer must be used outside the current lesson; lesson-local branching, examples, feedback, summaries, and inputs stay no-variable. Therefore every table entry has `effect_scope: "cross_lesson"`; a local scope is invalid and should be represented by a no-variable interaction instead. Still list `course_prompt` in `used_in` whenever `course-prompt.md` references the variable. For variable *syntax and runtime substitution semantics* (`{{var}}` → stored value or `UNKNOWN`) see [markdownflow.md#variables](markdownflow.md#variables); for variable *strategy and pacing* see [pedagogy.md#variable-strategy](pedagogy.md#variable-strategy).
 
 ## Lesson Schema
 


### PR DESCRIPTION
## Summary

- align the segmentation contract with the object-shaped source spans used by the examples
- define canonical transfer-signal keys and restrict named variables to cross-lesson scope
- replace abbreviated Course Prompt examples with complete runnable artifacts that use author-provided names
- complete the generation example's visual-text pair and downstream learner output
- validate example JSON, segment contracts, variable scope, and Course Prompt template retention

## Root cause

The documented schemas and runnable examples had evolved independently. Existing validation checked metadata and Markdown anchors, but did not verify that example payloads still satisfied the current data and Course Prompt contracts.

## Benefit

Course authors and agents now receive internally consistent examples, and future schema or prompt-template drift fails repository validation instead of reaching users.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `python3 -m compileall scripts/validate_skill_quality.py`
- `git diff --check`
- negative contract probe confirming malformed source spans and unknown transfer-signal keys are rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional course author name support for personalized Course Prompts.
  * Course Prompt examples now preserve the complete six-section template as a standalone artifact.
  * Expanded instructional examples with richer verification guidance and learner decision steps.
  * Added clearer source attribution and transfer guidance to segmentation and lesson outputs.

* **Documentation**
  * Updated data contracts for source spans, transfer signals, global variables, and author information.

* **Tests**
  * Added validation for example JSON structures and Course Prompt completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->