### PR TITLE
fix: simplify course output language handling

### DIFF
--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -764,7 +764,6 @@ def validate_course_prompt_example(
     prompt_template_lines: list[str],
     md_file: Path,
     issues: IssueBag,
-    is_localized: bool = False,
 ) -> None:
     if "XXX" in prompt:
         issues.add_error(
@@ -804,7 +803,7 @@ def validate_course_prompt_example(
                 f"{md_file}: Course Prompt example headings are out of order; "
                 f"expected: {', '.join(english_headings)}"
             )
-        elif english_headings and not is_localized:
+        elif english_headings:
             missing_headings = sorted(english_heading_set - heading_set)
             unexpected_headings = sorted(heading_set - english_heading_set)
             issues.add_error(
@@ -812,9 +811,6 @@ def validate_course_prompt_example(
                 f"the template; missing: {', '.join(missing_headings) or 'none'}; "
                 f"unexpected: {', '.join(unexpected_headings) or 'none'}"
             )
-        # Localized examples cannot be compared to English instructions by exact
-        # text. Their six-section shape and resolved placeholders are still
-        # validated above; semantic localization remains a human review concern.
         return
 
     for required_line in prompt_template_lines:
@@ -870,7 +866,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
             payload_offsets.append(match.start())
 
         source_candidates: dict[str, list[tuple[int, str]]] = {}
-        target_language_candidates: list[tuple[int, str]] = []
         interaction_mode_candidates: list[tuple[int, str | None]] = []
         for payload_index, payload in enumerate(parsed_payloads):
             if isinstance(payload, dict):
@@ -879,8 +874,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                         source_candidates.setdefault(key, []).append(
                             (payload_index, value)
                         )
-                    if key == "target_language" and isinstance(value, str):
-                        target_language_candidates.append((payload_index, value))
                     if key == "interaction_policy":
                         interaction_mode_candidates.append(
                             (
@@ -894,17 +887,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
         for payload_index, payload in enumerate(parsed_payloads):
             source_texts = source_texts_for_payload(
                 payload_index, source_candidates
-            )
-            target_language = source_texts_for_payload(
-                payload_index,
-                (
-                    {"target_language": target_language_candidates}
-                    if target_language_candidates
-                    else {}
-                ),
-            ).get("target_language")
-            is_localized = bool(target_language) and not (
-                target_language.lower().startswith("en")
             )
             interaction_mode = interaction_mode_at_offset(
                 interaction_mode_candidates,
@@ -1021,7 +1003,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                             prompt_template_lines,
                             md_file,
                             issues,
-                            is_localized=is_localized,
                         )
                     else:
                         issues.add_error(
@@ -1057,10 +1038,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                     issues,
                 )
 
-        artifact_is_localized = bool(target_language_candidates) and all(
-            not language.lower().startswith("en")
-            for _, language in target_language_candidates
-        )
         for match in course_prompt_artifact_matches:
             interaction_mode = interaction_mode_at_offset(
                 interaction_mode_candidates,
@@ -1075,7 +1052,6 @@ def validate_example_contracts(skill_dir: Path, issues: IssueBag) -> None:
                 prompt_template_lines,
                 md_file,
                 issues,
-                is_localized=artifact_is_localized,
             )
 
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -13,11 +13,12 @@ Route each request to the smallest complete instruction set needed to create, ed
 
 On the first invocation in a session:
 
-1. Read `references/session-controls.md` completely before the first user-visible response.
-2. Apply its contact, version-check, output-language, and terminology rules.
-3. Classify the request with the routing table below.
-4. Read every file listed for the selected route, in order, before acting. Do not load unrelated route guides.
-5. For mixed requests, combine the relevant rows and preserve their dependency order.
+1. Read `references/data-contracts.md#language-resolution` and resolve `resolved_target_language` before the first user-visible response.
+2. Read `references/session-controls.md` completely before the first user-visible response.
+3. Apply its contact, version-check, progress/error/handoff, and terminology rules.
+4. Classify the request with the routing table below.
+5. Read every file listed for the selected route, in order, before acting. Do not load unrelated route guides.
+6. For mixed requests, combine the relevant rows and preserve their dependency order.
 
 ## Task Router
 
@@ -59,7 +60,7 @@ Apply `references/report-template.md#formatting-rules` to every user-facing phas
 
 ### Shared and route guides
 
-- `references/session-controls.md` — first-turn contact, update check, global output language, and canonical terminology.
+- `references/session-controls.md` — first-turn contact, update check, progress/error/handoff messages, and canonical terminology.
 - `references/authentication.md` — verify-first login and SMS-quota protection.
 - `references/course-target.md` — mandatory new-vs-existing resolution.
 - `references/authoring-controls.md` — execution modes and shared authoring control inputs.

--- a/skills/ai-shifu-course-creator/examples/deploy-only.md
+++ b/skills/ai-shifu-course-creator/examples/deploy-only.md
@@ -1,6 +1,6 @@
 # Deploy Only Example
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 Deploy pre-existing Teaching Prompts (and a Course Prompt) without running the authoring pipeline.
 

--- a/skills/ai-shifu-course-creator/examples/fallback-mode.md
+++ b/skills/ai-shifu-course-creator/examples/fallback-mode.md
@@ -1,6 +1,6 @@
 # Fallback Mode Example
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 Demonstrates degraded-input handling across the four phases. This file is the single home for fallback scenarios; the phase-only examples cover standard mode and point here.
 

--- a/skills/ai-shifu-course-creator/examples/generation-only.md
+++ b/skills/ai-shifu-course-creator/examples/generation-only.md
@@ -1,6 +1,6 @@
 # Generation Only Example
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 ## Minimal Input
 

--- a/skills/ai-shifu-course-creator/examples/optimization-only.md
+++ b/skills/ai-shifu-course-creator/examples/optimization-only.md
@@ -1,6 +1,6 @@
 # Optimization Only Example
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 ## Minimal Input
 
@@ -9,7 +9,6 @@
   "existing_teaching_prompt": "## Objective\nUnderstand retry policy.\n\n?[%{{answer}} yes | no]\n\nGreat job.",
   "course_material": "Learner must differentiate transient vs permanent failure and choose a matching retry stop rule.",
   "course_author_name": "Priya Shah",
-  "target_language": "en-US",
   "interaction_policy": {
     "mode": "enabled",
     "purposes": ["pre_content_thinking"]

--- a/skills/ai-shifu-course-creator/examples/pipeline-full.md
+++ b/skills/ai-shifu-course-creator/examples/pipeline-full.md
@@ -1,6 +1,6 @@
 # Full Pipeline Example (Segmentation → Orchestration → Generation → Optimization)
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 ## Input Payload (example)
 
@@ -24,8 +24,7 @@
   },
   "delivery_constraints": {
     "must_cover_topics": ["diagnosis", "verification"]
-  },
-  "target_language": "en-US"
+  }
 }
 ```
 

--- a/skills/ai-shifu-course-creator/examples/segmentation-only.md
+++ b/skills/ai-shifu-course-creator/examples/segmentation-only.md
@@ -1,6 +1,6 @@
 # Segmentation Only Example
 
-> Note: Outputs in this example are illustrated in English for clarity. Actual output language follows `../references/data-contracts.md#language-resolution` (e.g., Chinese invocation → Chinese output).
+> Note: This repository example is illustrated in English for clarity.
 
 ## Minimal Input
 
@@ -18,8 +18,7 @@
   },
   "delivery_constraints": {
     "must_cover_topics": ["idempotency", "failure taxonomy"]
-  },
-  "target_language": "en-US"
+  }
 }
 ```
 

--- a/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
+++ b/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
@@ -115,6 +115,8 @@ Pass every result through these checks before showing it to the user:
 
 ## Answer Structure
 
+Write answer headings, narrative findings, interpretations, refusals, and drill-down offers in `resolved_target_language`. Keep table names, JSON/DSL fields, commands, raw enum codes, and ids as internal control data; present their translated human meaning according to the gate above.
+
 1. **Numbers + plain language**: express results in ordinary language; all codes and IDs are already translated.
 2. **One-line interpretation**: avoid raw data dumps — add a brief "what this means" judgement.
 3. **Proactive drill-down offer**: based on the current result, suggest 1–2 follow-up questions the user might want to explore.

--- a/skills/ai-shifu-course-creator/references/authentication.md
+++ b/skills/ai-shifu-course-creator/references/authentication.md
@@ -6,6 +6,8 @@ Read this file before any CLI-backed course-target, deployment, management, or a
 
 Always use `scripts/shifu-cli.py`. Never read tokens directly, construct authentication headers, or make raw platform API calls.
 
+Write SMS-code prompts, verification or network-failure explanations, and next-step login guidance in `resolved_target_language`. Keep CLI commands, exit codes, and raw technical values unchanged when they must be shown.
+
 1. Run `shifu-cli.py verify` before considering login.
 2. Handle the exit code:
    - Exit `0`: the token is valid; continue without logging in.

--- a/skills/ai-shifu-course-creator/references/authoring-controls.md
+++ b/skills/ai-shifu-course-creator/references/authoring-controls.md
@@ -23,6 +23,5 @@ Use these optional controls across authoring phases:
 - `course_profile` (json): audience and pedagogical parameters.
 - `delivery_constraints` (json): platform limits, topic policy, and non-negotiable fragments.
 - `interaction_policy` (json): normalized Course Design Intake result with `mode` and selected `purposes`; see `data-contracts.md#interaction-policy`.
