### PR TITLE
fix: list and search courses across all pages

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `list` and `find-title` to include courses beyond the first API page.
 - Turn `SKILL.md` into a task router with explicit shared dependencies.
 - Split authoring, deployment, authentication, and analytics instructions into route-specific reference files.
 - Restore global language and reporting contracts, narrow analytics routing to live-course data, and add routing regression evals.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -566,8 +566,6 @@ def _fetch_all_courses(base_url, token):
         if len(items) < COURSE_LIST_PAGE_SIZE:
             break
 
-        if not items:
-            break
         page_index += 1
 
     return courses

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -49,7 +49,7 @@ _TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
 # or list every course must page explicitly instead of silently using that
 # first-page default.
 COURSE_LIST_PAGE_SIZE = 50
-MAX_COURSE_PAGES = 200
+MAX_COURSE_PAGES = 10
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -49,6 +49,7 @@ _TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
 # or list every course must page explicitly instead of silently using that
 # first-page default.
 COURSE_LIST_PAGE_SIZE = 50
+MAX_COURSE_PAGES = 200
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
@@ -532,6 +533,12 @@ def _fetch_all_courses(base_url, token):
     page_index = 1
 
     while True:
+        if page_index > MAX_COURSE_PAGES:
+            print(
+                "API error: GET /shifus exceeded the maximum page limit; "
+                "refusing to return incomplete course results"
+            )
+            sys.exit(1)
         result = api(
             base_url,
             token,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -559,13 +559,11 @@ def _fetch_all_courses(base_url, token):
 
         page_count = result.get("page_count")
         total = result.get("total")
-        if isinstance(page_count, int):
-            if page_index >= page_count:
-                break
-        elif isinstance(total, int):
-            if len(courses) >= total:
-                break
-        elif len(items) < COURSE_LIST_PAGE_SIZE:
+        if isinstance(page_count, int) and page_index >= page_count:
+            break
+        if isinstance(total, int) and len(courses) >= total:
+            break
+        if len(items) < COURSE_LIST_PAGE_SIZE:
             break
 
         if not items:

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -45,6 +45,11 @@ TOKEN_EXPIRE_SECONDS = 604800
 _TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
 # 1001 = userNotFound, 1004 = userNotLogin, 1005 = userTokenExpired
 
+# The course-list endpoint defaults to 10 rows. Commands that promise to search
+# or list every course must page explicitly instead of silently using that
+# first-page default.
+COURSE_LIST_PAGE_SIZE = 50
+
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
 def load_env():
@@ -515,6 +520,54 @@ def cmd_verify(args):
 
 
 # ── List ───────────────────────────────────────────────────────────────────────
+def _fetch_all_courses(base_url, token):
+    """Return every active course visible to the current creator.
+
+    The backend returns a ``PageNationDTO`` and defaults to 10 rows when the
+    caller omits pagination. Keep the legacy list response fallback for older
+    deployments, while following ``page_count`` on the current API.
+    """
+
+    courses = []
+    page_index = 1
+
+    while True:
+        result = api(
+            base_url,
+            token,
+            "get",
+            f"/shifus?page_index={page_index}&page_size={COURSE_LIST_PAGE_SIZE}",
+        )
+        if isinstance(result, list):
+            courses.extend(result)
+            break
+        if not isinstance(result, dict):
+            break
+
+        items = result.get("items") or []
+        if not isinstance(items, list):
+            print("API error: GET /shifus returned invalid pagination data")
+            sys.exit(1)
+        courses.extend(items)
+
+        page_count = result.get("page_count")
+        total = result.get("total")
+        if isinstance(page_count, int):
+            if page_index >= page_count:
+                break
+        elif isinstance(total, int):
+            if len(courses) >= total:
+                break
+        elif len(items) < COURSE_LIST_PAGE_SIZE:
+            break
+
+        if not items:
+            break
+        page_index += 1
+
+    return courses
+
+
 def _fetch_shifu_title(base_url, token, shifu_bid, *, table_key, session=None):
     """Fetch the current title from one of the shifu metadata tables.
 
@@ -560,13 +613,7 @@ def cmd_list(args):
     the draft title for the live learner-facing title.
     """
     base_url, token = resolve_auth(args)
-    result = api(base_url, token, "get", "/shifus")
-
-    if not result:
-        print("No courses found.")
-        return
-
-    courses = result if isinstance(result, list) else result.get("items", [])
+    courses = _fetch_all_courses(base_url, token)
     if not courses:
         print("No courses found.")
         return
@@ -2325,8 +2372,7 @@ def cmd_find_title(args):
         )
         sys.exit(1)
 
