### PR TITLE
fix: remove unnecessary soft line breaks

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -69,9 +69,7 @@ Use these optional controls across all phases:
 - `course_author_name` (string): course author's real name for the Course Prompt role.
 - `course_profile` (json): audience and pedagogical parameters.
 - `delivery_constraints` (json): platform limits, topic policy, and non-negotiable fragments.
-- `interaction_policy` (json): normalized Course Design Intake result with
-  `mode` and selected `purposes`; see
-  `references/data-contracts.md#interaction-policy`.
+- `interaction_policy` (json): normalized Course Design Intake result with `mode` and selected `purposes`; see `references/data-contracts.md#interaction-policy`.
 - `target_language` (BCP-47 string, e.g. `zh-CN` / `en-US` / `fr-FR`): explicit output language; takes priority over prompt-language detection. Full priority order in `references/data-contracts.md#language-resolution`.
 
 Field-level schemas with example JSON in `references/data-contracts.md#recommended-object-shapes`.
@@ -187,21 +185,7 @@ Use the answers as course-design constraints:
   `## Generation`) to lesson content, the Course Prompt, and Listen Mode.
   Question explicitly skipped → infer the format from the source material
   structure instead of inventing a fixed default.
-- **Interaction choices → interaction policy and placement.** Resolve one of
-  three policies before Orchestration: one or more purposes selected →
-  `enabled`; none selected → `disabled`; question explicitly skipped →
-  `unspecified`. Under `enabled`, place early learner-context collection for
-  adaptive teaching, pre-content prompts for thinking or misconception
-  correction, and lesson-end self-checks for assessment only as selected.
-  `learner_context` requires collection at an early course or module point,
-  `pre_content_thinking` requires a prompt before the relevant explanation, and
-  `lesson_end_self_check` requires a self-check at each lesson end. `enabled`
-  does not by itself require an interaction in every lesson beyond those
-  selected-purpose placements. Under `disabled`, emit no `?[]` blocks, solicit
-  no learner answer, and collect no learner-answer variables. `unspecified`
-  adds no interaction-policy constraint or override; keep the existing
-  authoring behavior as-is. Pass the normalized `interaction_policy` unchanged
-  to Generation and Optimization.
+- **Interaction choices → interaction policy and placement.** Resolve one of three policies before Orchestration: one or more purposes selected → `enabled`; none selected → `disabled`; question explicitly skipped → `unspecified`. Under `enabled`, place early learner-context collection for adaptive teaching, pre-content prompts for thinking or misconception correction, and lesson-end self-checks for assessment only as selected. `learner_context` requires collection at an early course or module point, `pre_content_thinking` requires a prompt before the relevant explanation, and `lesson_end_self_check` requires a self-check at each lesson end. `enabled` does not by itself require an interaction in every lesson beyond those selected-purpose placements. Under `disabled`, emit no `?[]` blocks, solicit no learner answer, and collect no learner-answer variables. `unspecified` adds no interaction-policy constraint or override; keep the existing authoring behavior as-is. Pass the normalized `interaction_policy` unchanged to Generation and Optimization.
 - **Listen Mode**: pure slides → disable it and do not ask the question.
   Otherwise the question must mention the extra AI-Shifu credit consumption;
   unanswered → disabled; an explicit enable/disable decision carries into the
@@ -355,14 +339,7 @@ Generate a runnable Teaching Prompt for each lesson.
 
 Apply the patterns and constraints in `references/pedagogy.md#teaching-patterns`, `#cognitive-techniques`, `#variable-strategy`, `#interaction-design`, and `#visual-text-coordination` unless content requires a justified variation.
 
-Resolve the Course Design Intake interaction policy before applying those
-patterns. Under `enabled`, explicitly choose the interaction type before writing
-the `?[]` line per Hard Rule 3, but add it only where a selected purpose applies;
-if a lesson naturally asks "which of these apply?", default to multi-select
-unless the source or user says only one answer is allowed. Under `disabled`,
-convert learner-response steps into worked examples, model-led application, or
-consolidation; emit no `?[]` blocks or learner-answer variables. Under
-`unspecified`, apply the baseline as-is without an interaction-policy override.
+Resolve the Course Design Intake interaction policy before applying those patterns. Under `enabled`, explicitly choose the interaction type before writing the `?[]` line per Hard Rule 3, but add it only where a selected purpose applies; if a lesson naturally asks "which of these apply?", default to multi-select unless the source or user says only one answer is allowed. Under `disabled`, convert learner-response steps into worked examples, model-led application, or consolidation; emit no `?[]` blocks or learner-answer variables. Under `unspecified`, apply the baseline as-is without an interaction-policy override.
 
 ### Single-Lesson Generation Strategy
 