-- `target_language` (BCP-47 string): explicit output language; apply the global resolution rules in `session-controls.md#output-language`.
 
 Field-level schemas and example JSON: `data-contracts.md#recommended-object-shapes`.

--- a/skills/ai-shifu-course-creator/references/authoring-intake.md
+++ b/skills/ai-shifu-course-creator/references/authoring-intake.md
@@ -10,7 +10,7 @@ statistics requests.
 
 Before asking anything, extract answers already present in the user's current
 instruction, source material, or pulled course directory. Ask only for missing
-items, in the user's language, as a step-by-step choice flow — ask the
+items, in `resolved_target_language`, as a step-by-step choice flow — ask the
 usage-scenario question first, show its options, wait for the answer, then ask
 only the next still-missing applicable question. Do not offer "you can let me
 decide" or similar bypass wording before the required choice flow is complete.

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -60,6 +60,8 @@ Field reference:
 
 `assets/raw/` is a recommendation, not enforced: store originals there so the manifest's `local` paths are stable across machines. The `build` command ignores `assets/` entirely.
 
+When Generation authors a new `images[].alt` value that will be embedded in a Teaching Prompt, write it in `resolved_target_language`. Preserve a source-provided alt selected as immutable; the other manifest bookkeeping fields are not localized.
+
 ## .shifu-sync.json
 
 Auto-maintained by `pull` and the version-aware write commands
@@ -92,16 +94,22 @@ concurrent edit. `content_sha256` lets `status` tell whether the local file was
 edited since the last sync. See
 `cli-reference.md#version-sync-pull--status` for the workflow.
 
+## README.md
+
+The first Markdown heading is the course-title source when `--title` is absent. When the skill creates or edits that heading, write the title in `resolved_target_language`. Other README content is not consumed by `build` as course metadata.
+
 ## Lesson Files
 
 When `structure.json` is not present, `build` auto-discovers only `lesson-*.md` files (e.g., `lesson-01.md`, `lesson-02.md`) and ignores other filenames. When `structure.json` is present, lesson files are taken from `chapters[].lessons[].file` and any filename is accepted as long as it exists.
+
+For every generated or edited lesson file, write authored Teaching Prompt instructions and learner-facing text in `resolved_target_language`. Preserve MarkdownFlow syntax, code, URLs, existing variable names, and required verbatim source text.
 
 ## course-description.md
 
 Contains the learner-facing SEO/listing description for the course. Path A and
 Author Only outputs must generate this file from the course topic, target
 learners, and concrete learning outcomes; do not include author-side workflow
-notes.
+notes. Write its complete learner-facing content in `resolved_target_language`.
 
 The `build` and `import --course-dir` commands map this file to
 `shifu.description` in `shifu-import.json`, which the CLI sends to the platform
@@ -122,6 +130,8 @@ successful platform update.
 
 Defines the AI engine's course-wide role and presentation style. Teaching methods and interaction rules remain in the per-lesson Teaching Prompts; the Course Prompt follows them without replacing their pedagogy. The `build` command reads this file and populates `shifu.course_prompt` in the import JSON automatically (which the CLI maps to the platform API field `system_prompt` on import).
 
+Write the six section headings, fill values, and instruction text in `resolved_target_language`; preserve stable syntax, URLs, code, and required verbatim source text.
+
 Authoring rules and a fillable template live in `../course-prompt.md`.
 
 Course Prompt content follows the HTML-comment behavior defined in `../markdownflow.md#preprocessing`; comments do not provide runtime instructions to the LLM.
