### PR TITLE
chore: bump ai-shifu-course-creator to 1.1.1

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: AI-Shifu Course Creator
 description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing Teaching Prompts (per-lesson) and Course Prompts (course-level) — both written in MarkdownFlow (MDF). Covers the full course lifecycle — from converting raw material into structured lessons, to scripting interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Also covers post-deployment analytics on those courses — learner count, completion rate, stuck lessons, orders, revenue, ratings, credit consumption, audience profiles, and individual learner tracking. Trigger on any mention of AI-Shifu, AI师傅, MarkdownFlow, Teaching Prompt, Course Prompt authoring, course analytics, creator analytics, 学习人数, 完成率, 卡课节, 订单收入, 积分消耗, or learner progress.
-version: 1.1.0
+version: 1.1.1
 version_management: standalone
 ---
 


### PR DESCRIPTION
## Why

ClawHub rejects re-publishing an existing version (`Version 1.1.0 already exists`), so releasing the content changes merged since the 1.1.0 release (e.g. #100) requires a version bump. Release versions across all channels follow the SKILL.md `version` field.

## Changes

- `skills/ai-shifu-course-creator/SKILL.md`: `version` 1.1.0 → 1.1.1 (one line, no content changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI Shifu Course Creator skill to version 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->