@@ -371,9 +348,7 @@ Required anchors per lesson:
 1. Opening paragraph with a teaching-start function (Hard Rule 6) — not a copied chapter / lesson title or directory label.
 2. Opening objective plus slide-style visual cover.
 3. Evidence-chain explanation.
-4. When a selected interaction purpose applies to this lesson, an effective
-   interaction with visible downstream effect. Otherwise, a worked application
-   or consolidation step with visible instructional value and no learner input.
+4. When a selected interaction purpose applies to this lesson, an effective interaction with visible downstream effect. Otherwise, a worked application or consolidation step with visible instructional value and no learner input.
 5. At least one reusable deliverable.
 6. Lesson close with summary or decision checkpoint.
 
@@ -381,30 +356,18 @@ Optional modules: viewpoint calibration, misconception correction, dual delivera
 
 ### Slide-Only Generation Override
 
-When Course Design Intake resolves to pure slides / classroom interactive
-slides, replace the default explanation-heavy lesson pattern with a projection
-pattern. Pure slides are for classroom projection by a human instructor, not AI
-narration:
+When Course Design Intake resolves to pure slides / classroom interactive slides, replace the default explanation-heavy lesson pattern with a projection pattern. Pure slides are for classroom projection by a human instructor, not AI narration:
 
 - Treat each lesson as a small slide deck controlled by a human instructor.
-- Generate slide-facing blocks only: slide title, 2-4 short bullets, and a
-  visual/layout instruction. When the interaction policy permits an
-  interaction, also include its prompt, options, and concise feedback states.
-- Keep permitted interactions runnable with the normal MarkdownFlow syntax,
-  but keep the surrounding content presentation-oriented. Under `disabled`,
-  omit interaction prompts, options, feedback branches, and learner-answer
-  variables entirely.
+- Generate slide-facing blocks only: slide title, 2-4 short bullets, and a visual/layout instruction. When the interaction policy permits an interaction, also include its prompt, options, and concise feedback states.
+- Keep permitted interactions runnable with the normal MarkdownFlow syntax, but keep the surrounding content presentation-oriented. Under `disabled`, omit interaction prompts, options, feedback branches, and learner-answer variables entirely.
 - Do not include AI narration directives or learner-facing lecture prose such as
   "explain to the learner", "walk through", "向学习者说明", "讲解", "用文字解释",
   "讲清", or long paragraphs intended for the AI to speak.
 - Do not require the normal visual-text explanation pair. The visual itself and
   the short on-slide labels carry the projection content; any explanation
   belongs to the human instructor, not the Teaching Prompt.
-- The Course Prompt must describe the runtime role as producing classroom
-  slides, using "interactive slides" only when the interaction policy permits
-  interactions, not as conducting one-on-one tutoring. Do not include
-  course-level instructions that ask the AI to verbally explain the lesson to a
-  single learner.
+- The Course Prompt must describe the runtime role as producing classroom slides, using "interactive slides" only when the interaction policy permits interactions, not as conducting one-on-one tutoring. Do not include course-level instructions that ask the AI to verbally explain the lesson to a single learner.
 
 ### Outputs
 

--- a/skills/ai-shifu-course-creator/examples/generation-only.md
+++ b/skills/ai-shifu-course-creator/examples/generation-only.md
@@ -67,8 +67,7 @@ Have the learner write a one-sentence verification rule containing the signal, e
 
 ## No-Interaction Variant
 
-When Course Design Intake explicitly resolves to no interactions, the same
-lesson uses a worked application instead of forcing the default interaction:
+When Course Design Intake explicitly resolves to no interactions, the same lesson uses a worked application instead of forcing the default interaction:
 
 ```json
 {
@@ -88,9 +87,7 @@ lesson uses a worked application instead of forcing the default interaction:
 }
 ```
 
-This variant contains no `?[]` block, learner-answer request, answer-dependent
-branch, or learner-answer variable. Its loop is setup → explanation → worked
-application → close.
+This variant contains no `?[]` block, learner-answer request, answer-dependent branch, or learner-answer variable. Its loop is setup → explanation → worked application → close.
 
 ## Degraded Input
 