@@ -131,6 +141,8 @@ Course Prompt content follows the HTML-comment behavior defined in `../markdownf
 Defines multi-chapter course structure. If this file exists, `build` uses it to organize lessons into chapters; otherwise all lessons are placed under a single auto-generated chapter.
 
 Use `structure.json` as the metadata outlet for chapter and lesson titles. Do not duplicate these titles as opening Markdown headings inside the lesson files unless the course explicitly needs visible headings and rendering support has been confirmed.
+
+Write `chapters[].title` and `chapters[].lessons[].title` in `resolved_target_language`. Keep JSON keys, lesson filenames, access values, booleans, and ids unchanged.
 
 Schema:
 

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -11,11 +11,11 @@ Use this file to materialize one course-wide artifact from the six-section templ
 
 ## Authoring Workflow
 
-1. Resolve the output language using [data-contracts.md#language-resolution](data-contracts.md#language-resolution).
+1. Resolve `resolved_target_language` using [data-contracts.md#language-resolution](data-contracts.md#language-resolution).
 2. Copy the complete [Fillable Template](#fillable-template), preserving its six sections and their order.
 3. Replace every `XXX` from [Placeholder Sources and Context](#placeholder-sources-and-context). Use already-collected artifacts and apply the listed context constraints to the fill values.
-4. Render section headings and body text in the resolved output language. The English template is canonical structure, not a language default.
-5. Keep every non-placeholder instruction. Adapt wording only when needed to preserve the same rule in the resolved language.
+4. Render section headings and body text in `resolved_target_language`. The English template is canonical structure, not a language default.
+5. Keep every non-placeholder instruction. Adapt wording only when needed to preserve the same rule in `resolved_target_language`.
 6. Run the [Materialization Checks](#materialization-checks).
 
 ## Fillable Template
@@ -81,7 +81,7 @@ Use these inputs as context constraints while wording the five fill values; they
 
 ## Materialization Checks
 
-- The six template sections are present in their original order and localized to the resolved output language.
+- The six template sections are present in their original order and localized to `resolved_target_language`.
 - All five `XXX` occurrences are replaced with course-specific content derived from the mapped sources.
 - Every non-placeholder template instruction remains represented with the same behavior.
 - The fill values satisfy the learner-profile, topic-scope, and delivery-mode context constraints above.

--- a/skills/ai-shifu-course-creator/references/course-target.md
+++ b/skills/ai-shifu-course-creator/references/course-target.md
@@ -4,6 +4,8 @@
 
 This workflow is mandatory before course creation, course-content editing, or deploy-only work. Read and complete `authentication.md` first.
 
+Write course-match summaries, new-versus-existing choice questions, ambiguous-match choices, and no-match explanations in `resolved_target_language`. Preserve course titles, Shifu BIDs, directory paths, and CLI commands verbatim.
+
 **This runs first for every course-creation or editing request — before
 Orchestration, before proposing any course architecture/outline, before writing a
 single lesson.** The AI-Shifu platform DB is the single source of truth; you must

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -1,6 +1,6 @@
 # Data Contracts
 
-Authoritative source for all schemas crossing the skill boundary: what comes in (input), what goes out (output), how output target language is resolved, and the per-lesson and per-variable shapes.
+Authoritative source for all schemas crossing the skill boundary: what comes in (input), what goes out (output), how `resolved_target_language` is derived, and the per-lesson and per-variable shapes.
 
 ## Input Contract
 
@@ -23,7 +23,6 @@ Provide one of:
 - `course_profile` object.
 - `delivery_constraints` object.
 - `interaction_policy` object: normalized Course Design Intake result; see [Interaction Policy](#interaction-policy).
-- `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`).
 
 ### Recommended Object Shapes
 
@@ -75,8 +74,6 @@ The teaching effects, purpose placements, and non-interactive substitutions are 
 
 - Input files must be readable text or markdown.
 - If multiple files are provided, ordering must be explicit.
-- Source language and expected output language should be specified when multilingual content exists.
-- Explicit output language requests must not be overridden by source-language mixes (see [Language Resolution](#language-resolution)).
 - `interaction_policy` must satisfy the mode/purpose invariants above before Generation or Optimization applies pedagogical gates.
 
 ## Output Contract
@@ -94,17 +91,17 @@ The teaching effects, purpose placements, and non-interactive substitutions are 
 Each item:
 
 - `lesson_id` (string, required)
-- `lesson_title` (string, required)
-- `core_question` (string, required)
+- `lesson_title` (string, required) — learner-facing title written in `resolved_target_language`.
+- `core_question` (string, required) — human-readable lesson question written in `resolved_target_language`.
 - `source_span_map` (array of `{source_id, start, end}`, required)
 
 ### `course_prompt` (string, required)
 
-Required for full-course authoring.
+Required for full-course authoring. Its six section headings, fill values, and instruction text use `resolved_target_language`; exact source quotations, code, URLs, and stable MarkdownFlow syntax remain unchanged.
 
 ### `course_description` (string, required)
 
-Required for full-course authoring. Write it to `course-description.md`; its directory contract and build mapping are defined in [course-directory-spec.md](cli/course-directory-spec.md#course-descriptionmd).
+Required for full-course authoring. Write the learner-facing description in `resolved_target_language` to `course-description.md`; its directory contract and build mapping are defined in [course-directory-spec.md](cli/course-directory-spec.md#course-descriptionmd).
 
 ## Segment Schema
 
@@ -112,7 +109,7 @@ Each item in the Segmentation output (consumed by Orchestration and Generation):
 
 - `segment_id` (string, required) — stable identifier within the run.
 - `segment_type` (string enum, required) — must satisfy [Segment Types](#segment-types).
-- `core_point` (string, required) — the single teachable point this segment carries.
+- `core_point` (string, required) — the single teachable point this segment carries, written in `resolved_target_language`.
 - `preserve_block` (boolean, required) — `true` when the source span is selected as immutable by [optimization-workflow.md#preservation-decisions](optimization-workflow.md#preservation-decisions). The field records the decision; downstream MarkdownFlow behavior is defined in [markdownflow.md#preservation](markdownflow.md#preservation).
 - `source_span` (object, required) — traceable source location with `source_id`
   (string), `start` (non-negative integer, inclusive character offset), and `end`
@@ -135,7 +132,7 @@ Each item in the Segmentation output (consumed by Orchestration and Generation):
 
 ### Transfer Signals
 
-`transfer_signals` must be non-empty. Include every applicable canonical key, omit inapplicable keys rather than inventing content, and give every included key a non-empty, concise string value.
+`transfer_signals` must be non-empty. Include every applicable canonical key, omit inapplicable keys rather than inventing content, and give every included key a non-empty, concise string value in `resolved_target_language`. Preserve an exact source quotation or other immutable source span when the signal intentionally carries it verbatim.
 
 | Key | Meaning |
 |---|---|
@@ -157,7 +154,7 @@ For segmentation rules and methodology, see [segmentation-orchestration.md#segme
 
 `global_variable_table` is an array. Each item:
 
-- `name` (string, required) — the variable name as referenced in `{{var}}` / `?[%{{var}} ...]`; new variable names use the resolved output language and are composed of letters, numbers, and underscores.
+- `name` (string, required) — the variable name as referenced in `{{var}}` / `?[%{{var}} ...]`; new variable names use `resolved_target_language` and are composed of letters, numbers, and underscores.
 - `collected_in` (string, required) — `lesson_id` where the variable is first collected.
 - `used_in` (array of strings, required) — every lesson that references the variable through `{{var}}`, plus reserved value `course_prompt` when `course-prompt.md` references it. Include `collected_in` only if that same lesson also references `{{var}}` after collecting it.
 - `effect_scope` (string constant: `cross_lesson`, required).
@@ -169,48 +166,21 @@ Only named variables belong in `global_variable_table`; no-variable `?[...]` int
 Each item in `lesson_teaching_prompts` (Generation per-lesson output):
 
 - `lesson_id` (string, required) — stable, deterministic identifier.
-- `lesson_title` (string, required) — concise learner-facing title. Chapter titles, lesson titles, numbering, hierarchy labels, and ordering markers belong in `course_index` / `structure.json`; do not duplicate them in the Teaching Prompt body.
-- `teaching_prompt` (string, required) — the per-lesson Teaching Prompt content (written in MarkdownFlow); apply [prompt-contracts.md#prompt-semantics](prompt-contracts.md#prompt-semantics).
+- `lesson_title` (string, required) — concise learner-facing title written in `resolved_target_language`. Chapter titles, lesson titles, numbering, hierarchy labels, and ordering markers belong in `course_index` / `structure.json`; do not duplicate them in the Teaching Prompt body.
+- `teaching_prompt` (string, required) — the per-lesson Teaching Prompt content, with authored natural-language instructions and learner-facing text written in `resolved_target_language` and MarkdownFlow syntax kept stable; apply [prompt-contracts.md#prompt-semantics](prompt-contracts.md#prompt-semantics).
 - `used_variables` (array of strings, required) — every named variable referenced or collected in this lesson; no-variable interactions are excluded. Cross-check with [Variable Table](#variable-table): each item here must have a matching `global_variable_table` entry, and that entry's `used_in` list must include this lesson when the variable is referenced outside the interaction line. If the Course Prompt references the same variable, `used_in` must also include `course_prompt`.
 - `depends_on_lessons` (array of lesson ids, required) — explicit list; empty list if none.
 
 ## Language Resolution
 
+`resolved_target_language` is a string derived for the current request; it is not an input field or an output artifact field. All downstream references to the selected language use `resolved_target_language`.
+
 ### Priority Order
 
-Resolve target language with this strict priority:
+Determine `resolved_target_language` with these two rules:
 
-1. `explicit_output_language_request` — language explicitly stated in the current user prompt.
-2. `target_language_parameter` — `target_language` field supplied in the input payload (BCP-47 recommended).
-3. `prior_context_language_directive` — language requirement declared **outside** the current prompt but visible to the skill: project/system instructions (e.g. `CLAUDE.md`), earlier turns of the same conversation, or directives injected by the calling agent. The skill cannot read external platform/account locale settings, so only in-context directives count here.
-4. `prompt_language_detection` — language detected from the wording of the current user prompt itself.
-5. `source_material_dominant_language` — the dominant language of the supplied course material.
-6. `default_fallback_language` — `zh-CN`.
-
-### Control Fields
-
-- `target_language` (BCP-47 recommended, for example `fr-FR`, `ja-JP`, `zh-CN`)
-
-### Rules
-
-- Do not restrict supported languages to a fixed list.
-- If output language is explicit, source-language distribution must not override it.
-- Learner-facing course content generated from Teaching Prompts must follow the resolved target language.
-- Newly authored MarkdownFlow variable names must follow the resolved output language within the valid variable-character set. Preserve existing or source-provided variable names when renaming would break an existing variable contract.
-- User-visible agent output must follow the resolved target language: chat replies, phase summaries, reports, headings, artifact labels, review notes, handoff instructions, and error explanations.
-- Human-facing labels for skill concepts must follow the canonical terms in [session-controls.md#canonical-term-translation-table](session-controls.md#canonical-term-translation-table) when the resolved target language is listed there; do not keep English labels merely because the skill docs and examples are written in English.
-- Stable machine-facing identifiers and verbatim source material remain unchanged even when the surrounding prose is localized: JSON keys (`course_index`, `global_variable_table`, `lesson_id`, `lesson_title`, `lesson_teaching_prompts`, `teaching_prompt`, `course_prompt`, `course_description`), file names (`course-description.md`, `course-prompt.md`, `structure.json`), CLI commands and flags, API fields, code symbols, MarkdownFlow syntax, URLs, code samples, and quoted source text or direct quotations that must be preserved verbatim.
-
-### Pre-Deploy Language Audit
-
-Before finalizing or deploying a generated course directory, audit all build-consumed user-visible artifacts and effective build metadata, so template headings or directive phrases from a different language do not remain after target-language rendering:
-
-- Resolved course title (`--title`, `README.md` first heading, or directory-name fallback).
-- Resolved course description (`--description` or `course-description.md`).
-- Resolved chapter titles (`structure.json`, `--chapter-name`, or course-title fallback).
-- Learner-facing lesson title fields in `structure.json`.
-- `course-prompt.md`.
-- Every lesson file referenced by `structure.json` (or every auto-discovered `lessons/lesson-*.md` file when `structure.json` is absent).
+1. `context_language_directive` — any applicable context explicitly specifies a language, including the current prompt, project or system instructions, earlier conversation turns, and directives from the calling agent.
+2. `prompt_language_detection` — otherwise, the language detected from the current user prompt.
 
 ## Fallback Output Extensions
 
@@ -224,7 +194,7 @@ Per-segment (extends [Segment Schema](#segment-schema)):
 
 Top-level addition to the Segmentation output:
 
-- `rerun_hints` (array of strings) — user-facing prompts describing what authoritative input would resolve the uncertainty.
+- `rerun_hints` (array of strings) — user-facing prompts in `resolved_target_language` describing what authoritative input would resolve the uncertainty.
 
 ### Orchestration fallback fields
 
@@ -236,15 +206,15 @@ Top-level addition:
 
 - `rerun_plan` (object, required when any lesson is uncertain):
   - `lessons_to_rerun` (array of lesson ids).
-  - `reason` (string) — why the rerun is needed.
+  - `reason` (string) — why the rerun is needed, written in `resolved_target_language`.
 
 ### Generation fallback fields
 
 Per-lesson (extends [Lesson Schema](#lesson-schema)):
 
 - `fallback_mode` (boolean) — `true` when this lesson was generated under fallback.
-- `assumptions` (array of strings) — assumptions made due to incomplete input.
-- `upgrade_notes` (array of strings) — what additional input would upgrade this lesson.
+- `assumptions` (array of strings) — assumptions made due to incomplete input, written in `resolved_target_language`.
+- `upgrade_notes` (array of strings) — what additional input would upgrade this lesson, written in `resolved_target_language`.
 
 ### Optimization fallback fields
 
@@ -254,6 +224,6 @@ Inside `risk_and_issue_report`:
 
 Top-level addition:
 
-- `follow_up` (array of strings) — required inputs to complete a full-coverage audit.
+- `follow_up` (array of strings) — required inputs in `resolved_target_language` to complete a full-coverage audit.
 
 For the four end-to-end fallback scenarios, see `examples/fallback-mode.md`.

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -179,7 +179,7 @@ Each item in `lesson_teaching_prompts` (Generation per-lesson output):
 
 Determine `resolved_target_language` with these two rules:
 
-1. `context_language_directive` — any applicable context explicitly specifies a language, including the current prompt, project or system instructions, earlier conversation turns, and directives from the calling agent.
+1. `context_language_directive` — any applicable context explicitly specifies a language, including the current prompt, project or system instructions, earlier conversation turns, and directives from the calling agent. When explicit directives conflict, follow the normal instruction hierarchy; at the same authority level, use the most recent applicable directive.
 2. `prompt_language_detection` — otherwise, the language detected from the current user prompt.
 
 ## Fallback Output Extensions

--- a/skills/ai-shifu-course-creator/references/deployment-workflow.md
+++ b/skills/ai-shifu-course-creator/references/deployment-workflow.md
@@ -47,7 +47,7 @@ All commands documented in `cli/cli-reference.md` (deployment: `build` / `import
 
 ### Deployment Workflow
 