-    result = api(base_url, token, "get", "/shifus")
-    courses = result if isinstance(result, list) else (result or {}).get("items", [])
+    courses = _fetch_all_courses(base_url, token)
     if not courses:
         print("No courses found for this account.")
         return

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -147,6 +147,31 @@ class CourseCreatorCliPaginationTests(unittest.TestCase):
             ],
         )
 
+    def test_course_pagination_stops_at_the_safety_limit(self):
+        def full_page_api(_base_url, _token, method, path, **_kwargs):
+            self.assertEqual(method, "get")
+            self.requested_paths.append(path)
+            return {"items": list(self.first_page)}
+
+        with (
+            mock.patch.object(course_creator_cli, "COURSE_LIST_PAGE_SIZE", 2),
+            mock.patch.object(course_creator_cli, "MAX_COURSE_PAGES", 2),
+            mock.patch.object(course_creator_cli, "api", side_effect=full_page_api),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                course_creator_cli._fetch_all_courses("base", "token")
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("maximum page limit", stdout.getvalue())
+        self.assertEqual(
+            self.requested_paths,
+            [
+                "/shifus?page_index=1&page_size=2",
+                "/shifus?page_index=2&page_size=2",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = REPO_ROOT / "skills" / "ai-shifu-course-creator" / "scripts"
+SCRIPT_PATH = SCRIPT_DIR / "shifu-cli.py"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# The repository test workflow installs requests, while python-dotenv is only a
+# runtime dependency of the deployment CLI. Stub its two imported functions so
+# these transport-free unit tests stay self-contained.
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda **_kwargs: None
+    dotenv_stub.set_key = lambda *_args, **_kwargs: None
+    sys.modules["dotenv"] = dotenv_stub
+
+spec = importlib.util.spec_from_file_location("course_creator_cli", SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+course_creator_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(course_creator_cli)
+
+
+class CourseCreatorCliPaginationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.first_page = [
+            {
+                "bid": "course-1",
+                "name": "第一门课",
+                "status": "draft",
+                "updated_at": "2026-07-13T08:00:00Z",
+            },
+            {
+                "bid": "course-2",
+                "name": "第二门课",
+                "status": "draft",
+                "updated_at": "2026-07-13T07:00:00Z",
+            },
+        ]
+        self.second_page = [
+            {
+                "bid": "course-3",
+                "name": "跟 AI 学 AI 通识",
+                "status": "published",
+                "updated_at": "2026-07-12T08:00:00Z",
+            }
+        ]
+        self.requested_paths: list[str] = []
+
+    def fake_course_list_api(self, _base_url, _token, method, path, **_kwargs):
+        self.assertEqual(method, "get")
+        self.requested_paths.append(path)
+        if path == "/shifus?page_index=1&page_size=2":
+            return {
+                "page": 1,
+                "page_size": 2,
+                "total": 3,
+                "page_count": 2,
+                "items": self.first_page,
+            }
+        if path == "/shifus?page_index=2&page_size=2":
+            return {
+                "page": 2,
+                "page_size": 2,
+                "total": 3,
+                "page_count": 2,
+                "items": self.second_page,
+            }
+        self.fail(f"Unexpected API path: {path}")
+
+    def test_list_includes_courses_from_later_pages(self):
+        args = types.SimpleNamespace(token="token")
+
+        with (
+            mock.patch.object(
+                course_creator_cli, "resolve_auth", return_value=("base", "token")
+            ),
+            mock.patch.object(
+                course_creator_cli, "COURSE_LIST_PAGE_SIZE", 2
+            ),
+            mock.patch.object(
+                course_creator_cli, "api", side_effect=self.fake_course_list_api
+            ),
+            mock.patch.object(
+                course_creator_cli, "_fetch_shifu_title", return_value=None
+            ),
+            mock.patch.object(course_creator_cli.requests, "Session"),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            course_creator_cli.cmd_list(args)
+
+        output = stdout.getvalue()
+        self.assertIn("course-3", output)
+        self.assertIn("Total: 3 courses", output)
+        self.assertEqual(
+            self.requested_paths,
+            [
+                "/shifus?page_index=1&page_size=2",
+                "/shifus?page_index=2&page_size=2",
+            ],
+        )
+
+    def test_find_title_matches_a_course_from_a_later_page(self):
+        args = types.SimpleNamespace(keyword="通识", token="token")
+
+        def fake_title(_base_url, _token, bid, *, table_key, session=None):
+            del session
+            if bid == "course-3" and table_key == "shifu_published_shifus":
+                return "跟 AI 学 AI 通识"
+            return None
+
+        with (
+            mock.patch.object(
+                course_creator_cli, "resolve_auth", return_value=("base", "token")
+            ),
+            mock.patch.object(
+                course_creator_cli, "COURSE_LIST_PAGE_SIZE", 2
+            ),
+            mock.patch.object(
+                course_creator_cli, "api", side_effect=self.fake_course_list_api
+            ),
+            mock.patch.object(
+                course_creator_cli, "_fetch_shifu_title", side_effect=fake_title
+            ),
+            mock.patch.object(course_creator_cli.requests, "Session"),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            course_creator_cli.cmd_find_title(args)
+
+        output = stdout.getvalue()
+        self.assertIn("Published", output)
+        self.assertIn("course-3  跟 AI 学 AI 通识", output)
+        self.assertEqual(
+            self.requested_paths,
+            [
+                "/shifus?page_index=1&page_size=2",
+                "/shifus?page_index=2&page_size=2",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -172,6 +172,36 @@ class CourseCreatorCliPaginationTests(unittest.TestCase):
             ],
         )
 
+    def test_course_pagination_stops_when_total_is_reached_early(self):
+        def oversized_page_count_api(
+            _base_url, _token, method, path, **_kwargs
+        ):
+            self.assertEqual(method, "get")
+            self.requested_paths.append(path)
+            if path != "/shifus?page_index=1&page_size=2":
+                self.fail(f"Unexpected redundant API path: {path}")
+            return {
+                "page": 1,
+                "page_size": 2,
+                "total": 1,
+                "page_count": 2,
+                "items": list(self.second_page),
+            }
+
+        with (
+            mock.patch.object(course_creator_cli, "COURSE_LIST_PAGE_SIZE", 2),
+            mock.patch.object(
+                course_creator_cli, "api", side_effect=oversized_page_count_api
+            ),
+        ):
+            courses = course_creator_cli._fetch_all_courses("base", "token")
+
+        self.assertEqual(courses, self.second_page)
+        self.assertEqual(
+            self.requested_paths,
+            ["/shifus?page_index=1&page_size=2"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -185,7 +185,7 @@ class CourseCreatorCliPaginationTests(unittest.TestCase):
                 "page_size": 2,
                 "total": 1,
                 "page_count": 2,
-                "items": list(self.second_page),
+                "items": list(self.first_page),
             }
 
         with (
@@ -196,7 +196,7 @@ class CourseCreatorCliPaginationTests(unittest.TestCase):
         ):
             courses = course_creator_cli._fetch_all_courses("base", "token")
 
-        self.assertEqual(courses, self.second_page)
+        self.assertEqual(courses, self.first_page)
         self.assertEqual(
             self.requested_paths,
             ["/shifus?page_index=1&page_size=2"],


### PR DESCRIPTION
## Summary

- Fetch every `/shifus` page for both `list` and `find-title`.
- Reuse one shared pagination helper with a 50-course page size.
- Add regression coverage for listing and title matching when the target course is on a later page.
- Record the fix in the AI-Shifu Course Creator changelog.

## Root cause

The CLI called the paginated `/shifus` endpoint without pagination parameters. The service defaults to 10 courses, so `list` reported only the first page and `find-title` returned false negatives for older courses.

## Impact

Creators can now list and search every active course visible to their account, including courses beyond the first API page.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 44 tests passed
- `python3 scripts/validate_skill_quality.py` — 2 skills validated
- `python3 -m py_compile skills/ai-shifu-course-creator/scripts/shifu-cli.py tests/test_course_creator_cli.py`
- Live verification: `find-title "通识"` found both matching courses, including `跟 AI 学 AI 通识`
- Live verification: `list` reported 33 courses instead of the previous first-page total of 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated course listing to include courses from all available pages.
  - Expanded title searches to find matching courses beyond the first page.
  - Improved compatibility with different course API response formats.

- **Tests**
  - Added coverage for multi-page listing and title search results.
  - Verified correct pagination requests, totals, and search output.

- **Documentation**
  - Added an Unreleased changelog entry describing the pagination fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->