@@ -98,9 +95,7 @@ Degraded-input handling for this phase (fallback lesson JSON with `fallback_mode
 
 ## Acceptance Notes
 
-- In the `enabled` snapshot, the selected interaction drives current-lesson text
-  changes.
+- In the `enabled` snapshot, the selected interaction drives current-lesson text changes.
 - Core idea includes visual-plus-text explanation in final script.
 - Interaction count stays within declared limits.
-- The no-interaction variant satisfies the alternative teaching loop without
-  adding interaction syntax or learner-answer variables.
+- The no-interaction variant satisfies the alternative teaching loop without adding interaction syntax or learner-answer variables.

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -22,8 +22,7 @@ Provide one of:
   instead of inventing a persona name.
 - `course_profile` object.
 - `delivery_constraints` object.
-- `interaction_policy` object: normalized Course Design Intake result; see
-  [Interaction Policy](#interaction-policy).
+- `interaction_policy` object: normalized Course Design Intake result; see [Interaction Policy](#interaction-policy).
 - `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`).
 
 ### Recommended Object Shapes
@@ -65,19 +64,13 @@ Provide one of:
 }
 ```
 
-Course Design Intake resolves this control once and passes it unchanged to
-Generation and Optimization:
+Course Design Intake resolves this control once and passes it unchanged to Generation and Optimization:
 
-- `enabled` requires a non-empty, duplicate-free `purposes` array containing
-  only the three canonical values above. Each purpose controls only its own
-  placement; enabling one does not implicitly enable the others.
+- `enabled` requires a non-empty, duplicate-free `purposes` array containing only the three canonical values above. Each purpose controls only its own placement; enabling one does not implicitly enable the others.
 - `disabled` and `unspecified` require an empty `purposes` array.
 - `disabled` forbids interaction syntax and learner-answer variables.
-- `unspecified` adds no downstream behavior constraint or override; existing
-  authoring logic, including `delivery_constraints.interaction_density`,
-  applies as-is.
-- `delivery_constraints.interaction_density` never overrides `disabled` or the
-  selected-purpose placements under `enabled`.
+- `unspecified` adds no downstream behavior constraint or override; existing authoring logic, including `delivery_constraints.interaction_density`, applies as-is.
+- `delivery_constraints.interaction_density` never overrides `disabled` or the selected-purpose placements under `enabled`.
 
 ### Minimal Input Payload Example
 
@@ -112,8 +105,7 @@ Generation and Optimization:
 - If multiple files are provided, ordering must be explicit.
 - Source language and expected output language should be specified when multilingual content exists.
 - Explicit output language requests must not be overridden by source-language mixes (see [Language Resolution](#language-resolution)).
-- `interaction_policy` must satisfy the mode/purpose invariants above before
-  Generation or Optimization applies pedagogical gates.
+- `interaction_policy` must satisfy the mode/purpose invariants above before Generation or Optimization applies pedagogical gates.
 
 ## Output Contract
 

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -22,24 +22,13 @@ Disallowed patterns:
 
 ## Interaction Policy Precedence
 
-The `enabled` and `disabled` interaction policies resolved by Course Design
-Intake override the applicable default teaching patterns and gates in this file;
-`unspecified` leaves them unchanged:
+The `enabled` and `disabled` interaction policies resolved by Course Design Intake override the applicable default teaching patterns and gates in this file; `unspecified` leaves them unchanged:
 
-- `enabled`: one or more interaction purposes were selected. Require only the
-  selected-purpose placements: `learner_context` at an early course or module
-  point, `pre_content_thinking` before the relevant explanation, and
-  `lesson_end_self_check` at each lesson end. Enabling one purpose does not make
-  the unselected purposes or a blanket per-lesson interaction mandatory.
-- `disabled`: the author explicitly selected no interactions. Emit no `?[]`
-  blocks, solicit no learner answer, collect no learner-answer variables, and
-  create no answer-dependent branch. Replace interactive steps with worked
-  examples, model-led application, or consolidation.
-- `unspecified`: add no interaction-policy requirement or override. Apply the
-  teaching patterns and gates in this file as-is.
+- `enabled`: one or more interaction purposes were selected. Require only the selected-purpose placements: `learner_context` at an early course or module point, `pre_content_thinking` before the relevant explanation, and `lesson_end_self_check` at each lesson end. Enabling one purpose does not make the unselected purposes or a blanket per-lesson interaction mandatory.
+- `disabled`: the author explicitly selected no interactions. Emit no `?[]` blocks, solicit no learner answer, collect no learner-answer variables, and create no answer-dependent branch. Replace interactive steps with worked examples, model-led application, or consolidation.
+- `unspecified`: add no interaction-policy requirement or override. Apply the teaching patterns and gates in this file as-is.
 
-A `disabled` lesson is not incomplete merely because it has no interaction. All
-non-interaction pedagogy rules remain active.
+A `disabled` lesson is not incomplete merely because it has no interaction. All non-interaction pedagogy rules remain active.
 
 ## Teaching Patterns
 
@@ -48,9 +37,7 @@ non-interaction pedagogy rules remain active.
 1. Observable phenomenon
 2. Mechanism explanation
 3. Practical implication
-4. Learner interaction; under `enabled`, include it only when a selected purpose
-   applies to this lesson, and under `disabled`, replace it with worked
-   application
+4. Learner interaction; under `enabled`, include it only when a selected purpose applies to this lesson, and under `disabled`, replace it with worked application
 5. Summary and action
 
 ### Pattern B: Misconception Repair
@@ -58,29 +45,19 @@ non-interaction pedagogy rules remain active.
 1. Surface common misconception
 2. Explain why it sounds plausible
 3. Correct with mechanism and boundary
-4. Run an interaction check; under `enabled`, include it only when a selected
-   purpose applies to this lesson, and under `disabled`, show a worked boundary
-   check instead
+4. Run an interaction check; under `enabled`, include it only when a selected purpose applies to this lesson, and under `disabled`, show a worked boundary check instead
 5. Apply corrected model to a real case
 
 ### Pattern C: Comparison-Driven Learning
 
-1. Baseline response capture; under `enabled`, include it only when a selected
-   purpose applies to this lesson, and under `disabled`, establish a worked
-   baseline instead
+1. Baseline response capture; under `enabled`, include it only when a selected purpose applies to this lesson, and under `disabled`, establish a worked baseline instead
 2. Alternate scenario or constraint
 3. Side-by-side interpretation
 4. Updated decision path
 
 ## Cognitive Techniques
 
-Increase learner understanding through targeted cognitive moves rather than
-information dumping. By default, each lesson should include at least one of
-these moves as a deepening interaction. Under `enabled`, require an interaction
-only where a selected purpose applies; when `pre_content_thinking` or
-`lesson_end_self_check` applies, use at least one move as that interaction.
-Under `disabled`, express the move as a model-led demonstration, contrast,
-worked decision, or action synthesis without soliciting learner input.
+Increase learner understanding through targeted cognitive moves rather than information dumping. By default, each lesson should include at least one of these moves as a deepening interaction. Under `enabled`, require an interaction only where a selected purpose applies; when `pre_content_thinking` or `lesson_end_self_check` applies, use at least one move as that interaction. Under `disabled`, express the move as a model-led demonstration, contrast, worked decision, or action synthesis without soliciting learner input.
 
 1. **Calibration prompt** — Ask learners to make a concrete judgment before explanation.
 2. **Boundary framing** — Clarify where the concept works and where it breaks.
@@ -92,11 +69,7 @@ worked decision, or action synthesis without soliciting learner input.
 
 Every lesson must satisfy a minimum teaching loop and a few cross-cutting constraints:
 
-- **Minimum teaching loop**: by default, setup → explanation → interaction →
-  close. Under `enabled`, use that loop only when a selected purpose applies to
-  the current lesson; otherwise use setup → explanation → worked application or
-  consolidation → close. Under `disabled`, use the non-interactive loop for
-  every lesson. A lesson missing a required phase is incomplete.
+- **Minimum teaching loop**: by default, setup → explanation → interaction → close. Under `enabled`, use that loop only when a selected purpose applies to the current lesson; otherwise use setup → explanation → worked application or consolidation → close. Under `disabled`, use the non-interactive loop for every lesson. A lesson missing a required phase is incomplete.
 - **One core question per lesson**: each lesson resolves exactly one teachable question.
 - **Action tasks** must be either immediately executable by the learner or explicitly linked to a downstream lesson — no orphan actions.
 - **Variable naming** must be consistent and traceable across lessons (new variables should use the resolved output language; use letters, numbers, and underscores; cross-check with [data-contracts.md#variable-table](data-contracts.md#variable-table)).
@@ -194,15 +167,8 @@ These are the *teaching* rules around variables — when to collect, how often, 
 
 These are the *teaching* rules around interactions. For interaction *syntax* see [markdownflow.md#interactions](markdownflow.md#interactions).
 
-- These rules are the default interaction design. Under `enabled`, selected
-  purposes replace the blanket per-lesson interaction requirement. Under
-  `disabled`, they require no interaction.
-- Every selected-purpose placement is present at its defined scope. An
-  interaction serving `pre_content_thinking` or `lesson_end_self_check` includes
-  a deepening move (calibration, boundary check, or misconception correction —
-  see [Cognitive Techniques](#cognitive-techniques)); `learner_context`
-  collection is not forced into a different purpose merely to satisfy this
-  rule.
+- These rules are the default interaction design. Under `enabled`, selected purposes replace the blanket per-lesson interaction requirement. Under `disabled`, they require no interaction.
+- Every selected-purpose placement is present at its defined scope. An interaction serving `pre_content_thinking` or `lesson_end_self_check` includes a deepening move (calibration, boundary check, or misconception correction — see [Cognitive Techniques](#cognitive-techniques)); `learner_context` collection is not forced into a different purpose merely to satisfy this rule.
 - Interaction prompts must be concrete and directly answerable.
 - Place interactions at decision points, not only at lesson start.
 - Choose the interaction type by the nature of the learner decision:

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -31,12 +31,9 @@ Optimization 全面审计清单 — Optimization Optimization 必须把每条都
 
 ## Lesson Loop
 
-- The interaction policy used for this audit resolves to `enabled`, `disabled`,
-  or `unspecified` and matches the Course Design Intake answer.
+- The interaction policy used for this audit resolves to `enabled`, `disabled`, or `unspecified` and matches the Course Design Intake answer.
 - By default, the minimum loop is setup → explanation → interaction → close.
-- Under `enabled`, require the default interaction loop only when a selected
-  purpose applies; otherwise use setup → explanation → worked application or
-  consolidation → close.
+- Under `enabled`, require the default interaction loop only when a selected purpose applies; otherwise use setup → explanation → worked application or consolidation → close.
 - Under `disabled`, use the non-interactive loop for every lesson.
 - One core question per lesson; resolved by lesson close.
 - Action tasks executable now or explicitly linked to a downstream lesson.
@@ -46,19 +43,15 @@ Optimization 全面审计清单 — Optimization Optimization 必须把每条都
 
 ## Interaction Quality
 
-- Under `disabled`, no `?[]` block, learner-answer request, learner-answer
-  variable, or answer-dependent branch is present.
+- Under `disabled`, no `?[]` block, learner-answer request, learner-answer variable, or answer-dependent branch is present.
 - Interactions that are present are concrete and answerable.
 - Interaction type matches the decision: single-select for mutually exclusive path choices, multi-select for non-exclusive learner context, goals, interests, modules, blockers, scenarios, experience, or practice needs. For multi-select, downstream content is driven through combined feedback, prioritization, or tailored examples rather than exhaustive branching for every combination.
 - Learner-facing questions appear before interaction syntax, not after `%{{var}}` inside `?[%{{var}} ...]`.
 - Each `?[]` interaction appears on its own line.
 - If the pre-interaction text enumerates or describes choices, the `?[]` option labels match those choices exactly — same set, order, and wording.
 - Input interactions include a specific pre-interaction question plus a shorter `...` placeholder.
-- Unless `enabled` or `disabled` overrides the default, at least one deepening
-  interaction appears per lesson.
-- Every selected-purpose placement appears at its defined scope. Interactions
-  serving `pre_content_thinking` or `lesson_end_self_check` include a deepening
-  move; `learner_context` collection is not forced into another purpose.
+- Unless `enabled` or `disabled` overrides the default, at least one deepening interaction appears per lesson.
+- Every selected-purpose placement appears at its defined scope. Interactions serving `pre_content_thinking` or `lesson_end_self_check` include a deepening move; `learner_context` collection is not forced into another purpose.
 - Branching paths are distinct where required; `*_viewpoint_check` interactions branch by option.
 - Instructional interaction results affect later content through immediate feedback or a visible downstream effect.
 - Repeated interaction semantics avoided across lessons unless comparison intent is explicit.


### PR DESCRIPTION
## Summary

- Join unnecessary soft-wrapped prose in the interaction policy documentation.
- Preserve all wording, Markdown structure, code blocks, paragraph boundaries, and list hierarchy.

## Why

Artificial line wrapping made prose-only changes harder to edit and review by adding line-level noise without changing rendered output.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `python3 -m unittest tests.test_validate_skill_quality`
- `git diff --check`
- Confirmed the word-level diff contains no textual changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and clarified guidance for interaction policies across course creation specifications, data contracts, pedagogy references, and review checklists.
  * Improved formatting and readability of generation-only examples and acceptance notes.
  * Preserved existing interaction behavior, validation requirements, and slide-only generation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->