-**Language gate:** Before finalizing or deploying generated or edited course content, run the [Pre-Deploy Language Audit](data-contracts.md#pre-deploy-language-audit) against the effective course directory and build metadata. This workflow invokes that gate; `data-contracts.md` remains the authority for what the audit covers.
+**Language gate:** Before any content or metadata mutation, run the source, effective-value, direct-command, and user-facing checks in [Language Audit](review-checklist.md#language-audit). After `build`, inspect the listed `shifu-import.json` fields before import or publish. This two-stage gate verifies the actual deployment payload rather than only the source files.
 
 **From pipeline (Path A continuation):**
 1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-description.md` (the generated SEO description; no author-side process notes), `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `course-prompt.md#fillable-template`), and required `structure.json`.

--- a/skills/ai-shifu-course-creator/references/generation-workflow.md
+++ b/skills/ai-shifu-course-creator/references/generation-workflow.md
@@ -47,6 +47,7 @@ Ask the learner for the course-wide goal that later lessons and the Course Promp
 - For a named value, first bind the substituted value in a natural sentence, such as `The learner goal is {{learning_goal}}.`, and then describe the branches against that sentence's value.
 - When a named value can be read before collection, branch on the literal substituted value `UNKNOWN`; do not test whether the marker exists or whether a variable is ready.
 - Every named learner-answer reference must have a matching variable-backed collection and satisfy the lifecycle and metadata invariants in `data-contracts.md#variable-table`.
+- Compose each newly authored variable name in `resolved_target_language` using only letters, numbers, and underscores. Preserve an existing or source-provided variable name when changing it would break the variable contract.
 
 #### Preservation Encoding
 
@@ -90,6 +91,10 @@ When Course Design Intake resolves to pure slides / classroom interactive slides
 
 Per-lesson schema in `data-contracts.md#lesson-schema`.
 
+Write `lesson_teaching_prompts[].lesson_title` and every authored natural-language part of `lesson_teaching_prompts[].teaching_prompt` in `resolved_target_language`. This includes teaching instructions, learner-facing questions and options, input hints, feedback and branch descriptions, explanations, summaries, and deterministic output text. Keep JSON keys, lesson ids, MarkdownFlow syntax, existing variable names, URLs, code, and required verbatim source text unchanged.
+
+When fallback mode adds `assumptions[]` or `upgrade_notes[]`, write those human-readable entries in `resolved_target_language`.
+
 ### Validation
 
 - Each `teaching_prompt` is valid runnable MarkdownFlow.
@@ -97,6 +102,7 @@ Per-lesson schema in `data-contracts.md#lesson-schema`.
 - Per-lesson schema populated per `data-contracts.md#lesson-schema`.
 - Pedagogical decisions pass per `pedagogy.md`; authoring passes [MarkdownFlow Authoring](#markdownflow-authoring); syntax and runtime behavior pass `markdownflow.md`.
 - The Teaching Prompt contains the lesson's teaching method and does not outsource pedagogical decisions to the Course Prompt.
+- The lesson title and every authored natural-language Teaching Prompt fragment pass the output-language requirements in [Outputs](#outputs).
 
 ### Image Authoring
 
@@ -111,9 +117,9 @@ Every uploaded image URL embedded in a Teaching Prompt uses `https://res.ai-shif
 | Display the uploaded image as authored, without layout customization | Wrap standard Markdown image syntax in the single-line deterministic form: `===![informative alt](url)===` |
 | Control width, alignment, caption, or multi-image layout | Write a natural-language HTML-view instruction and leave it generative |
 
-For a fixed image, make the alt describe what information the image conveys rather than using a generic label. The deterministic form makes the image line bypass the LLM.
+For a fixed image, make the alt describe what information the image conveys rather than using a generic label. Write newly authored alt text in `resolved_target_language`; preserve a source-provided alt selected as immutable. The deterministic form makes the image line bypass the LLM.
 
-For an HTML-view image, do not put generated HTML or the instruction inside `===...===` / `!===...!===`. Give the LLM one explicit directive containing the position, exact URL, image content, and layout. The wording must require the image to appear at that position, preserve the URL exactly, retain the content description for a semantic alt, and preserve the original aspect ratio whenever width is constrained. Use this compact shape in the resolved output language:
+For an HTML-view image, do not put generated HTML or the instruction inside `===...===` / `!===...!===`. Give the LLM one explicit directive in `resolved_target_language` containing the position, exact URL, image content, caption, and layout. Write newly authored descriptions, captions, and layout wording in `resolved_target_language`; preserve source-provided immutable text. The wording must require the image to appear at that position, preserve the URL exactly, retain the content description for a semantic alt, and preserve the original aspect ratio whenever width is constrained. Use this compact shape:
 
 ```markdown
 必须在此处以 HTML-view 方式插入一张带图注的图片,不得省略,并使用 HTML <figure>/<figcaption> 结构。

--- a/skills/ai-shifu-course-creator/references/optimization-workflow.md
+++ b/skills/ai-shifu-course-creator/references/optimization-workflow.md
@@ -66,7 +66,7 @@ Other instructional interactions satisfy their effect requirement through immedi
 
 ### Course Prompt
 
-Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six sections, their order, and every non-placeholder instruction; replace every `XXX` with course-specific content and render the result in `resolved_target_language`.
+Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six-section structure and order, placeholder source mapping, semantic requirements, and required literals. Replace every `XXX` with course-specific content, and translate every non-placeholder instruction into `resolved_target_language` without dropping or weakening its rule; keep required code, syntax, URLs, and other contract literals unchanged.
 
 Load and apply `prompt-contracts.md#artifact-responsibilities` before materializing the Course Prompt; Optimization does not reinterpret that boundary.
 
@@ -84,5 +84,5 @@ Write human-readable findings in `risk_and_issue_report`, each `change_list[].ch
 - Full review against `review-checklist.md` passes, or remaining gaps are explicitly listed as non-blocking suggestions.
 - Coverage, meaning, information density, and immutable source content remain intact; every broader rewrite is scoped, justified, and revalidated.
 - A `course_prompt` artifact is produced when input includes course material, with all six required canonical sections present.
-- Generated `course_prompt` has no unresolved `XXX`, retains every non-placeholder template instruction, and applies delivery-mode behavior consistent with the Course Design Intake.
+- Generated `course_prompt` has no unresolved `XXX`, represents every non-placeholder template instruction with the same behavior after localization, and applies delivery-mode behavior consistent with the Course Design Intake.
 - `course_description`, human-readable review findings, change descriptions, and fallback follow-up entries pass [Course Description and Review Outputs](#course-description-and-review-outputs).

--- a/skills/ai-shifu-course-creator/references/optimization-workflow.md
+++ b/skills/ai-shifu-course-creator/references/optimization-workflow.md
@@ -66,11 +66,17 @@ Other instructional interactions satisfy their effect requirement through immedi
 
 ### Course Prompt
 
-Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six sections, their order, and every non-placeholder instruction; replace every `XXX` with course-specific content and render the result in the resolved output language.
+Optimization also produces a course-level `course_prompt` artifact when input includes course material. Generate it by **copying and filling `course-prompt.md#fillable-template`, not by free-form composition**. Preserve the six sections, their order, and every non-placeholder instruction; replace every `XXX` with course-specific content and render the result in `resolved_target_language`.
 
 Load and apply `prompt-contracts.md#artifact-responsibilities` before materializing the Course Prompt; Optimization does not reinterpret that boundary.
 
-Resolve every placeholder and fill-value context strictly from [course-prompt.md#placeholder-sources-and-context](course-prompt.md#placeholder-sources-and-context); do not reconstruct or duplicate that source mapping here. Supply the artifacts and Course Design Intake controls named there, the resolved target language from [data-contracts.md#language-resolution](data-contracts.md#language-resolution), and relevant [Segmentation transfer signals](data-contracts.md#transfer-signals). Do not invent a fill value when its mapped source is unavailable; specifically, if `course_author_name` is missing, ask the author for their real name.
+Resolve every placeholder and fill-value context strictly from [course-prompt.md#placeholder-sources-and-context](course-prompt.md#placeholder-sources-and-context); do not reconstruct or duplicate that source mapping here. Supply the artifacts and Course Design Intake controls named there, `resolved_target_language` from [data-contracts.md#language-resolution](data-contracts.md#language-resolution), and relevant [Segmentation transfer signals](data-contracts.md#transfer-signals). Do not invent a fill value when its mapped source is unavailable; specifically, if `course_author_name` is missing, ask the author for their real name.
+
+### Course Description and Review Outputs
+
+Write the complete learner-facing `course_description` in `resolved_target_language`; keep author-side workflow notes out of it.
+
+Write human-readable findings in `risk_and_issue_report`, each `change_list[].change`, and fallback `follow_up[]` entries in `resolved_target_language`. Keep JSON keys, issue and risk enums, ids, file paths, MarkdownFlow syntax, code, URLs, and required verbatim source text unchanged.
 
 ### Validation
 
@@ -79,3 +85,4 @@ Resolve every placeholder and fill-value context strictly from [course-prompt.md
 - Coverage, meaning, information density, and immutable source content remain intact; every broader rewrite is scoped, justified, and revalidated.
 - A `course_prompt` artifact is produced when input includes course material, with all six required canonical sections present.
 - Generated `course_prompt` has no unresolved `XXX`, retains every non-placeholder template instruction, and applies delivery-mode behavior consistent with the Course Design Intake.
+- `course_description`, human-readable review findings, change descriptions, and fallback follow-up entries pass [Course Description and Review Outputs](#course-description-and-review-outputs).

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -151,6 +151,8 @@ Lesson-level preview URLs are no longer printed at all (they used to clutter rep
 
 Copy each printed URL **verbatim** (never reconstruct from a template, never hand-edit query parameters) and render it as three lines per the top-level Formatting Rules exception. The third line must be the script's following `# ...` hint copied verbatim, with the leading `#` and surrounding indentation removed. This keeps the script as the single source of truth for link-purpose and credit-consumption wording.
 
+The fenced snippets below are illustrative templates only. In the generated report, emit their three content lines as ordinary Markdown without the surrounding fence so the first line remains clickable.
+
 - `Admin console:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `管理后台`)
 
   ```md

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -6,15 +6,16 @@ Use the section matching the executed phase. Omit sections for phases not run.
 
 These rules apply to every report produced from this template, and to any other user-visible chat output that includes URLs.
 
+- **Report language.** Write report section headings, field labels, findings, issue explanations, suggestions, validation explanations, next actions, and handoff notes in `resolved_target_language`. Keep contract literals such as `standard|fallback`, `pass|fail`, `yes|no`, and `low|medium|high`, plus file paths, ids, CLI commands, and URLs unchanged.
 - **Links must be Markdown, never bare URLs.** Whenever you show a URL to the user (admin console, course preview, contact page, etc.), wrap it in Markdown link syntax `[descriptive text](URL)`. Never emit a bare `https://...` on its own line.
 - **Why:** the AI-Shifu chat client only treats Markdown links as clickable / copy-on-tap. A bare URL renders as plain text — the user cannot click it and cannot copy it cleanly on mobile.
 - **Where this applies:** phase reports below, the opening introduction, contact mentions, and any ad-hoc message that surfaces a URL to the user.
 - **Where this does NOT apply:** URLs inside Teaching Prompts (those follow MarkdownFlow image / link rules) and URLs shown inside fenced code blocks for reference.
 - **Exception — deployment / management Verification URLs.** When transcribing the `Verification URLs:` block printed by `shifu-cli.py` (`publish` / `import` / `create` / `show`), emit each URL as **three lines**:
-  1. A Markdown link — `[<course name> - <用途中文标签>](<URL>)`
+  1. A Markdown link — `[<course name> - <purpose label in resolved_target_language>](<URL>)`
   2. The same URL again on its own line (intentionally bare), indented two spaces — so the user can long-press / select to copy it cleanly.
   3. The script's following Chinese `# ...` hint, copied verbatim without the leading `#`.
-  The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients.
+  The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients. The script-owned Chinese hint on line 3 is a verbatim-output exception to the report-language rule; do not translate or rewrite it.
 
 ## Segmentation Report
 
@@ -150,28 +151,28 @@ Lesson-level preview URLs are no longer printed at all (they used to clutter rep
 
 Copy each printed URL **verbatim** (never reconstruct from a template, never hand-edit query parameters) and render it as three lines per the top-level Formatting Rules exception. The third line must be the script's following `# ...` hint copied verbatim, with the leading `#` and surrounding indentation removed. This keeps the script as the single source of truth for link-purpose and credit-consumption wording.
 
-- `Admin console:` → label `管理后台`
+- `Admin console:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `管理后台`)
 
   ```md
-  - [<course name> - 管理后台](<URL from script>)
+  - [<course name> - <localized admin-console label>](<URL from script>)
     <URL from script>
     <Chinese hint copied verbatim from the script output, without "#">
   ```
 
-- `Course preview:` → label `预览课程`
+- `Course preview:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `预览课程`)
 
   ```md
-  - [<course name> - 预览课程](<URL from script>)
+  - [<course name> - <localized course-preview label>](<URL from script>)
     <URL from script>
     <Chinese hint copied verbatim from the script output, without "#">
   ```
 
-- `Published URL:` (only when the script printed it) → label `课程学习`
+- `Published URL:` (only when the script printed it) → localize the purpose label in `resolved_target_language` (Simplified Chinese: `课程学习`)
 
   ```md
-  - [<course name> - 课程学习](<URL from script>)
+  - [<course name> - <localized published-course label>](<URL from script>)
     <URL from script>
     <Chinese hint copied verbatim from the script output, without "#">
   ```
 
-When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one line below them: `> 课程尚未发布，运行 \`publish <shifu_bid>\` 后会得到可对外分享的地址。`
+When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one sentence in `resolved_target_language` explaining that the course is not yet published and that `publish <shifu_bid>` will produce the shareable address.

--- a/skills/ai-shifu-course-creator/references/review-checklist.md
+++ b/skills/ai-shifu-course-creator/references/review-checklist.md
@@ -12,13 +12,41 @@ Optimization 全面审计清单。Optimization 必须逐项检查可观察结果
 
 - Teaching Prompt and Course Prompt content passes [prompt-contracts.md#prompt-semantics](prompt-contracts.md#prompt-semantics).
 
-## User-Visible Language
+## Language Audit
 
-- User-visible agent output outside generated course content follows the resolved target language from `data-contracts.md#language-resolution`.
-- Generated course artifacts and learner-facing passages follow the resolved target language.
-- Effective build metadata follows the resolved target language after precedence is applied: course title (`--title`, `README.md`, or directory-name fallback), course description (`--description` or `course-description.md`), chapter titles (`structure.json`, `--chapter-name`, or course-title fallback), and lesson titles.
-- Human-facing labels for canonical concepts follow [session-controls.md#canonical-term-translation-table](session-controls.md#canonical-term-translation-table) when the resolved target language is listed there.
-- Machine-facing identifiers and verbatim source material remain unchanged: JSON keys, file names, CLI flags, API fields, code symbols, MarkdownFlow syntax, URLs, code samples, and required verbatim source quotes.
+Resolve `resolved_target_language` from `data-contracts.md#language-resolution`, then inspect every human-readable output produced or changed by the active workflow. Passing one file is not enough; check each applicable item below.
+
+### Phase Output Fields
+
+- **Segmentation:** `segments[].core_point`, every human-readable `segments[].transfer_signals.*` value, `lesson_cut_candidates[].core_question`, and fallback `rerun_hints[]`.
+- **Orchestration:** `course_index[].lesson_title`, `course_index[].core_question`, and fallback `rerun_plan.reason`.
+- **Generation:** `lesson_teaching_prompts[].lesson_title` and the complete `lesson_teaching_prompts[].teaching_prompt`, including teaching instructions, learner questions and option labels, input hints, feedback or branch descriptions, explanations, summaries, newly authored image alt/content/caption/layout text, and deterministic output text. Also check fallback `assumptions[]` and `upgrade_notes[]`.
+- **Optimization:** the complete `course_prompt` (all six headings, fill values, and every section's instruction text), the complete learner-facing `course_description`, human-readable findings in `risk_and_issue_report`, every `change_list[].change`, and fallback `follow_up[]`.
+- **Variables:** each newly authored `global_variable_table[].name`; preserve an existing or source-provided variable name when changing it would break the contract.
+
+### Course Directory and Effective Build Values
+
+- **Course title:** check the value that will actually win: `--title`, otherwise the first heading in `README.md`, otherwise the directory name.
+- **Course description:** check `--description` when present; otherwise check the complete `course-description.md`; an empty fallback has no language to audit.
+- **Chapter titles:** check `structure.json.chapters[].title`; without `structure.json`, check `--chapter-name` or the resolved course-title fallback.
+- **Lesson titles:** check `structure.json.chapters[].lessons[].title`; without an explicit title, check the filename-derived title that `build` will emit.
+- **Course Prompt and lessons:** check the complete `course-prompt.md` and every lesson file referenced by `structure.json`; without `structure.json`, check every auto-discovered `lessons/lesson-*.md` file.
+- **Images:** check newly authored `assets/image-manifest.json.images[].alt` values that are embedded in lessons, plus the resulting lesson alt/content/caption/layout text.
+- **Direct management commands:** before mutation, check human-readable values passed through `create --name/--description`, `add-chapter --name`, `add-lesson --name/--teaching-prompt-file`, `update-meta --name/--description/--course-prompt-file`, `update-lesson --teaching-prompt-file`, and `rename-lesson --name`.
+- **Built deployment payload:** after `build`, inspect `shifu-import.json` fields `shifu.title`, `shifu.description`, and `shifu.course_prompt`; every `outline_items[].title`; each lesson item's `outline_items[].content`; and each lesson item's copied `outline_items[].course_prompt`. This confirms the final precedence and fallback values, not just the source files.
+
+### User-Facing Operational Outputs
+
+- Check contact and version notices, authentication guidance, course-target choices, Course Design Intake questions and options, progress updates, errors, review notes, and handoff instructions.
+- Check every phase report's headings, field labels, findings, issue explanations, suggestions, validation explanations, next actions, and handoff notes.
+- Check analytics answer headings, narrative findings, interpretations, refusals, and drill-down offers.
+- For canonical concepts, use the corresponding language column in `session-controls.md#canonical-term-translation-table` when available; otherwise localize naturally in `resolved_target_language`.
+
+### Language Audit Exclusions
+
+- Do not translate JSON keys, ids or BIDs, file names and paths, CLI commands and flags, API/DSL fields, code symbols, contract enum values, MarkdownFlow syntax, URLs, code samples, or fixed numeric values.
+- Preserve exact source quotations, regulated wording, source-selected immutable alt/captions, tables, and any other span selected by `optimization-workflow.md#preservation-decisions`; audit only the newly authored surrounding explanation.
+- In deployment reports, preserve the script-owned Chinese Verification URL hint verbatim as required by `report-template.md#formatting-rules`; localize the link-purpose label and surrounding explanation.
 
 ## Structure Separation
 
@@ -35,7 +63,7 @@ Optimization 全面审计清单。Optimization 必须逐项检查可观察结果
 - The final paragraph of each lesson is non-interactive.
 - One core question per lesson; resolved by lesson close.
 - Action tasks executable now or explicitly linked to a downstream lesson.
-- Variable naming consistent and traceable across lessons; new variable names follow the resolved output language and are composed of letters, numbers, and underscores.
+- Variable naming consistent and traceable across lessons; new variable names follow `resolved_target_language` and are composed of letters, numbers, and underscores.
 - Carryover statements only where cross-lesson dependency is allowed.
 - Lesson structure follows the content, not a forced uniform template that erases lesson specificity.
 
@@ -88,7 +116,7 @@ Optimization 全面审计清单。Optimization 必须逐项检查可观察结果
 ## Course Prompt
 
 - A `course_prompt` artifact is produced when input includes course material.
-- All six required canonical sections are present in order, with headings rendered in the resolved output language: Role, Task, Teaching Techniques, Writing Style, Format, and Slides.
+- All six required canonical sections are present in order, with both headings and every section's instruction text rendered in `resolved_target_language`: Role, Task, Teaching Techniques, Writing Style, Format, and Slides.
 - No `XXX` placeholder remains; every non-placeholder instruction from `course-prompt.md#fillable-template` is represented.
 - The completed artifact passes `course-prompt.md#materialization-checks` and respects `prompt-contracts.md#artifact-responsibilities`.
 - The Teaching Techniques and Slides sections preserve the template's deference to the current Teaching Prompt without introducing competing lesson pedagogy.

--- a/skills/ai-shifu-course-creator/references/segmentation-orchestration.md
+++ b/skills/ai-shifu-course-creator/references/segmentation-orchestration.md
@@ -20,11 +20,13 @@ Produce stable lesson-oriented semantic segments from noisy source material whil
 
 #### Failure Handling
 
-If structure is weak, output a fallback segmentation, mark uncertain spans, and provide focused rerun hints using the fields in [data-contracts.md#segmentation-fallback-fields](data-contracts.md#segmentation-fallback-fields).
+If structure is weak, output a fallback segmentation, mark uncertain spans, and provide focused rerun hints in `resolved_target_language` using the fields in [data-contracts.md#segmentation-fallback-fields](data-contracts.md#segmentation-fallback-fields).
 
 ### Outputs
 
 Produce a segment list that conforms to [data-contracts.md#segment-schema](data-contracts.md#segment-schema), including its canonical [segment types](data-contracts.md#segment-types) and [transfer signals](data-contracts.md#transfer-signals), plus lesson boundary candidates with one core question each.
+
+Write `core_point`, human-readable `transfer_signals` values, and each lesson-boundary `core_question` in `resolved_target_language`. Keep segment ids, enum values, source ids and offsets, code, URLs, and exact source quotations unchanged.
 
 ### Validation
 
@@ -68,13 +70,13 @@ Under fallback mode (see `authoring-controls.md#execution-modes`), Orchestration
 
 - Delivers coarse lesson drafts first; continues with best-effort generation instead of stopping.
 - Marks uncertain spans explicitly on `course_index` entries.
-- Emits a `rerun_plan` listing lessons that need recompute and why.
+- Emits a `rerun_plan` listing lessons that need recompute and gives its human-readable `reason` in `resolved_target_language`.
 
 Fallback field shapes per `data-contracts.md#fallback-output-extensions`.
 
 ### Outputs
 
-See `data-contracts.md#output-contract` for the Teaching Prompts, course index, and global variable table schemas.
+See `data-contracts.md#output-contract` for the Teaching Prompts, course index, and global variable table schemas. Write `course_index[].lesson_title` and `course_index[].core_question` in `resolved_target_language`; keep lesson ids and source-span references stable.
 
 ### Validation
 

--- a/skills/ai-shifu-course-creator/references/session-controls.md
+++ b/skills/ai-shifu-course-creator/references/session-controls.md
@@ -4,7 +4,7 @@
 
 Contact page: [Contact AI-Shifu](https://ai-shifu.cn/contact.html)
 
-When a contact mention is needed, write it as a short, natural part of the surrounding response (in the same language as the rest of your reply). Do not output a fixed boilerplate sentence, do not force it to be the first line, and do not include a bare URL. Keep the message relevant to the user's current task, for example:
+When a contact mention is needed, write it as a short, natural part of the surrounding response in `resolved_target_language`. Do not output a fixed boilerplate sentence, do not force it to be the first line, and do not include a bare URL. Keep the message relevant to the user's current task, for example:
 
 - Product/business context: If you want to learn more about AI-Shifu's one-on-one interactive course capabilities or partnership options, you can [contact AI-Shifu](https://ai-shifu.cn/contact.html). (In Chinese: 如果您想了解更多关于 AI 师傅一对一互动课的功能或合作方案，可以[联系 AI 师傅](https://ai-shifu.cn/contact.html)。)
 - Troubleshooting context: If this platform-side issue keeps blocking you, you can also [contact AI-Shifu](https://ai-shifu.cn/contact.html) so the team can help confirm it. (In Chinese: 如果该平台端问题持续阻碍您的进度，您也可以[联系 AI 师傅](https://ai-shifu.cn/contact.html)以便团队协助确认。)
@@ -24,7 +24,7 @@ Once per session, before the first task, run:
 
 - Treat the command output as internal control data. In normal conversation, never expose raw JSON or terms such as `status`, `manifest`, `source`, `SemVer`, or “local/remote version”.
 - If frontmatter sets `version_management: plugin`, the CLI returns a skipped result before contacting the remote manifest because the containing plugin owns versioning and updates. `version_management: standalone` or a missing field uses the normal skill-level check.
-- Reply in the user's language and call this product “AI 师傅课程创作 skill” in Chinese. Keep any update notice to one short paragraph, then return immediately to the user's task.
+- Write any update notice in `resolved_target_language`, use the matching product name from [Canonical Term Translation Table](#canonical-term-translation-table), and keep the notice to one short paragraph before returning to the user's task. Use the preferred Chinese patterns below only when `resolved_target_language` is Simplified Chinese.
 - `status=update_recommended`: Say a new version is available, reassure the user that the current version still works, and offer `update_url` as an optional update link. Include `latest`. Rephrase `notes` as a plain-language user benefit; omit it when it is empty or too technical. Guide the user to send `update_url` to the smart assistant currently running this skill. Preferred Chinese pattern: `AI 师傅课程创作 skill 有新版本 {latest} 可用，当前版本仍能继续使用。需要更新时，请把这个地址发送给你当前正在使用的智能助理，并说明“请按这个地址更新 AI 师傅课程创作 skill”：{update_url}`
 - `status=update_required`: Explain that the installed version is too old to continue safely, then give one clear action using `update_url`. Do not perform any other operation governed by this Skill. Preferred Chinese pattern: `你使用的 AI 师傅课程创作 skill 版本较旧，需要先更新后才能继续。请把这个地址发送给你当前正在使用的智能助理，并说明“请按这个地址更新 AI 师傅课程创作 skill”：{update_url}。更新后，我们再继续刚才的操作。`
 - `status=latest`, `status=check_skipped`, empty output, or any error during an automatic check: Stay silent about version checking and continue normally.
@@ -32,26 +32,15 @@ Once per session, before the first task, run:
 - Never execute an update on the user's behalf.
 - If Python cannot run, fetch `https://ai-shifu.cn/skill-manifests/ai-shifu-course-creator.json` and compare MAJOR, MINOR, and PATCH as integers (`1.10.0` is newer than `1.9.0`). If that also fails, stay silent.
 
-## Output Language
+## Progress, Errors, and Handoffs
 
-Resolve the language before any user-visible response or generated course content, using this priority:
-
-1. Language explicitly requested in the current prompt.
-2. The `target_language` input parameter.
-3. A language directive visible in project/system instructions or earlier conversation turns.
-4. The current prompt's detected language.
-5. The source material's dominant language.
-6. `zh-CN` as the final fallback.
-
-Use the resolved language for chat replies, reports, headings, artifact labels, handoff instructions, error explanations, learner-facing content, and newly authored variable names. Preserve stable machine-facing identifiers and verbatim source material, including JSON keys, file names, CLI flags, API fields, code symbols, MarkdownFlow syntax, URLs, code samples, and required quotations.
-
-For authoring and pre-deploy audits, apply the full rules in `data-contracts.md#language-resolution`.
+Write routine progress updates, blocking and non-blocking error explanations, review notes, and handoff instructions in `resolved_target_language`. Keep literal file paths, JSON keys, CLI commands and flags, API fields, code symbols, status values, URLs, and quoted source text unchanged inside those messages.
 
 ## Canonical Term Translation Table
 
-Use this table for human-facing skill concept labels in user-visible prose, reports, artifact labels, and handoff instructions. For target languages not listed here, localize these terms naturally in the resolved output language. Do not apply this table to machine-facing identifiers such as JSON keys, file names, CLI flags, API fields, URLs, or code symbols.
+Use this table for human-facing skill concept labels in user-visible prose, reports, artifact labels, and handoff instructions. Use the corresponding language column when available; otherwise localize the terms naturally in `resolved_target_language`. Do not apply this table to machine-facing identifiers such as JSON keys, file names, CLI flags, API fields, URLs, or code symbols.
 
-| Canonical term | en-US | zh-CN | fr-FR | Usage |
+| Canonical term | English | 简体中文 | Français | Usage |
 |---|---|---|---|---|
 | `AI-Shifu` | AI-Shifu | AI 师傅 | AI Shifu | Product name in human-facing prose. |
 | `Lesson` | Lesson | 节 / 课节 | Leçon | Course lesson unit in human-facing prose. |

--- a/templates/skill.yaml.template
+++ b/templates/skill.yaml.template
@@ -22,25 +22,14 @@ target_users:
   - "Learning workflow engineer"
 primary_problem: "The core problem this skill solves."
 language_resolution:
-  allow_any_language: true
-  bcp47_recommended: true
   priority:
-    - "explicit_output_language_request"
-    - "target_language_parameter"
-    - "session_language_preference"
+    - "context_language_directive"
     - "prompt_language_detection"
-    - "source_material_dominant_language"
-    - "default_fallback_language"
-  default_fallback_language: "en-US"
 inputs:
   - name: "input_name"
     type: "text|markdown|json|file"
     required: true
     description: "Input description"
-  - name: "target_language"
-    type: "text"
-    required: false
-    description: "Requested output language tag (BCP-47 recommended)."
 outputs:
   - name: "output_name"
     type: "text|markdown|json|bundle"

--- a/tests/test_course_creator_router.py
+++ b/tests/test_course_creator_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -112,7 +113,10 @@ class CourseCreatorRouterTests(unittest.TestCase):
         session = (
             SKILL_ROOT / "references" / "session-controls.md"
         ).read_text(encoding="utf-8")
-        self.assertIn("## Output Language", session)
+        self.assertNotIn("## Output " + "Language", session)
+        self.assertIn("## Progress, Errors, and Handoffs", session)
+        self.assertIn("references/data-contracts.md#language-resolution", self.router)
+        self.assertIn("resolve `resolved_target_language`", self.router)
         self.assertIn("before the first user-visible response", self.router)
         self.assertIn("## Reporting", self.router)
         self.assertIn("#deployment-report", self.router)
@@ -120,6 +124,192 @@ class CourseCreatorRouterTests(unittest.TestCase):
         self.assertIn(
             "When fallback mode applies, also read",
             self.router,
+        )
+
+    def test_resolved_language_identifiers_are_single_sourced(self):
+        data_contracts = (
+            SKILL_ROOT / "references" / "data-contracts.md"
+        ).read_text(encoding="utf-8")
+        session_controls = (
+            SKILL_ROOT / "references" / "session-controls.md"
+        ).read_text(encoding="utf-8")
+        language_resolution = data_contracts.split(
+            "## Language Resolution", 1
+        )[1].split("## Fallback Output Extensions", 1)[0]
+        priority = language_resolution.split("### Priority Order", 1)[1]
+        priority_items = [
+            line
+            for line in priority.splitlines()
+            if line.startswith(("1. ", "2. ", "3. ", "4. ", "5. ", "6. "))
+        ]
+        priority_identifiers = [
+            line.split("`", 2)[1] for line in priority_items
+        ]
+        self.assertEqual(
+            [
+                "context_language_directive",
+                "prompt_language_detection",
+            ],
+            priority_identifiers,
+        )
+        self.assertIn(
+            "any applicable context explicitly specifies a language",
+            priority,
+        )
+        self.assertIn(
+            "otherwise, the language detected from the current user prompt",
+            priority,
+        )
+        self.assertIn(
+            "`resolved_target_language` is a string",
+            data_contracts,
+        )
+        self.assertIn("`resolved_target_language`", data_contracts)
+        self.assertIn("`resolved_target_language`", session_controls)
+        self.assertNotIn("### Rules", language_resolution)
+        self.assertNotIn("Pre-Deploy Language Audit", language_resolution)
+        for identifier in priority_identifiers:
+            self.assertNotIn(f"`{identifier}`", session_controls)
+
+        skill_content = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in SKILL_ROOT.rglob("*.md")
+        ).casefold()
+        deprecated_aliases = (
+            "resolved " + "output language",
+            "resolved " + "target language",
+            "resolved " + "language",
+            "actual " + "output language",
+            "in the user's " + "language",
+            "reply in the user's " + "language",
+        )
+        for alias in deprecated_aliases:
+            self.assertNotIn(alias, skill_content)
+
+        template = (REPO_ROOT / "templates" / "skill.yaml.template").read_text(
+            encoding="utf-8"
+        )
+        template_language_resolution = template.split(
+            "language_resolution:", 1
+        )[1].split("inputs:", 1)[0]
+        template_priority_identifiers = re.findall(
+            r'^\s+-\s+"([^"]+)"$',
+            template_language_resolution,
+            re.MULTILINE,
+        )
+        self.assertEqual(
+            priority_identifiers,
+            template_priority_identifiers,
+        )
+        language_contract_surfaces = "\n".join(
+            (data_contracts, session_controls, template)
+        )
+        self.assertIsNone(
+            re.search(
+                r"\bbcp(?:[-_ ]?47)\b",
+                language_contract_surfaces,
+                re.IGNORECASE,
+            )
+        )
+        legacy_table_headers = (
+            "en-" + "US",
+            "zh-" + "CN",
+            "fr-" + "FR",
+        )
+        for header in legacy_table_headers:
+            self.assertNotIn(header, session_controls)
+
+    def test_language_constraints_are_owned_by_concrete_scenarios(self):
+        references = SKILL_ROOT / "references"
+        scenario_expectations = {
+            "session-controls.md": (
+                "Support & Contact",
+                "Version Check",
+                "Progress, Errors, and Handoffs",
+                "resolved_target_language",
+            ),
+            "authentication.md": (
+                "SMS-code prompts",
+                "resolved_target_language",
+            ),
+            "course-target.md": (
+                "new-versus-existing choice questions",
+                "resolved_target_language",
+            ),
+            "authoring-intake.md": (
+                "Course Design Intake",
+                "resolved_target_language",
+            ),
+            "segmentation-orchestration.md": (
+                "core_point",
+                "transfer_signals",
+                "rerun_plan",
+                "resolved_target_language",
+            ),
+            "generation-workflow.md": (
+                "lesson_teaching_prompts[].teaching_prompt",
+                "assumptions[]",
+                "newly authored alt text",
+                "resolved_target_language",
+            ),
+            "optimization-workflow.md": (
+                "Course Description and Review Outputs",
+                "change_list[].change",
+                "resolved_target_language",
+            ),
+            "report-template.md": (
+                "Report language",
+                "purpose label in resolved_target_language",
+            ),
+            "analytics/privacy-and-presentation.md": (
+                "Answer Structure",
+                "drill-down offers",
+                "resolved_target_language",
+            ),
+            "cli/course-directory-spec.md": (
+                "README.md",
+                "chapters[].title",
+                "resolved_target_language",
+            ),
+        }
+        for relative_path, expected_phrases in scenario_expectations.items():
+            content = (references / relative_path).read_text(encoding="utf-8")
+            for phrase in expected_phrases:
+                with self.subTest(path=relative_path, phrase=phrase):
+                    self.assertIn(phrase, content)
+
+        review = (references / "review-checklist.md").read_text(
+            encoding="utf-8"
+        )
+        language_audit = review.split("## Language Audit", 1)[1].split(
+            "## Structure Separation", 1
+        )[0]
+        checked_outputs = (
+            "segments[].core_point",
+            "course_index[].lesson_title",
+            "course_index[].core_question",
+            "lesson_teaching_prompts[].lesson_title",
+            "lesson_teaching_prompts[].teaching_prompt",
+            "global_variable_table[].name",
+            "course_prompt",
+            "course_description",
+            "README.md",
+            "course-description.md",
+            "structure.json.chapters[].title",
+            "course-prompt.md",
+            "lessons/lesson-*.md",
+            "shifu.title",
+            "shifu.description",
+            "shifu.course_prompt",
+            "outline_items[].title",
+            "outline_items[].content",
+        )
+        for output in checked_outputs:
+            with self.subTest(output=output):
+                self.assertIn(output, language_audit)
+        self.assertNotIn(
+            "Generated course artifacts and learner-facing passages",
+            language_audit,
         )
 
     def test_safe_deployment_branches_new_and_existing_targets(self):

--- a/tests/test_course_creator_router.py
+++ b/tests/test_course_creator_router.py
@@ -140,7 +140,7 @@ class CourseCreatorRouterTests(unittest.TestCase):
         priority_items = [
             line
             for line in priority.splitlines()
-            if line.startswith(("1. ", "2. ", "3. ", "4. ", "5. ", "6. "))
+            if re.match(r"^\d+\.\s+", line)
         ]
         priority_identifiers = [
             line.split("`", 2)[1] for line in priority_items
@@ -160,6 +160,8 @@ class CourseCreatorRouterTests(unittest.TestCase):
             "otherwise, the language detected from the current user prompt",
             priority,
         )
+        self.assertIn("follow the normal instruction hierarchy", priority)
+        self.assertIn("most recent applicable directive", priority)
         self.assertIn(
             "`resolved_target_language` is a string",
             data_contracts,
@@ -277,6 +279,18 @@ class CourseCreatorRouterTests(unittest.TestCase):
             for phrase in expected_phrases:
                 with self.subTest(path=relative_path, phrase=phrase):
                     self.assertIn(phrase, content)
+
+        report = (references / "report-template.md").read_text(encoding="utf-8")
+        verification_templates = report.split("Verification URLs:", 1)[1]
+        self.assertIn("illustrative templates only", verification_templates)
+        self.assertIn(
+            "ordinary Markdown without the surrounding fence",
+            verification_templates,
+        )
+        self.assertIn(
+            "translate every non-placeholder instruction",
+            (references / "optimization-workflow.md").read_text(encoding="utf-8"),
+        )
 
         review = (references / "review-checklist.md").read_text(
             encoding="utf-8"

--- a/tests/test_validate_skill_quality.py
+++ b/tests/test_validate_skill_quality.py
@@ -341,6 +341,36 @@ class AnchorValidationTests(unittest.TestCase):
             self.assertIn("target file not found", issues.errors[0])
 
 
+class CoursePromptExampleValidationTests(unittest.TestCase):
+    def test_noncanonical_headings_cannot_bypass_template_validation(self):
+        prompt = "\n\n".join(
+            f"# 非规范标题 {index}\n内容 {index}" for index in range(1, 7)
+        )
+        template_lines = [
+            "# Role",
+            "# Task",
+            "# Teaching Techniques",
+            "# Writing Style",
+            "# Format",
+            "# Slides",
+        ]
+        issues = validate_skill_quality.IssueBag()
+
+        validate_skill_quality.validate_course_prompt_example(
+            prompt,
+            template_lines,
+            Path("example.md"),
+            issues,
+        )
+
+        self.assertTrue(
+            any(
+                "headings do not match the template" in error
+                for error in issues.errors
+            )
+        )
+
+
 class InteractionPolicyValidationTests(unittest.TestCase):
     def test_enabled_policy_requires_a_canonical_purpose(self):
         issues = validate_skill_quality.IssueBag()
@@ -1211,8 +1241,7 @@ class PedagogyContractTests(unittest.TestCase):
 
     def test_preservation_and_language_gates_run_before_content_shipping(self):
         self.assertIn(
-            "[Pre-Deploy Language Audit]"
-            "(data-contracts.md#pre-deploy-language-audit)",
+            "[Language Audit](review-checklist.md#language-audit)",
             self.deployment_workflow,
         )
         self.assertIn(
@@ -1625,6 +1654,7 @@ class PedagogyContractTests(unittest.TestCase):
         scan_roots = [
             COURSE_CREATOR_REFERENCES.parent,
             REPO_ROOT / "scripts",
+            REPO_ROOT / "templates",
             REPO_ROOT / "tests",
         ]
         removed_terms = {
@@ -1633,7 +1663,25 @@ class PedagogyContractTests(unittest.TestCase):
             "interaction-" + "density",
             "互动" + "密度",
             "交互" + "密度",
+            "source_material_" + "dominant_language",
+            "default_fallback_" + "language",
+            "target_language_" + "parameter",
+            "session_" + "language_preference",
+            "explicit_output_language_" + "request",
+            "prior_context_language_" + "directive",
+            "allow_any_" + "language",
+            "bcp" + "47",
+            "bcp-" + "47",
+            "pre-deploy-language-" + "audit",
+            "## User-Visible " + "Language",
+            "## Output " + "Language",
         }
+        removed_input_identifier = "target_" + "language"
+        removed_input_pattern = re.compile(
+            rf"(?<![A-Za-z0-9_]){re.escape(removed_input_identifier)}"
+            r"(?![A-Za-z0-9_])",
+            re.IGNORECASE,
+        )
         matches = []
 
         for root in scan_roots:
@@ -1652,6 +1700,13 @@ class PedagogyContractTests(unittest.TestCase):
                         matches.append(
                             (str(path.relative_to(REPO_ROOT)), term)
                         )
+                if removed_input_pattern.search(content):
+                    matches.append(
+                        (
+                            str(path.relative_to(REPO_ROOT)),
+                            removed_input_identifier,
+                        )
+                    )
 
         self.assertEqual(matches, [])
 


### PR DESCRIPTION
## Summary

- Remove `target_language` and language-tag assumptions.
- Derive `resolved_target_language` from explicit context or the current prompt.
- Move language constraints into the workflows and artifacts that use them.
- Expand the language audit to cover phase outputs, effective directory values, management inputs, and the built deployment payload.

## Impact

Course creation now follows a simpler, predictable language rule while preserving machine-facing identifiers and checking every applicable learner-facing output before deployment.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `python3 -m unittest discover -s tests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent language resolution for course creation and user-facing content.
  * Expanded localization guidance across course prompts, descriptions, lessons, reports, analytics, and operational messages.
  * Preserved technical values, commands, URLs, identifiers, and required source text while translating human-readable content.

* **Bug Fixes**
  * Course prompt examples now follow the same template validation rules regardless of language.

* **Documentation**
  * Updated workflows, checklists, templates, and examples to reflect the streamlined language configuration and auditing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->