### PR TITLE
chore: make commit titles clear to product users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,10 @@
 ## Git Commit Message Requirements
 
 - Subject: use English Conventional Commits without scope parentheses, such as
-  `type: summary`; do not use `type(scope): summary`.
+  `type: summary`; do not use `type(scope): summary`. Write the summary in
+  plain language that product users can understand. When a change affects
+  users, describe the user-visible outcome or benefit instead of only naming
+  the internal implementation detail.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
 - Classification: use `chore` for repository-maintenance-only instructions,
   guidance updates like this file, or non-behavioral skill maintenance.


### PR DESCRIPTION
## Summary

- Require commit summaries to use plain language that product users can understand.
- For user-impacting changes, describe the visible outcome or benefit instead of only internal implementation details.

## Why

Commit history should communicate the purpose of a change to product users and reviewers, not only to the implementation author.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `python3 -m unittest discover -s tests` (53 tests)