### PR TITLE
chore: format Markdown before commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     hooks:
       - id: prettier
         name: format Markdown
-        files: \.md$
+        types: [markdown]
         exclude: ^CLAUDE\.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.5
+    rev: 9337a74165b178ae2c766f60bee7252a0f06f3e8 # v3.9.5
     hooks:
       - id: prettier
         name: format Markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.5
+    hooks:
+      - id: prettier
+        name: format Markdown
+        files: \.md$
+        exclude: ^CLAUDE\.md$

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "never"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,10 @@
 
 ## Git Commit Message Requirements
 
-- Subject: use English Conventional Commits without scope parentheses, such as
-  `type: summary`; do not use `type(scope): summary`. Write the summary in
-  plain language that product users can understand. When a change affects
-  users, describe the user-visible outcome or benefit instead of only naming
-  the internal implementation detail.
+- Subject: use English Conventional Commits without scope parentheses, such as `type: summary`; do not use `type(scope): summary`. Write the summary in plain language that product users can understand. When a change affects users, describe the user-visible outcome or benefit instead of only naming the internal implementation detail.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
-- Classification: use `chore` for repository-maintenance-only instructions,
-  guidance updates like this file, or non-behavioral skill maintenance.
-- Skill content changes affect skill behavior and capability: inside a skill
-  directory, only changes limited to intentionally present `README*` files
-  count as documentation-only. Changes to `SKILL.md` (including its
-  frontmatter), references, prompts, templates, examples, scripts, or other
-  skill assets must use `feat` when adding capability and `fix` when correcting
-  behavior; do not use `docs`.
+- Classification: use `chore` for repository-maintenance-only instructions, guidance updates like this file, or non-behavioral skill maintenance.
+- Skill content changes affect skill behavior and capability: inside a skill directory, only changes limited to intentionally present `README*` files count as documentation-only. Changes to `SKILL.md` (including its frontmatter), references, prompts, templates, examples, scripts, or other skill assets must use `feat` when adding capability and `fix` when correcting behavior; do not use `docs`.
 
 Example:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,6 +3,7 @@
 ## Our Standards
 
 Contributors are expected to:
+
 1. Be respectful and constructive.
 2. Focus feedback on ideas and implementation.
 3. Avoid harassment, discrimination, and personal attacks.
@@ -16,10 +17,8 @@ Contributors are expected to:
 
 ## Enforcement
 
-Repository maintainers may edit, hide, or remove comments/PRs/issues that violate this code.
-Serious or repeated violations can lead to temporary or permanent bans.
+Repository maintainers may edit, hide, or remove comments/PRs/issues that violate this code. Serious or repeated violations can lead to temporary or permanent bans.
 
 ## Reporting
 
-If you encounter violations, open a private report through repository maintainers.
-Include links and context so maintainers can review quickly.
+If you encounter violations, open a private report through repository maintainers. Include links and context so maintainers can review quickly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ python3 scripts/validate_skill_quality.py
 ## Reporting Issues
 
 Open a GitHub Issue with:
+
 1. skill slug
 2. expected behavior
 3. actual behavior

--- a/INDEX.md
+++ b/INDEX.md
@@ -3,6 +3,6 @@
 Total skills: **2**
 
 | Skill | One-liner | Category | Maturity |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | [AI-Shifu Course Creator（AI 师傅课程创作器）](./skills/ai-shifu-course-creator/SKILL.md) | Convert raw course material into optimized MarkdownFlow teaching scripts, deploy as live AI-Shifu courses, and query post-deployment analytics (progress, orders, costs, audiences). | course-authoring | beta |
 | [Course Direction Advisor（课程选题顾问）](./skills/course-direction-advisor/SKILL.md) | Advise on market-fit course directions from source materials with competitor analysis and GO/HOLD/REWORK/NO-GO decisions. | content-preprocessing | beta |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ skills/
 
 ## Usage
 
-Each skill keeps `SKILL.md` as the behavior source of truth.
-The directory name is the stable machine slug; the `name` frontmatter field is the human-readable display name.
+Each skill keeps `SKILL.md` as the behavior source of truth. The directory name is the stable machine slug; the `name` frontmatter field is the human-readable display name.
 
 ## Course Authoring & Deployment Paths
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,8 +19,7 @@ skills/
 
 ## 使用说明
 
-skill 以 `SKILL.md` 作为行为定义。
-目录名是稳定的机器 slug；`name` frontmatter 字段是面向人的展示名。
+skill 以 `SKILL.md` 作为行为定义。目录名是稳定的机器 slug；`name` frontmatter 字段是面向人的展示名。
 
 ## 课程生产与部署路径
 

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -23,7 +23,7 @@ On the first invocation in a session:
 ## Task Router
 
 | User intent | Required files, in order |
-|---|---|
+| --- | --- |
 | Create a full course, make a structural course edit, or run authoring end to end | `references/authentication.md` → `references/course-target.md` → `references/authoring-controls.md` → `references/prompt-contracts.md` → `references/authoring-intake.md` → `references/optimization-workflow.md#preservation-decisions` → `references/segmentation-orchestration.md` → `references/generation-workflow.md` → `references/optimization-workflow.md` → `references/deployment-workflow.md` |
 | Plan course structure or decide chapter and lesson counts from supplied material | `references/authentication.md` → `references/course-target.md` → `references/authoring-controls.md` → `references/authoring-intake.md` → `references/optimization-workflow.md#preservation-decisions` → `references/segmentation-orchestration.md#segmentation` |
 | Segment supplied material only | `references/authentication.md` → `references/course-target.md` → `references/authoring-controls.md` → `references/optimization-workflow.md#preservation-decisions` → `references/segmentation-orchestration.md#segmentation` |

--- a/skills/ai-shifu-course-creator/references/analytics/dsl.md
+++ b/skills/ai-shifu-course-creator/references/analytics/dsl.md
@@ -22,7 +22,7 @@ All examples are CLI invocations. Read `overview.md` first if you have not alrea
 ## Operators (`where[].op`)
 
 | Operator | Notes |
-|---|---|
+| --- | --- |
 | `=`, `!=` | Equality |
 | `>`, `>=`, `<`, `<=` | Numeric / date comparison |
 | `in` | `value` is a list |
@@ -33,11 +33,11 @@ All examples are CLI invocations. Read `overview.md` first if you have not alrea
 
 ## Aggregate Functions (`aggregate[].fn`)
 
-| Fn | Use |
-|---|---|
-| `count` | Row count |
-| `count_distinct` | Distinct values of `field` |
-| `sum`, `avg`, `min`, `max` | Numeric aggregates |
+| Fn                         | Use                        |
+| -------------------------- | -------------------------- |
+| `count`                    | Row count                  |
+| `count_distinct`           | Distinct values of `field` |
+| `sum`, `avg`, `min`, `max` | Numeric aggregates         |
 
 Every aggregate must carry an `alias` — the output column is named after it.
 

--- a/skills/ai-shifu-course-creator/references/analytics/overview.md
+++ b/skills/ai-shifu-course-creator/references/analytics/overview.md
@@ -19,7 +19,7 @@ Enter the analytics path when a course author or admin asks about:
 
 > Raw token counts are **not** exposed to creators. Any question about "how much was spent" maps to credits — query via `shifu-cli.py credit-detail`.
 
-Do **not** enter the analytics path when the user asks only "how many courses do I have?" — that is a `shifu-cli.py list` call. **But** if the user names a course by title (e.g. "show me the data on 跟 AI 学 AI 通识"), resolve the current `shifu_bid → title` via Course Metadata recipes first, *then* run the downstream analytics — `shifu-cli.py list` is a draft snapshot and can leak historical / renamed titles.
+Do **not** enter the analytics path when the user asks only "how many courses do I have?" — that is a `shifu-cli.py list` call. **But** if the user names a course by title (e.g. "show me the data on 跟 AI 学 AI 通识"), resolve the current `shifu_bid → title` via Course Metadata recipes first, _then_ run the downstream analytics — `shifu-cli.py list` is a draft snapshot and can leak historical / renamed titles.
 
 ## CLI-Only Rule
 
@@ -68,7 +68,10 @@ The CLI injects `shifu_bid` into the body, handles authentication, and prints th
   "code": 0,
   "data": {
     "columns": ["status", "n"],
-    "rows": [[602, 124], [603, 87]],
+    "rows": [
+      [602, 124],
+      [603, 87]
+    ],
     "limit": 100,
     "offset": 0
   }
@@ -90,7 +93,7 @@ Cross-course analysis: send one `analytics-query` per `shifu_bid` and merge resu
 The CLI prints the full response on every call. When the response carries a non-zero `code`, react as follows:
 
 | Code | Meaning | Action |
-|---|---|---|
+| --- | --- | --- |
 | `0` | Success | Parse `data.columns` / `data.rows`, then apply the Translation Gate |
 | `11001` | No access to this course | Confirm the `shifu_bid` is owned by the logged-in user; switch course or stop |
 | `11002` | Invalid DSL | Re-check required fields, duplicate `alias`, or leading-wildcard `like` |
@@ -113,7 +116,7 @@ Each query is scoped to one `shifu_bid`. The endpoint does not support cross-cou
 Before constructing any DSL, identify the correct table. Use this map:
 
 | User asks about... | Table | Key filter | Key field |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Course overview (high-level snapshot, not one metric)** | `learn_progress_records` + `order_orders` + `shifu_user_archives` | see **Recipe 0d** | bundles learners + orders + revenue + recent activity |
 | Learner count / completion / stuck lessons | `learn_progress_records` | `status = 603` (completed), `602` (stuck) | `outline_item_bid`, `status` |
 | **Follow-up questions / Q&A** | `learn_generated_blocks` | **`type = 321`** (NOT `role = 2`!) | `type`, `generated_content` |
@@ -139,6 +142,7 @@ These are the mistakes that most commonly cause repeated failed queries and wast
 ### Pitfall 2 — Credit queries: `credit-detail` vs `bill_daily_usage_metrics`
 
 These are **different tools for different questions**:
+
 - `shifu-cli.py credit-detail <bid>` — raw per-usage detail, server-side join, **always works**. Use for "how many credits did I spend", "what did my learners cost me", per-lesson breakdown.
 - DSL against `bill_daily_usage_metrics` — daily aggregated trends by model/scene/type. **Currently empty in production** (cron not registered). Do not use for credit data — it always returns zero rows.
 
@@ -149,6 +153,7 @@ The DSL requires `where` to be an array of filter objects, even for a single con
 ### Pitfall 4 — Table name guessing
 
 Do not guess table names — the schema has 10 tables and many sound-alike names. Always check the full list in `tables.md` first. Common wrong guesses:
+
 - "user logs" or "user_logs" → does not exist. Use `learn_generated_blocks` for interaction data, `learn_progress_records` for progress data.
 - "billing" or "usage" → `bill_daily_usage_metrics` (currently empty) or `shifu-cli.py credit-detail` for actual credit data.
 

--- a/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
+++ b/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
@@ -38,8 +38,14 @@ python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
 Returns:
 
 ```json
-{"columns":["user_bid","nickname"],
- "rows":[["u-bid-1","Python 学徒"],["u-bid-2","[REDACTED-PHONE]"],["u-bid-3","Alice"]]}
+{
+  "columns": ["user_bid", "nickname"],
+  "rows": [
+    ["u-bid-1", "Python 学徒"],
+    ["u-bid-2", "[REDACTED-PHONE]"],
+    ["u-bid-3", "Alice"]
+  ]
+}
 ```
 
 ### Use B — reverse-look up `user_bid` from a phone number
@@ -56,8 +62,10 @@ python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
 Returns:
 
 ```json
-{"columns":["user_bid","nickname","user_identify"],
- "rows":[["u-bid-xxx","Python 学徒","138*****000"]]}
+{
+  "columns": ["user_bid", "nickname", "user_identify"],
+  "rows": [["u-bid-xxx", "Python 学徒", "138*****000"]]
+}
 ```
 
 Once you have the `user_bid`, use it to query `order_orders` (purchase status), `learn_progress_records` (learning progress), `learn_generated_blocks` (follow-up questions), etc.

--- a/skills/ai-shifu-course-creator/references/analytics/recipes.md
+++ b/skills/ai-shifu-course-creator/references/analytics/recipes.md
@@ -112,7 +112,7 @@ python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
 口径说明（present these definitions alongside the numbers so they are unambiguous):
 
 - **学员数 (learners)** = `count_distinct(user_bid)` on `learn_progress_records` — everyone who entered the course (Method ① in `tables.md`). This is the dashboard's "学员数".
-- **订单数 (orders)** = `count` of `order_orders` rows with `status = 502` — paid orders (includes ¥0 free enrolments). For *strictly paid* (`paid_price > 0`) use Recipe 3; for the full funnel use Recipe 5.
+- **订单数 (orders)** = `count` of `order_orders` rows with `status = 502` — paid orders (includes ¥0 free enrolments). For _strictly paid_ (`paid_price > 0`) use Recipe 3; for the full funnel use Recipe 5.
 - **营收 (revenue)** = `sum(paid_price)` over the same `status = 502` rows. Round to 2 decimals (`¥5,870.70`).
 - **最近活跃 (last_active)** = the `created_at` of the latest `learn_progress_records` row (query 1b). Convert to local time before presenting.
 - **活跃学员 (active_learners)** = non-archived learners (`shifu_user_archives.archived = 0`); usually ≤ 学员数 because some learners archived the course.
@@ -276,9 +276,9 @@ Pseudo-shape:
   "code": 0,
   "data": {
     "summary": {
-      "total_records":   52,
-      "total_credits":   "26.6900",
-      "unique_users":    1,
+      "total_records": 52,
+      "total_credits": "26.6900",
+      "unique_users": 1,
       "unique_progress": 5,
       "wallet_creator_bid": "029bacf0...",
       "time_range": ["2026-05-15 16:05:18", "2026-05-15 23:45:17"]
@@ -290,15 +290,15 @@ Pseudo-shape:
         "user_bid": "...",
         "progress_record_bid": "...",
         "outline_item_bid": "...",
-        "usage_type":  1101,
+        "usage_type": 1101,
         "usage_scene": 1203,
-        "provider":    "deepseek",
-        "model":       "deepseek-v4-flash",
-        "credits":     "0.5100",
+        "provider": "deepseek",
+        "model": "deepseek-v4-flash",
+        "credits": "0.5100",
         "wallet_creator_bid": "029bacf0..."
       }
     ],
-    "limit":  100,
+    "limit": 100,
     "offset": 0
   }
 }
@@ -514,4 +514,4 @@ python3 scripts/shifu-cli.py analytics-query <bid> --dsl '{
 }'
 ```
 
-> Translate each `outline_item_bid` to "Lesson X.Y: \<title\>" via the `shifu-cli.py show <bid>` outline cache before presenting. High-ask lessons are usually candidates for content reinforcement (more concrete examples / explicit interaction). Low-ask lessons are often either very clear *or* skipped — cross-reference with `learn_progress_records` to tell which.
+> Translate each `outline_item_bid` to "Lesson X.Y: \<title\>" via the `shifu-cli.py show <bid>` outline cache before presenting. High-ask lessons are usually candidates for content reinforcement (more concrete examples / explicit interaction). Low-ask lessons are often either very clear _or_ skipped — cross-reference with `learn_progress_records` to tell which.

--- a/skills/ai-shifu-course-creator/references/analytics/tables.md
+++ b/skills/ai-shifu-course-creator/references/analytics/tables.md
@@ -5,7 +5,7 @@ The 10 tables you can query, the fields each carries, the code/enum tables to tr
 ## 10 Tables at a Glance
 
 | Table | Answers | Key fields |
-|---|---|---|
+| --- | --- | --- |
 | `learn_progress_records` | Learner count / completion rate / stuck lesson / recent activity / **lessons completed per learner** | `user_bid`, `outline_item_bid`, `status` (601-608, see code table), `created_at` |
 | `learn_generated_blocks` | Content interaction count / likes / type popularity / **interactions per learner** / **follow-up Q&A replay** | `user_bid`, `progress_record_bid`, `outline_item_bid`, `type` (see code table), `role` (1 teacher/AI · 2 learner · 3 UI, **integer**), `status` (1 active / 0 history — **API auto-filters to 1**), `position` (block ordering within a `progress_record_bid`), `liked` (-1/0/1), `generated_content` (raw text, restricted — see `dsl.md`) |
 | `learn_lesson_feedbacks` | Lesson ratings / Read Mode vs Listen Mode preference / **avg rating per learner** | `user_bid`, `progress_record_bid`, `mode` (read/listen), `score` (1-5) |
@@ -21,7 +21,7 @@ The 9 shifu-scoped tables (everything except `user_users`) are automatically con
 
 `user_users` is a **global** user table (no `shifu_bid` column). Its access is heavily restricted — read `privacy-and-presentation.md` before querying.
 
-**Token usage is intentionally not exposed.** Creators can only see *credit* consumption. The canonical real-time path is `shifu-cli.py credit-detail <bid>`, which the backend joins on the fly from `bill_usage` × `credit_ledger_entries` and returns ABS(amount) as `credits` (positive). When the daily aggregation cron is enabled, `bill_daily_usage_metrics.consumed_credits` will become the path for "by-day trend" DSL queries; until then it is empty and `credit-detail` is the only working path.
+**Token usage is intentionally not exposed.** Creators can only see _credit_ consumption. The canonical real-time path is `shifu-cli.py credit-detail <bid>`, which the backend joins on the fly from `bill_usage` × `credit_ledger_entries` and returns ABS(amount) as `credits` (positive). When the daily aggregation cron is enabled, `bill_daily_usage_metrics.consumed_credits` will become the path for "by-day trend" DSL queries; until then it is empty and `credit-detail` is the only working path.
 
 ## Course title is "current published", not "history"
 
@@ -44,7 +44,7 @@ Operational corollaries:
 `type` (integer):
 
 | type | Name | Source | `generated_content` selectable? |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `301` | `content` — system narration | Course template | yes |
 | `311` | `mdcontent` — Markdown narration | Course template | yes |
 | `312` | `mdinteraction` — interaction prompt | Course template | yes |
@@ -54,7 +54,7 @@ Operational corollaries:
 
 `role` (integer): `1` = teacher / AI (`assistant`) · `2` = learner (`user`) · `3` = UI widget
 
-> **Trap — `role = 2` is not only follow-up questions.** The learner-input role is shared by input widgets (`type = 303` input, `type = 309` phone, `type = 310` checkcode, etc.). To count *follow-up* questions specifically, filter `type = 321` — do **not** key off `role = 2` alone. (PDF §6 trap #1.)
+> **Trap — `role = 2` is not only follow-up questions.** The learner-input role is shared by input widgets (`type = 303` input, `type = 309` phone, `type = 310` checkcode, etc.). To count _follow-up_ questions specifically, filter `type = 321` — do **not** key off `role = 2` alone. (PDF §6 trap #1.)
 
 `status` (integer): `1` = current live row · `0` = superseded by a reroll. The API auto-injects `status = 1`, so a follow-up count reflects what the learner actually sees, not earlier rerolls. The DSL still accepts `status` in `filter` / `group_by` for debugging — but adding `status = 1` explicitly is redundant.
 
@@ -75,16 +75,16 @@ The 2026-05-15 query handbook PDF §6 recommends pairing a `type = 321` learner 
 
 ## `learn_progress_records.status`
 
-| Code | Chinese | English |
-|---|---|---|
-| `601` | 未开始 | Not started |
-| `602` | 进行中 | In progress |
-| `603` | 已完成 | Completed |
-| `604` | 已退款 | Refunded |
-| `605` | 已锁定 | Locked |
-| `606` | 不可用 | Unavailable |
+| Code  | Chinese  | English        |
+| ----- | -------- | -------------- |
+| `601` | 未开始   | Not started    |
+| `602` | 进行中   | In progress    |
+| `603` | 已完成   | Completed      |
+| `604` | 已退款   | Refunded       |
+| `605` | 已锁定   | Locked         |
+| `606` | 不可用   | Unavailable    |
 | `607` | 分支跳过 | Branch-skipped |
-| `608` | 已重置 | Reset |
+| `608` | 已重置   | Reset          |
 
 Completion rate counts `status = 603` only. "Participating learners" = `status >= 602`.
 
@@ -95,18 +95,18 @@ Completion rate counts `status = 603` only. "Participating learners" = `status >
 
 ## `order_orders.status`
 
-| Code | Chinese | English |
-|---|---|---|
+| Code  | Chinese      | English         |
+| ----- | ------------ | --------------- |
 | `501` | 已创建未付款 | Created, unpaid |
-| `502` | 已付款 ✅ | Paid |
-| `503` | 已退款 | Refunded |
-| `504` | 待支付 | Pending payment |
-| `505` | 已超时 | Timed out |
+| `502` | 已付款 ✅    | Paid            |
+| `503` | 已退款       | Refunded        |
+| `504` | 待支付       | Pending payment |
+| `505` | 已超时       | Timed out       |
 
 **Match the filter to the user's intent:**
 
 | User asks | Correct filter | Notes |
-|---|---|---|
+| --- | --- | --- |
 | "How many people paid" | `status = 502, paid_price > 0` | Strict paid, excludes ¥0 orders |
 | "Free enrolments / ¥0 purchases" | `status = 502, paid_price = 0` | Paid but ¥0 |
 | "All paid orders (incl. ¥0)" | `status = 502` | No price filter |
@@ -118,21 +118,21 @@ Completion rate counts `status = 603` only. "Participating learners" = `status >
 
 ## `order_orders.payment_channel`
 
-| Value | Meaning |
-|---|---|
-| `pingxx` | Ping++ aggregated channel (WeChat Pay / Alipay etc.) |
-| `stripe` | Stripe (international credit cards) |
-| `alipay` | Alipay native |
-| `wechatpay` | WeChat Pay native |
-| `open_api` | Orders created via OpenAPI (not learner-initiated payments) |
-| `""` (empty) | Legacy data or manually imported activity orders |
+| Value        | Meaning                                                     |
+| ------------ | ----------------------------------------------------------- |
+| `pingxx`     | Ping++ aggregated channel (WeChat Pay / Alipay etc.)        |
+| `stripe`     | Stripe (international credit cards)                         |
+| `alipay`     | Alipay native                                               |
+| `wechatpay`  | WeChat Pay native                                           |
+| `open_api`   | Orders created via OpenAPI (not learner-initiated payments) |
+| `""` (empty) | Legacy data or manually imported activity orders            |
 
 ## `learn_lesson_feedbacks.mode`
 
-| Value | Meaning |
-|---|---|
-| `"read"` | Reading mode (text lesson) |
-| `"listen"` | Listening mode (audio) |
+| Value      | Meaning                    |
+| ---------- | -------------------------- |
+| `"read"`   | Reading mode (text lesson) |
+| `"listen"` | Listening mode (audio)     |
 
 ## `learn_lesson_feedbacks.score`
 
@@ -140,19 +140,17 @@ Completion rate counts `status = 603` only. "Participating learners" = `status >
 
 ## `bill_daily_usage_metrics.usage_type`
 
-| Code | Meaning |
-|---|---|
-| `1101` | LLM inference call |
+| Code   | Meaning              |
+| ------ | -------------------- |
+| `1101` | LLM inference call   |
 | `1102` | TTS speech synthesis |
 
-> **Common misclassification**: `usage_type = 1102` (TTS) has nothing to do with learner follow-up questions.
-> Follow-ups trigger LLM calls (`usage_type = 1101`); TTS records Listen Mode audio generation. They are independent paths.
-> To measure follow-up question volume, query `learn_generated_blocks(type = 321)`.
+> **Common misclassification**: `usage_type = 1102` (TTS) has nothing to do with learner follow-up questions. Follow-ups trigger LLM calls (`usage_type = 1101`); TTS records Listen Mode audio generation. They are independent paths. To measure follow-up question volume, query `learn_generated_blocks(type = 321)`.
 
 ## `bill_daily_usage_metrics.usage_scene`
 
 | Code | Meaning | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `1201` | Debug | Author debugging in editor (rare) |
 | `1202` | Preview | Author / shared teacher / admin previewing course |
 | `1203` | Learner production | **Real learner learning** |
@@ -161,27 +159,27 @@ Completion rate counts `status = 603` only. "Participating learners" = `status >
 
 ## `bill_daily_usage_metrics.billing_metric`
 
-| Code | Meaning |
-|---|---|
-| `7451` | LLM input tokens |
+| Code   | Meaning                                       |
+| ------ | --------------------------------------------- |
+| `7451` | LLM input tokens                              |
 | `7452` | LLM cache-hit tokens (typically priced lower) |
-| `7453` | LLM output tokens |
+| `7453` | LLM output tokens                             |
 
 > `billing_metric` lets you split a model's credit consumption into input vs cache vs output. Sum across all three values for a single model's total credits.
 
 ## `shifu_user_archives.archived`
 
-| Code | Meaning |
-|---|---|
-| `0` | Active / enrolled |
-| `1` | Archived (learner removed from bookshelf) |
+| Code | Meaning                                   |
+| ---- | ----------------------------------------- |
+| `0`  | Active / enrolled                         |
+| `1`  | Archived (learner removed from bookshelf) |
 
 ## ID Field Translation Rules
 
 All `*_bid` values are 36-char pseudo-IDs. Never display them raw. Translate as follows:
 
 | Field | How to translate |
-|---|---|
+| --- | --- |
 | `shifu_bid` | Use the `shifu-cli.py list` cache: `bid → name` |
 | `outline_item_bid` | Use the `shifu-cli.py show <shifu_bid>` cache: recurse the outline tree to map `bid → name`; render as "Lesson X.Y: \<title\>" |
 | `progress_record_bid` | Two-step: ① DSL query `learn_progress_records` with `where progress_record_bid in […]` + `select progress_record_bid, outline_item_bid` to get the mapping; ② translate `outline_item_bid` via the outline cache |
@@ -210,7 +208,7 @@ A learner can have multiple progress records for the **same lesson** (`outline_i
 ## Three Independent "Amounts" — Never Mix
 
 | Amount type | Source | Who pays | How to query |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Course price / revenue** | `order_orders.paid_price` | Learner pays the creator | DSL `order_orders` |
 | **Model call credit consumption** | `credit_ledger_entries.amount` (joined with `bill_usage` server-side) | Creator's credits are deducted | `shifu-cli.py credit-detail <bid>` (`bill_daily_usage_metrics` is currently empty pending cron registration) |
 | **Plan / credit pack purchases** | Internal billing tables | Creator recharges credits | not queryable |
@@ -224,7 +222,7 @@ The `credit-detail` endpoint returns the absolute credit amount (`ABS(credit_led
 When in doubt, do not guess — only the 10 tables above are valid. These table names do **not** exist and will trigger `11003` (table not in whitelist):
 
 | Wrong guess | Why it fails | Use instead |
-|---|---|---|
+| --- | --- | --- |
 | `user_logs` | Does not exist | `learn_generated_blocks` for interaction data, `learn_progress_records` for progress |
 | `logs` / `event_logs` | Does not exist | Same as above |
 | `billing` / `usage` | Does not exist | `bill_daily_usage_metrics` (currently empty) or `shifu-cli.py credit-detail` |

--- a/skills/ai-shifu-course-creator/references/analytics/workflow.md
+++ b/skills/ai-shifu-course-creator/references/analytics/workflow.md
@@ -14,7 +14,7 @@ Post-deployment data queries on live courses. Trigger this section whenever a co
 ### Workflow
 
 1. **Resolve credentials** — complete `../authentication.md`.
-2. **Resolve the course** — run `shifu-cli.py list` (or `shifu-cli.py find-title <keyword>`) to map `shifu_bid ↔ course name`. **If the user mentioned a course by title**, always resolve the *current* `shifu_bid → title` via Course Metadata recipes 0a / 0b in `recipes.md` before issuing downstream queries — `list` is a draft snapshot and can show stale or historical titles. Never report a historical title as the course's current name.
+2. **Resolve the course** — run `shifu-cli.py list` (or `shifu-cli.py find-title <keyword>`) to map `shifu_bid ↔ course name`. **If the user mentioned a course by title**, always resolve the _current_ `shifu_bid → title` via Course Metadata recipes 0a / 0b in `recipes.md` before issuing downstream queries — `list` is a draft snapshot and can show stale or historical titles. Never report a historical title as the course's current name.
 3. **Resolve the outline** (only for lesson-level dimensions) — run `shifu-cli.py show <shifu_bid>` to map `outline_item_bid → name / position`. Skipping this makes outline-dimension numbers unreadable.
 4. **Run DSL queries** — `shifu-cli.py analytics-query <shifu_bid> --dsl '<json-body>'` (or `--dsl-file query.json` for long bodies).
 5. **Translate before presenting** — pass every result through the Translation Gate in `privacy-and-presentation.md`. Never paste raw codes (`601`, `502`, `1101`), raw `*_bid` strings, or raw `user_bid` values in user-facing output.

--- a/skills/ai-shifu-course-creator/references/authoring-intake.md
+++ b/skills/ai-shifu-course-creator/references/authoring-intake.md
@@ -2,53 +2,25 @@
 
 ## Course Design Intake (before Orchestration)
 
-Run this intake after `course-target.md#resolve-the-course-target` and before Orchestration for: Path A end-to-end
-course creation, Path B author-only generation, and existing-course edits that
-change the course structure, lesson design, or interaction strategy. Do **not**
-run it for deploy-only, analytics, login, publish, management, or pure
-statistics requests.
+Run this intake after `course-target.md#resolve-the-course-target` and before Orchestration for: Path A end-to-end course creation, Path B author-only generation, and existing-course edits that change the course structure, lesson design, or interaction strategy. Do **not** run it for deploy-only, analytics, login, publish, management, or pure statistics requests.
 
-Before asking anything, extract answers already present in the user's current
-instruction, source material, or pulled course directory. Ask only for missing
-items, in `resolved_target_language`, as a step-by-step choice flow — ask the
-usage-scenario question first, show its options, wait for the answer, then ask
-only the next still-missing applicable question. Do not offer "you can let me
-decide" or similar bypass wording before the required choice flow is complete.
-Do not bypass the intake by inventing "conservative defaults" from a sparse
-topic or short brief — in particular, do not assume personalized AI self-study,
-thinking/self-check interactions, disabled Listen Mode, or a fixed chapter /
-lesson count before asking the relevant missing questions. Defaults below apply
-only after the user explicitly skips a question or asks you to continue without
-answering it.
+Before asking anything, extract answers already present in the user's current instruction, source material, or pulled course directory. Ask only for missing items, in `resolved_target_language`, as a step-by-step choice flow — ask the usage-scenario question first, show its options, wait for the answer, then ask only the next still-missing applicable question. Do not offer "you can let me decide" or similar bypass wording before the required choice flow is complete. Do not bypass the intake by inventing "conservative defaults" from a sparse topic or short brief — in particular, do not assume personalized AI self-study, thinking/self-check interactions, disabled Listen Mode, or a fixed chapter / lesson count before asking the relevant missing questions. Defaults below apply only after the user explicitly skips a question or asks you to continue without answering it.
 
-1. What usage scenarios should this course support? Multiple choices are
-   allowed: students follow AI one-on-one for personalized self-study;
-   interactive slides shown in class.
-2. What should interactions do? Multiple choices are allowed: understand
-   learner context for adaptive teaching; ask before teaching to trigger
-   thinking or break old assumptions; self-check learning effect at the end of
-   each lesson. Choosing none means no interactions.
-3. If the course is not slide-only, should Listen Mode be enabled so AI voice
-   teaches the course? When asking, also state that Listen Mode consumes more
-   AI-Shifu credits. If the user does not answer, default to disabled.
+1. What usage scenarios should this course support? Multiple choices are allowed: students follow AI one-on-one for personalized self-study; interactive slides shown in class.
+2. What should interactions do? Multiple choices are allowed: understand learner context for adaptive teaching; ask before teaching to trigger thinking or break old assumptions; self-check learning effect at the end of each lesson. Choosing none means no interactions.
+3. If the course is not slide-only, should Listen Mode be enabled so AI voice teaches the course? When asking, also state that Listen Mode consumes more AI-Shifu credits. If the user does not answer, default to disabled.
 4. How many chapters and lessons should the course have?
 
 Use the answers as course-design constraints:
 
 - **Usage scenario → content format.** Personalized AI self-study → illustrated text with fuller explanations and visual-text pairing. Only interactive classroom slides → apply the **Slide-Only Generation Override** (under `generation-workflow.md#slide-only-generation-override`) to lesson content, the Course Prompt, and Listen Mode. Question explicitly skipped → infer the format from the source material structure instead of inventing a fixed default.
 - **Interaction choices → normalized interaction policy.** Resolve one policy before Orchestration: one or more purposes selected → `enabled` with exactly those selected purposes; none selected → `disabled` with an empty `purposes` array; question explicitly skipped → `unspecified` with an empty `purposes` array. Validate the shape and enums against `data-contracts.md#interaction-policy`, then pass the normalized object unchanged to Generation and Optimization. Placement, teaching effect, and non-interactive substitutions are defined only by `pedagogy.md#interaction-policy-precedence`.
-- **Listen Mode**: pure slides → disable it and do not ask the question.
-  Otherwise the question must mention the extra AI-Shifu credit consumption;
-  unanswered → disabled; an explicit enable/disable decision carries into the
-  deployment handoff.
-- **Chapter and lesson counts** constrain the outline. Question explicitly
-  skipped → infer structure from source volume and existing lesson-granularity
-  rules instead of inventing a fixed default.
+- **Listen Mode**: pure slides → disable it and do not ask the question. Otherwise the question must mention the extra AI-Shifu credit consumption; unanswered → disabled; an explicit enable/disable decision carries into the deployment handoff.
+- **Chapter and lesson counts** constrain the outline. Question explicitly skipped → infer structure from source volume and existing lesson-granularity rules instead of inventing a fixed default.
 
 ## Pipeline Overview
 
-The phases are **not** a flat linear pipeline. **`course-target.md#resolve-the-course-target` gates the whole
-pipeline.** **Orchestration is an end-to-end driver** that internally calls Segmentation and Generation. Only Optimization and Deployment actually run in linear sequence after Orchestration completes. Load `optimization-workflow.md` and `deployment-workflow.md` only when the selected path needs them.
+The phases are **not** a flat linear pipeline. **`course-target.md#resolve-the-course-target` gates the whole pipeline.** **Orchestration is an end-to-end driver** that internally calls Segmentation and Generation. Only Optimization and Deployment actually run in linear sequence after Orchestration completes. Load `optimization-workflow.md` and `deployment-workflow.md` only when the selected path needs them.
 
 ```text
 Course request
@@ -94,6 +66,7 @@ Run the full pipeline from raw material to a live deployed course.
 ### Path B: Author Only
 
 Run Segmentation through Optimization to produce optimized Teaching Prompts, a Course Prompt, and an SEO course description without deploying. Sub-paths:
+
 - **Segment only**: Segmentation alone for structured segments and manual review.
 - **Generate only**: Generation alone on pre-existing segments to produce Teaching Prompts.
 - **Optimize only**: Optimization alone to audit and improve existing Teaching Prompts.

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -22,9 +22,7 @@ python3 {skillDir}/scripts/shifu-cli.py <command>
 
 ## Authentication
 
-The token persists in `{skillDir}/.env` and is valid for **7 days**, with each
-successful API call refreshing the expiry (sliding window — an active user never
-expires).  Before every operation that needs a token, run the one-shot check:
+The token persists in `{skillDir}/.env` and is valid for **7 days**, with each successful API call refreshing the expiry (sliding window — an active user never expires). Before every operation that needs a token, run the one-shot check:
 
 ```bash
 verify                         # exit 0 = valid, 1 = expired, 2 = unknown
@@ -40,54 +38,34 @@ login --phone 13800138000
 login --phone 13800138000 --sms-code 1234
 ```
 
-The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set
-`--token` / `SHIFU_TOKEN` directly.
+The CLI always talks to `https://app.ai-shifu.cn`. To skip the SMS login, set `--token` / `SHIFU_TOKEN` directly.
 
 ### Agent Login Flow
 
-**Gate: run `shifu-cli.py verify` first.** Exit 0 → skip login entirely; exit 1
-→ run the flow below **once**; exit 2 → retry later, do NOT trigger a new login.
+**Gate: run `shifu-cli.py verify` first.** Exit 0 → skip login entirely; exit 1 → run the flow below **once**; exit 2 → retry later, do NOT trigger a new login.
 
-**Hard constraint — one phone number = one SMS send per login session.**  Each
-phone number is capped at **5 SMS codes per day**.  Sending a second SMS when the
-first is still in transit wastes a slot and risks locking the user out.  The
-agent MUST:
+**Hard constraint — one phone number = one SMS send per login session.** Each phone number is capped at **5 SMS codes per day**. Sending a second SMS when the first is still in transit wastes a slot and risks locking the user out. The agent MUST:
+
 - Collect the phone number → send `login --phone <phone>` **exactly once**.
-- If the user asks "didn't receive / resend", reply "验证码在 60 秒内到达，请稍等" —
-  do NOT resend unless **3 consecutive wrong codes** have been entered.
-- After the 3rd consecutive wrong code, send `login --phone <phone>` one more
-  time (this is the final SMS for this session).
+- If the user asks "didn't receive / resend", reply "验证码在 60 秒内到达，请稍等" — do NOT resend unless **3 consecutive wrong codes** have been entered.
+- After the 3rd consecutive wrong code, send `login --phone <phone>` one more time (this is the final SMS for this session).
 
-Fixed flow: verify → (only if needed) ask for phone → send code → ask for SMS
-code → complete. Run the steps in order. Do not ask anything else.
+Fixed flow: verify → (only if needed) ask for phone → send code → ask for SMS code → complete. Run the steps in order. Do not ask anything else.
 
-Do not ask anything else. No status checks ("have you signed up / logged in
-before?"), no readiness or intent confirmations ("ready to start?", "I'll
-provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn
-collects exactly the next value (phone, then SMS code), nothing else. The
-Step 1 flow preview is a one-shot heads-up, not a confirmation prompt — do not
-wait for the user to acknowledge it before asking for the phone.
+Do not ask anything else. No status checks ("have you signed up / logged in before?"), no readiness or intent confirmations ("ready to start?", "I'll provide my phone"), no acknowledgment pauses, no recaps between steps. Each turn collects exactly the next value (phone, then SMS code), nothing else. The Step 1 flow preview is a one-shot heads-up, not a confirmation prompt — do not wait for the user to acknowledge it before asking for the phone.
 
 Steps:
 
-1. In a single turn, give the user a one-line preview of the full flow and then
-   immediately ask for the phone number. Cover all of these in the preview:
-   (a) SMS login, no password; (b) a 4-digit code will be sent to the phone;
-   (c) the user replies with the code in the next turn; (d) on success the token
-   is saved locally and login is complete; (e) new phone numbers auto-create an
-   account on first use. Keep it brief — one or two sentences total — then ask
-   for the phone in the same reply.
-2. Send SMS code **once**:
-   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone>`
+1. In a single turn, give the user a one-line preview of the full flow and then immediately ask for the phone number. Cover all of these in the preview: (a) SMS login, no password; (b) a 4-digit code will be sent to the phone; (c) the user replies with the code in the next turn; (d) on success the token is saved locally and login is complete; (e) new phone numbers auto-create an account on first use. Keep it brief — one or two sentences total — then ask for the phone in the same reply.
+2. Send SMS code **once**: `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone>`
 3. Ask the user for the 4-digit verification code they received.
-4. Complete login:
-   `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --sms-code <4-digit-code>`
+4. Complete login: `python3 {skillDir}/scripts/shifu-cli.py login --phone <phone> --sms-code <4-digit-code>`
 5. Token is automatically saved — proceed with the requested operation.
 
 **Error → agent behavior quick reference:**
 
 | What happened | Agent response |
-|---|---|
+| --- | --- |
 | `verify` exit 0 | Token valid — continue, no login |
 | `verify` exit 1 | Run the SMS flow above **once** |
 | `verify` exit 2 | Network issue — retry `verify` later |
@@ -97,10 +75,7 @@ Steps:
 | login returned sms code error (**3rd** consecutive time) | Re-send `login --phone <phone>` to get a new code |
 | Any API call returned code 1005 (token expired) | Run `verify` → login flow |
 
-**Token persistence.** The login step writes `SHIFU_TOKEN=<jwt>` into
-`{skillDir}/.env`. Once saved, `verify` is the gate — the token stays valid for
-7 days with sliding refresh. If the token expires (error codes `1001` / `1004`
-/ `1005`), re-run the login flow — the `.env` is overwritten in place.
+**Token persistence.** The login step writes `SHIFU_TOKEN=<jwt>` into `{skillDir}/.env`. Once saved, `verify` is the gate — the token stays valid for 7 days with sliding refresh. If the token expires (error codes `1001` / `1004` / `1005`), re-run the login flow — the `.env` is overwritten in place.
 
 Always use CLI commands. Never make raw HTTP/API calls directly.
 
@@ -131,6 +106,7 @@ Runs a DSL query against the creator-analytics endpoint and prints the full JSON
 The `shifu_bid` positional argument is injected into the body; if the DSL JSON already carries a `shifu_bid`, it must match the positional argument.
 
 Exit codes:
+
 - `0` — API responded with `code == 0` (the response carries `data.columns` / `data.rows`).
 - `1` — transport failure, JSON parse failure, or business error code (e.g. `11001` no access to course, `11002`-`11007` invalid DSL, `1001` / `1004` / `1005` token expired or missing).
 
@@ -157,39 +133,21 @@ Output is JSON: `summary` (total credits, distinct users / progress records, wal
 
 ## Version Sync (pull / status)
 
-The platform draft is the single source of truth — both draft and published
-versions carry an auto-incrementing `revision`. These commands keep a local
-course directory and the cloud draft version-consistent, like `git pull` /
-`git status`, so edits never silently overwrite a change another editor pushed.
+The platform draft is the single source of truth — both draft and published versions carry an auto-incrementing `revision`. These commands keep a local course directory and the cloud draft version-consistent, like `git pull` / `git status`, so edits never silently overwrite a change another editor pushed.
 
 ```bash
 pull <shifu_bid> --course-dir ./course-a/ [--force]   # Cloud -> local, writes .shifu-sync.json
 status --course-dir ./course-a/ [--exit-code]         # Compare local vs cloud revisions
 ```
 
-- `pull` fetches the course detail, outline tree, every lesson's MarkdownFlow,
-  and the course-level draft revision, writes them into the course directory
-  (`README.md`, `course-description.md`, `course-prompt.md`,
-  `lessons/lesson-NN.md`, `structure.json`),
-  and records the cloud `revision` of each lesson + the course in
-  `<course-dir>/.shifu-sync.json`. Any local file that diverges from the
-  incoming cloud content is backed up to `<file>.local-<ts>.bak` first (unless
-  `--force`).
-- `status` reads `.shifu-sync.json`, then reports per lesson: **behind** (cloud
-  revision advanced past the local baseline — run `pull`), **locally modified**
-  (the local file changed since last sync — will be pushed), **new on server**,
-  and **deleted on server**, plus a course-meta behind flag. `--exit-code`
-  returns non-zero when anything diverged (handy for agent scripting).
+- `pull` fetches the course detail, outline tree, every lesson's MarkdownFlow, and the course-level draft revision, writes them into the course directory (`README.md`, `course-description.md`, `course-prompt.md`, `lessons/lesson-NN.md`, `structure.json`), and records the cloud `revision` of each lesson + the course in `<course-dir>/.shifu-sync.json`. Any local file that diverges from the incoming cloud content is backed up to `<file>.local-<ts>.bak` first (unless `--force`).
+- `status` reads `.shifu-sync.json`, then reports per lesson: **behind** (cloud revision advanced past the local baseline — run `pull`), **locally modified** (the local file changed since last sync — will be pushed), **new on server**, and **deleted on server**, plus a course-meta behind flag. `--exit-code` returns non-zero when anything diverged (handy for agent scripting).
 
-`.shifu-sync.json` is **auto-maintained — do not hand-edit.** It is the local↔cloud
-version link (shifu_bid + per-lesson outline_bid + revision + course revision).
+`.shifu-sync.json` is **auto-maintained — do not hand-edit.** It is the local↔cloud version link (shifu_bid + per-lesson outline_bid + revision + course revision).
 
-**Canonical workflow:** `pull` → edit locally → `status` → `update-lesson` /
-`import` (push) → `publish`.
+**Canonical workflow:** `pull` → edit locally → `status` → `update-lesson` / `import` (push) → `publish`.
 
-**Exit-code convention** for the version-guarded write commands
-(`update-lesson`, `update-meta`, `import` when given `--course-dir`):
-`0` success · `2` conflict auto-pulled (redo on the new baseline) · `1` hard error.
+**Exit-code convention** for the version-guarded write commands (`update-lesson`, `update-meta`, `import` when given `--course-dir`): `0` success · `2` conflict auto-pulled (redo on the new baseline) · `1` hard error.
 
 ## Create Commands
 
@@ -210,51 +168,18 @@ set-access <shifu_bid> <outline_bid> --access guest|trial|normal [--hidden true|
 set-tts <shifu_bid> --enabled true|false [--speed SPEED] [--course-dir ./course-a/]
 ```
 
-`update-meta` sends only the content fields you pass (`--name` / `--description`
-/ `--course-prompt-file`), plus a locally modified `course-description.md` when
-`--course-dir` is supplied; it does **not** touch course
-attributes (model / price / TTS / Ask / …) — the backend preserves any field
-left out. When `--course-dir` is supplied, a successful description update
-writes `course-description.md` and records the new course metadata baseline in
-`.shifu-sync.json`. `rename-lesson` likewise changes only the name and no longer
-resets the lesson's learning permission.
+`update-meta` sends only the content fields you pass (`--name` / `--description` / `--course-prompt-file`), plus a locally modified `course-description.md` when `--course-dir` is supplied; it does **not** touch course attributes (model / price / TTS / Ask / …) — the backend preserves any field left out. When `--course-dir` is supplied, a successful description update writes `course-description.md` and records the new course metadata baseline in `.shifu-sync.json`. `rename-lesson` likewise changes only the name and no longer resets the lesson's learning permission.
 
-`set-access` sets one lesson's **learning permission** (`guest` = 无需登录 /
-`trial` = 试看·需登录 / `normal` = 需付费) without re-importing; it sends only
-`type` (+ `is_hidden` when `--hidden` is given), and the backend leaves the
-lesson's other fields untouched. With `--course-dir` it also writes the value
-into the `structure.json` reference.
+`set-access` sets one lesson's **learning permission** (`guest` = 无需登录 / `trial` = 试看·需登录 / `normal` = 需付费) without re-importing; it sends only `type` (+ `is_hidden` when `--hidden` is given), and the backend leaves the lesson's other fields untouched. With `--course-dir` it also writes the value into the `structure.json` reference.
 
-`set-tts` enables or disables course Listen Mode without re-importing. Disabling
-sends only `tts_enabled=false` and leaves the stored provider/model/voice/speed
-unchanged. Enabling sends the full TTS settings the backend validates:
-`tts_enabled=true`, `tts_provider`, `tts_model`, `tts_voice_id`, `tts_speed`,
-plus normalized `tts_pitch=0` and `tts_emotion=""`. Provider, model, voice, and
-default speed come from platform defaults at `/tts/config` (the same fallback
-used by the AI-Shifu settings page); `--speed` is the only optional override.
-With `--course-dir` it refreshes `course-config.json` and records the new course
-revision in `.shifu-sync.json`.
+`set-tts` enables or disables course Listen Mode without re-importing. Disabling sends only `tts_enabled=false` and leaves the stored provider/model/voice/speed unchanged. Enabling sends the full TTS settings the backend validates: `tts_enabled=true`, `tts_provider`, `tts_model`, `tts_voice_id`, `tts_speed`, plus normalized `tts_pitch=0` and `tts_emotion=""`. Provider, model, voice, and default speed come from platform defaults at `/tts/config` (the same fallback used by the AI-Shifu settings page); `--speed` is the only optional override. With `--course-dir` it refreshes `course-config.json` and records the new course revision in `.shifu-sync.json`.
 
-`update-lesson`, `update-meta`, and `set-tts` are version-aware when given `--course-dir`
-(a directory with a `.shifu-sync.json` from `pull`):
+`update-lesson`, `update-meta`, and `set-tts` are version-aware when given `--course-dir` (a directory with a `.shifu-sync.json` from `pull`):
 
-- `update-lesson` uses the **recorded baseline** revision for that outline (its
-  revision at last pull/push) as `base_revision`, so a concurrent edit by
-  another editor is actually detected. Without `--course-dir` it falls back to
-  the legacy behavior of taking the current cloud head as the baseline
-  (degraded — concurrent edits are not caught). On success it writes the new
-  revision back to the manifest and keeps the local lesson file in lockstep.
-- `update-meta` and `set-tts` have no server-side lock, so they compare the cloud
-  course-level revision against the manifest baseline before writing; any cloud
-  advance is treated conservatively as a conflict.
+- `update-lesson` uses the **recorded baseline** revision for that outline (its revision at last pull/push) as `base_revision`, so a concurrent edit by another editor is actually detected. Without `--course-dir` it falls back to the legacy behavior of taking the current cloud head as the baseline (degraded — concurrent edits are not caught). On success it writes the new revision back to the manifest and keeps the local lesson file in lockstep.
+- `update-meta` and `set-tts` have no server-side lock, so they compare the cloud course-level revision against the manifest baseline before writing; any cloud advance is treated conservatively as a conflict.
 
-**On conflict** these commands auto-pull the cloud copy over local (backing up
-your un-pushed change to `<file>.conflict` for a lesson, or
-`.shifu-meta.conflict.json` for meta — your work is never lost), print who
-changed it and when, and exit `2`. Re-apply your edit on the freshly pulled
-baseline and run the command again. Without `--course-dir`, `update-lesson`
-still sends the cloud-head `base_revision` and the server may reject the save
-with a raw conflict response (no auto-recovery).
+**On conflict** these commands auto-pull the cloud copy over local (backing up your un-pushed change to `<file>.conflict` for a lesson, or `.shifu-meta.conflict.json` for meta — your work is never lost), print who changed it and when, and exit `2`. Re-apply your edit on the freshly pulled baseline and run the command again. Without `--course-dir`, `update-lesson` still sends the cloud-head `base_revision` and the server may reject the save with a raw conflict response (no auto-recovery).
 
 ## Delete Commands
 
@@ -279,40 +204,15 @@ build --course-dir ./course-a/ [-o shifu-import.json] [--title "..."] [--descrip
 
 The `build` command works entirely offline — it reads the course directory's Teaching Prompts (one MarkdownFlow file per lesson under `lessons/`), the Course Prompt, and the SEO course description, then produces `shifu-import.json` without any network calls. The `import --course-dir` option combines build + import in one step. Description resolution order is `--description` -> `<course-dir>/course-description.md` -> empty string.
 
-**Course attributes are not pushed by default.** The skill manages course
-*content*; *attributes* (each lesson's learning permission / hidden state, and
-course-level model/price/TTS/Ask/…) are left to the platform. `build`/`import`
-send only content (lesson MarkdownFlow + course name/description/system prompt),
-and the backend uses **PATCH semantics** — any field a write omits is preserved.
-So `update-lesson` (content only) and `update-meta` (only the `--name` /
-`--description` / `--course-prompt-file` you pass, plus a locally modified
-`course-description.md` with `--course-dir`) never
-touch attributes.
+**Course attributes are not pushed by default.** The skill manages course _content_; _attributes_ (each lesson's learning permission / hidden state, and course-level model/price/TTS/Ask/…) are left to the platform. `build`/`import` send only content (lesson MarkdownFlow + course name/description/system prompt), and the backend uses **PATCH semantics** — any field a write omits is preserved. So `update-lesson` (content only) and `update-meta` (only the `--name` / `--description` / `--course-prompt-file` you pass, plus a locally modified `course-description.md` with `--course-dir`) never touch attributes.
 
-`pull` still writes the attributes into `structure.json` (`access`/`hidden`) and
-`course-config.json` as a **read-only reference** for the agent. To change an
-attribute, do it explicitly: `set-access` for a lesson's permission, `set-tts`
-for course Listen Mode, or the platform editor for other course-level
-settings.
+`pull` still writes the attributes into `structure.json` (`access`/`hidden`) and `course-config.json` as a **read-only reference** for the agent. To change an attribute, do it explicitly: `set-access` for a lesson's permission, `set-tts` for course Listen Mode, or the platform editor for other course-level settings.
 
-> **Iterating an existing course:** prefer the non-destructive granular commands
-> — `pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`.
-> The destructive whole-course `import` recreates every outline, so a recreated
-> lesson gets the platform default permission; use `import --new` for brand-new
-> courses, not to iterate an existing one.
+> **Iterating an existing course:** prefer the non-destructive granular commands — `pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`. The destructive whole-course `import` recreates every outline, so a recreated lesson gets the platform default permission; use `import --new` for brand-new courses, not to iterate an existing one.
 
-**Version-aware import.** When re-importing into an existing course with a
-`.shifu-sync.json` (`import <shifu_bid> --course-dir ...`), the CLI first checks
-the cloud course-level revision against the manifest baseline; if another editor
-advanced it, the whole local tree is backed up to `.conflict-backup-<ts>/`, the
-cloud copy is pulled over local, and the command exits `2` (re-apply, then
-re-run). After a successful import the manifest is re-seeded via an automatic
-`pull` so subsequent edits stay version-tracked.
+**Version-aware import.** When re-importing into an existing course with a `.shifu-sync.json` (`import <shifu_bid> --course-dir ...`), the CLI first checks the cloud course-level revision against the manifest baseline; if another editor advanced it, the whole local tree is backed up to `.conflict-backup-<ts>/`, the cloud copy is pulled over local, and the command exits `2` (re-apply, then re-run). After a successful import the manifest is re-seeded via an automatic `pull` so subsequent edits stay version-tracked.
 
-> **Note (Phase 1):** `import` is still destructive — it deletes and recreates
-> every outline, so all `outline_bid`s are regenerated on each import (per-lesson
-> server history does not carry over). For incremental, bid-stable edits prefer
-> `pull` → `update-lesson`. A non-destructive diff import (`--sync`) is planned.
+> **Note (Phase 1):** `import` is still destructive — it deletes and recreates every outline, so all `outline_bid`s are regenerated on each import (per-lesson server history does not carry over). For incremental, bid-stable edits prefer `pull` → `update-lesson`. A non-destructive diff import (`--sync`) is planned.
 
 Build behavior:
 

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -64,10 +64,7 @@ When Generation authors a new `images[].alt` value that will be embedded in a Te
 
 ## .shifu-sync.json
 
-Auto-maintained by `pull` and the version-aware write commands
-(`update-lesson` / `update-meta` / `import`). **Do not hand-edit.** It records
-the link between this local directory and the cloud course so pushes behave like
-`git push` (compare baseline before uploading) rather than blindly overwriting.
+Auto-maintained by `pull` and the version-aware write commands (`update-lesson` / `update-meta` / `import`). **Do not hand-edit.** It records the link between this local directory and the cloud course so pushes behave like `git push` (compare baseline before uploading) rather than blindly overwriting.
 
 Schema (abridged):
 
@@ -76,23 +73,38 @@ Schema (abridged):
   "schema_version": 1,
   "shifu_bid": "a1b2c3…",
   "base_url": "https://app.ai-shifu.cn",
-  "course": {"revision": 42, "name": "…", "description": "…", "updated_at": "…", "updated_user_bid": "…"},
+  "course": {
+    "revision": 42,
+    "name": "…",
+    "description": "…",
+    "updated_at": "…",
+    "updated_user_bid": "…"
+  },
   "lessons": [
-    {"file": "lessons/lesson-01.md", "outline_bid": "9a8b…", "name": "…",
-     "parent_bid": "ch_001", "revision": 1187, "is_chapter": false,
-     "content_sha256": "…"},
-    {"file": null, "outline_bid": "ch_001", "name": "第一章", "parent_bid": "",
-     "revision": null, "is_chapter": true}
+    {
+      "file": "lessons/lesson-01.md",
+      "outline_bid": "9a8b…",
+      "name": "…",
+      "parent_bid": "ch_001",
+      "revision": 1187,
+      "is_chapter": false,
+      "content_sha256": "…"
+    },
+    {
+      "file": null,
+      "outline_bid": "ch_001",
+      "name": "第一章",
+      "parent_bid": "",
+      "revision": null,
+      "is_chapter": true
+    }
   ],
-  "last_pull_at": "…", "last_push_at": "…"
+  "last_pull_at": "…",
+  "last_push_at": "…"
 }
 ```
 
-The per-lesson `revision` is the optimistic-locking baseline (the version at
-last pull/push) — how `status` detects "behind" and how a push detects a
-concurrent edit. `content_sha256` lets `status` tell whether the local file was
-edited since the last sync. See
-`cli-reference.md#version-sync-pull--status` for the workflow.
+The per-lesson `revision` is the optimistic-locking baseline (the version at last pull/push) — how `status` detects "behind" and how a push detects a concurrent edit. `content_sha256` lets `status` tell whether the local file was edited since the last sync. See `cli-reference.md#version-sync-pull--status` for the workflow.
 
 ## README.md
 
@@ -106,25 +118,15 @@ For every generated or edited lesson file, write authored Teaching Prompt instru
 
 ## course-description.md
 
-Contains the learner-facing SEO/listing description for the course. Path A and
-Author Only outputs must generate this file from the course topic, target
-learners, and concrete learning outcomes; do not include author-side workflow
-notes. Write its complete learner-facing content in `resolved_target_language`.
+Contains the learner-facing SEO/listing description for the course. Path A and Author Only outputs must generate this file from the course topic, target learners, and concrete learning outcomes; do not include author-side workflow notes. Write its complete learner-facing content in `resolved_target_language`.
 
-The `build` and `import --course-dir` commands map this file to
-`shifu.description` in `shifu-import.json`, which the CLI sends to the platform
-`description` field. Resolution order is:
+The `build` and `import --course-dir` commands map this file to `shifu.description` in `shifu-import.json`, which the CLI sends to the platform `description` field. Resolution order is:
 
 1. `--description`
 2. `<course-dir>/course-description.md`
 3. empty string
 
-Old course directories without `course-description.md` remain valid; they build
-with an empty platform description unless an explicit description flag is used.
-`pull` writes the current cloud description back to this file, and
-`update-meta --course-dir` pushes this file when it has a local content change;
-`update-meta --description --course-dir` also refreshes the file after a
-successful platform update.
+Old course directories without `course-description.md` remain valid; they build with an empty platform description unless an explicit description flag is used. `pull` writes the current cloud description back to this file, and `update-meta --course-dir` pushes this file when it has a local content change; `update-meta --description --course-dir` also refreshes the file after a successful platform update.
 
 ## course-prompt.md
 
@@ -152,8 +154,18 @@ Schema:
     {
       "title": "Chapter Title",
       "lessons": [
-        {"file": "lesson-01.md", "title": "Lesson Title", "access": "guest", "hidden": false},
-        {"file": "lesson-02.md", "title": "Another Lesson Title", "access": "normal", "hidden": false}
+        {
+          "file": "lesson-01.md",
+          "title": "Lesson Title",
+          "access": "guest",
+          "hidden": false
+        },
+        {
+          "file": "lesson-02.md",
+          "title": "Another Lesson Title",
+          "access": "normal",
+          "hidden": false
+        }
       ]
     }
   ]
@@ -171,25 +183,29 @@ Field reference:
 
 ## course-config.json
 
-A **read-only snapshot** of the course-level attributes (model / price / TTS /
-Ask / keywords / …), written by `pull` so the agent can see the current settings.
-**`build`/`import` do NOT send it** (attributes policy: `cli-reference.md#bulk-import`).
-The course **name** lives in `README.md`, the SEO **description** in
-`course-description.md`, and the **system prompt** in `course-prompt.md`.
-The one exception: `set-tts --course-dir` refreshes this snapshot after changing
-Listen Mode or its TTS provider/model/voice/speed settings.
+A **read-only snapshot** of the course-level attributes (model / price / TTS / Ask / keywords / …), written by `pull` so the agent can see the current settings. **`build`/`import` do NOT send it** (attributes policy: `cli-reference.md#bulk-import`). The course **name** lives in `README.md`, the SEO **description** in `course-description.md`, and the **system prompt** in `course-prompt.md`. The one exception: `set-tts --course-dir` refreshes this snapshot after changing Listen Mode or its TTS provider/model/voice/speed settings.
 
 ```json
 {
-  "model": "", "temperature": 0.3, "price": 0, "keywords": [], "avatar": "",
+  "model": "",
+  "temperature": 0.3,
+  "price": 0,
+  "keywords": [],
+  "avatar": "",
   "use_learner_language": false,
-  "tts_enabled": false, "tts_provider": "", "tts_model": "", "tts_voice_id": "",
-  "tts_speed": 1.0, "tts_pitch": 0, "tts_emotion": "",
-  "ask_enabled_status": 5101, "ask_model": "", "ask_temperature": 0.0,
-  "ask_system_prompt": "", "ask_provider_config": {}
+  "tts_enabled": false,
+  "tts_provider": "",
+  "tts_model": "",
+  "tts_voice_id": "",
+  "tts_speed": 1.0,
+  "tts_pitch": 0,
+  "tts_emotion": "",
+  "ask_enabled_status": 5101,
+  "ask_model": "",
+  "ask_temperature": 0.0,
+  "ask_system_prompt": "",
+  "ask_provider_config": {}
 }
 ```
 
-To change a lesson's permission (`set-access`) or course Listen Mode (`set-tts`),
-see `cli-reference.md#update-commands`. Other course-level attributes are changed
-in the platform editor.
+To change a lesson's permission (`set-access`) or course Listen Mode (`set-tts`), see `cli-reference.md#update-commands`. Other course-level attributes are changed in the platform editor.

--- a/skills/ai-shifu-course-creator/references/course-prompt.md
+++ b/skills/ai-shifu-course-creator/references/course-prompt.md
@@ -28,7 +28,7 @@ Use this file to materialize one course-wide artifact from the six-section templ
 
 # Task
 
-- The current course is *XXX*. Your goal is to help the learner master XXX.
+- The current course is _XXX_. Your goal is to help the learner master XXX.
 - Teach one-on-one, address the learner directly in the second person, and do not use group-addressing terms such as "everyone", "class", or "students".
 - Do not introduce yourself.
 - Do not greet the learner.

--- a/skills/ai-shifu-course-creator/references/course-target.md
+++ b/skills/ai-shifu-course-creator/references/course-target.md
@@ -6,27 +6,14 @@ This workflow is mandatory before course creation, course-content editing, or de
 
 Write course-match summaries, new-versus-existing choice questions, ambiguous-match choices, and no-match explanations in `resolved_target_language`. Preserve course titles, Shifu BIDs, directory paths, and CLI commands verbatim.
 
-**This runs first for every course-creation or editing request — before
-Orchestration, before proposing any course architecture/outline, before writing a
-single lesson.** The AI-Shifu platform DB is the single source of truth; you must
-know whether you are creating a brand-new course or editing an existing one
-*before* you invest in authoring. **Do NOT jump straight to a course outline or
-"架构方案".** Even when the user clearly says "make a new course", first check the
-cloud for an existing one.
+**This runs first for every course-creation or editing request — before Orchestration, before proposing any course architecture/outline, before writing a single lesson.** The AI-Shifu platform DB is the single source of truth; you must know whether you are creating a brand-new course or editing an existing one _before_ you invest in authoring. **Do NOT jump straight to a course outline or "架构方案".** Even when the user clearly says "make a new course", first check the cloud for an existing one.
 
 1. **Recognize intent** — new course, or edit an existing one?
-2. **Check whether a related course already exists** — run
-   `shifu-cli.py find-title <keyword>` (targeted title search; do **not** dump the
-   whole `list`).
+2. **Check whether a related course already exists** — run `shifu-cli.py find-title <keyword>` (targeted title search; do **not** dump the whole `list`).
 3. **Branch:**
-   - **New intent + a match exists** → **ASK the user**: edit that existing course,
-     or create a separate new one? *Edit it* → `pull <bid> --course-dir <dir>` then
-     edit locally; *Create new* → author from scratch, then `import --new`.
+   - **New intent + a match exists** → **ASK the user**: edit that existing course, or create a separate new one? _Edit it_ → `pull <bid> --course-dir <dir>` then edit locally; _Create new_ → author from scratch, then `import --new`.
    - **New intent + no match** → author from scratch, then `import --new`.
-   - **Edit intent + a match exists** → `pull <bid> --course-dir <dir>`, then edit
-     locally. **Do NOT ask** new-vs-edit; if several match, only resolve *which* one.
+   - **Edit intent + a match exists** → `pull <bid> --course-dir <dir>`, then edit locally. **Do NOT ask** new-vs-edit; if several match, only resolve _which_ one.
    - **Edit intent + no match** → author from scratch, then `import --new`.
 
-Only **after** the target is resolved do you enter `authoring-intake.md` or the selected standalone authoring phase.
-When the target is an existing course, author **on top of the pulled copy**,
-then push via the converging loop in `deployment-workflow.md#version-sync-workflow`.
+Only **after** the target is resolved do you enter `authoring-intake.md` or the selected standalone authoring phase. When the target is an existing course, author **on top of the pulled copy**, then push via the converging loop in `deployment-workflow.md#version-sync-workflow`.

--- a/skills/ai-shifu-course-creator/references/data-contracts.md
+++ b/skills/ai-shifu-course-creator/references/data-contracts.md
@@ -17,9 +17,7 @@ Provide one of:
 - Lesson granularity preference (`short`, `medium`, `long`).
 - Tone constraints.
 - Non-negotiable source fragments.
-- `course_author_name` (string): the course author's real name for the Course
-  Prompt role. If absent when a Course Prompt must be generated, ask the author
-  instead of inventing a persona name.
+- `course_author_name` (string): the course author's real name for the Course Prompt role. If absent when a Course Prompt must be generated, ask the author instead of inventing a persona name.
 - `course_profile` object.
 - `delivery_constraints` object.
 - `interaction_policy` object: normalized Course Design Intake result; see [Interaction Policy](#interaction-policy).
@@ -111,31 +109,28 @@ Each item in the Segmentation output (consumed by Orchestration and Generation):
 - `segment_type` (string enum, required) — must satisfy [Segment Types](#segment-types).
 - `core_point` (string, required) — the single teachable point this segment carries, written in `resolved_target_language`.
 - `preserve_block` (boolean, required) — `true` when the source span is selected as immutable by [optimization-workflow.md#preservation-decisions](optimization-workflow.md#preservation-decisions). The field records the decision; downstream MarkdownFlow behavior is defined in [markdownflow.md#preservation](markdownflow.md#preservation).
-- `source_span` (object, required) — traceable source location with `source_id`
-  (string), `start` (non-negative integer, inclusive character offset), and `end`
-  (integer greater than `start`, exclusive character offset). Use the same object
-  shape as entries in `course_index.source_span_map`.
+- `source_span` (object, required) — traceable source location with `source_id` (string), `start` (non-negative integer, inclusive character offset), and `end` (integer greater than `start`, exclusive character offset). Use the same object shape as entries in `course_index.source_span_map`.
 - `transfer_signals` (object, required) — must satisfy [Transfer Signals](#transfer-signals).
 
 ### Segment Types
 
 `segment_type` must use exactly one of these canonical values:
 
-| Value | Meaning |
-|---|---|
-| `concept` | Explanatory statements and definitions. |
-| `example` | Concrete demonstrations and walkthroughs. |
-| `code` | Executable or pseudo-code blocks. |
-| `image` | Image files and their source references. |
-| `exercise` | Learner action prompts. |
-| `transition` | Bridge text that links ideas. |
+| Value        | Meaning                                   |
+| ------------ | ----------------------------------------- |
+| `concept`    | Explanatory statements and definitions.   |
+| `example`    | Concrete demonstrations and walkthroughs. |
+| `code`       | Executable or pseudo-code blocks.         |
+| `image`      | Image files and their source references.  |
+| `exercise`   | Learner action prompts.                   |
+| `transition` | Bridge text that links ideas.             |
 
 ### Transfer Signals
 
 `transfer_signals` must be non-empty. Include every applicable canonical key, omit inapplicable keys rather than inventing content, and give every included key a non-empty, concise string value in `resolved_target_language`. Preserve an exact source quotation or other immutable source span when the signal intentionally carries it verbatim.
 
 | Key | Meaning |
-|---|---|
+| --- | --- |
 | `learner_hook` | Teaching entry point. |
 | `evidence_type` | Form of source evidence. |
 | `visual_cue` | Cue for expressing the segment as a slide. |

--- a/skills/ai-shifu-course-creator/references/deployment-workflow.md
+++ b/skills/ai-shifu-course-creator/references/deployment-workflow.md
@@ -23,23 +23,9 @@ Complete `authentication.md` first. Always use CLI commands; never make raw HTTP
 
 Teaching Prompts must be organized in a course directory (one MarkdownFlow file per lesson under `lessons/`) before deployment. See `cli/course-directory-spec.md` for the full specification. When continuing from Optimization (Path A), write the optimized Teaching Prompts and Course Prompt into this structure automatically.
 
-**Content vs attributes — the skill changes content, not attributes, by default.**
-Content = lesson MarkdownFlow + course name/description/prompt; attributes = each
-lesson's learning permission (`access` = 无需登录/试看/付费) and `hidden`, plus
-course-level model/price/TTS/Ask/keywords/…. The skill pushes only content, and
-the platform backend uses PATCH semantics (any field a write omits is left
-unchanged), so iterating content never resets attributes. `pull` writes the
-current attributes into `structure.json` and `course-config.json` as a
-**read-only reference**. Change attributes only when the user explicitly asks —
-`set-access` for a lesson's permission, `set-tts` for course Listen Mode (flags:
-`cli/cli-reference.md#update-commands`); other course-level settings
-are changed in the platform editor.
+**Content vs attributes — the skill changes content, not attributes, by default.** Content = lesson MarkdownFlow + course name/description/prompt; attributes = each lesson's learning permission (`access` = 无需登录/试看/付费) and `hidden`, plus course-level model/price/TTS/Ask/keywords/…. The skill pushes only content, and the platform backend uses PATCH semantics (any field a write omits is left unchanged), so iterating content never resets attributes. `pull` writes the current attributes into `structure.json` and `course-config.json` as a **read-only reference**. Change attributes only when the user explicitly asks — `set-access` for a lesson's permission, `set-tts` for course Listen Mode (flags: `cli/cli-reference.md#update-commands`); other course-level settings are changed in the platform editor.
 
-**Editing an existing course → use granular non-destructive commands**
-(`pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`).
-The destructive whole-course `import` recreates every outline (a recreated lesson
-gets the platform-default permission), so reserve `import --new` for brand-new
-courses — do not use it to iterate an existing one.
+**Editing an existing course → use granular non-destructive commands** (`pull → update-lesson / add-lesson / delete-lesson / reorder / set-access / set-tts`). The destructive whole-course `import` recreates every outline (a recreated lesson gets the platform-default permission), so reserve `import --new` for brand-new courses — do not use it to iterate an existing one.
 
 ### CLI Commands
 
@@ -50,6 +36,7 @@ All commands documented in `cli/cli-reference.md` (deployment: `build` / `import
 **Language gate:** Before any content or metadata mutation, run the source, effective-value, direct-command, and user-facing checks in [Language Audit](review-checklist.md#language-audit). After `build`, inspect the listed `shifu-import.json` fields before import or publish. This two-stage gate verifies the actual deployment payload rather than only the source files.
 
 **From pipeline (Path A continuation):**
+
 1. Write Optimization outputs into the course directory: `lessons/lesson-*.md`, `README.md`, `course-description.md` (the generated SEO description; no author-side process notes), `course-prompt.md` (the Optimization `course_prompt` artifact, structured per `course-prompt.md#fillable-template`), and required `structure.json`.
 2. Run `build --course-dir <dir>` to generate `shifu-import.json`.
 3. **Deploy a new target**: Run `import --new --json-file <dir>/shifu-import.json`. If `course-target.md` resolved an existing target, do not run this command; use the Version Sync Workflow below.
@@ -57,15 +44,13 @@ All commands documented in `cli/cli-reference.md` (deployment: `build` / `import
 5. Verify via platform URL.
 
 **Standalone deployment (Path C):**
+
 1. Ensure the course directory is ready: Teaching Prompt files under `lessons/`, a `course-description.md` SEO summary, a `course-prompt.md` (author per `course-prompt.md#fillable-template` first if missing), and `structure.json` (create it if missing). Directories without `course-description.md` still build, but the platform description will be empty unless `--description` is provided.
 2. New target: run `build` → `import --new` → `publish`. Existing target: use the Version Sync Workflow.
 
 ### Version Sync Workflow
 
-The **front guard** that fixes the target (new-vs-edit, `find-title`,
-pulling the existing course) is `course-target.md#resolve-the-course-target` — run it first. This section covers
-what happens once the target is an existing course you have pulled: the
-**pull → edit → push** loop that converges like `git pull` before `git push`.
+The **front guard** that fixes the target (new-vs-edit, `find-title`, pulling the existing course) is `course-target.md#resolve-the-course-target` — run it first. This section covers what happens once the target is an existing course you have pulled: the **pull → edit → push** loop that converges like `git pull` before `git push`.
 
 1. **`pull <shifu_bid> --course-dir <dir>`** — download the cloud draft into the local dir and record revisions.
 2. **Edit locally** — change lesson files / course description / course prompt in place.
@@ -73,26 +58,17 @@ what happens once the target is an existing course you have pulled: the
 4. **Push** with `--course-dir` so the recorded baseline is used: `update-lesson <bid> <ob> --teaching-prompt-file f.md --course-dir <dir>` for a single lesson, or `import <bid> --course-dir <dir>` for the whole course.
 5. **`publish <bid>`** when ready for learners.
 
-**Convergence loop on conflict.** A push checks whether the cloud advanced since
-your last sync:
+**Convergence loop on conflict.** A push checks whether the cloud advanced since your last sync:
 
 - **No newer version → push succeeds (exit 0) → done.** Proceed to `publish`.
-- **Newer version → push reports a conflict (exit 2). Exit 2 means "retry", not
-  "give up".** The CLI has **already** backed up your un-pushed change,
-  auto-pulled the latest cloud copy over local, and printed who changed it and
-  when. Then **loop**: re-read the freshly pulled files (the new baseline) →
-  re-apply your intended change on top of it (you, the agent, do the merge — the
-  CLI never auto-merges content) → run the same push again → **repeat until the
-  push succeeds (exit 0)**. Never force the old content back — the cloud is
-  authoritative.
+- **Newer version → push reports a conflict (exit 2). Exit 2 means "retry", not "give up".** The CLI has **already** backed up your un-pushed change, auto-pulled the latest cloud copy over local, and printed who changed it and when. Then **loop**: re-read the freshly pulled files (the new baseline) → re-apply your intended change on top of it (you, the agent, do the merge — the CLI never auto-merges content) → run the same push again → **repeat until the push succeeds (exit 0)**. Never force the old content back — the cloud is authoritative.
 
-Never hand-edit `.shifu-sync.json`, and always push with `--course-dir` —
-without it a concurrent edit cannot be detected. Backup file locations and full
-mechanics: `cli/cli-reference.md#version-sync-pull--status`.
+Never hand-edit `.shifu-sync.json`, and always push with `--course-dir` — without it a concurrent edit cannot be detected. Backup file locations and full mechanics: `cli/cli-reference.md#version-sync-pull--status`.
 
 ### Verification
 
 After any deployment or management operation, verify the result:
+
 1. Show the user the verification URLs the script printed — admin console, course preview, and (when the script also printed it) the published public URL. Copy URLs verbatim from the script output and render each as three lines: a Markdown link, a bare URL on the next line for copy-friendliness, and the script's following Chinese `# ...` hint copied verbatim without the leading `#` (per `report-template.md` — Deployment → Verification URLs, plus the top-level Formatting Rules exception). Never reconstruct URLs from a template by hand. Lesson-level URLs are intentionally omitted to keep the report scannable; if the user later asks for a specific lesson link, use `show <shifu_bid>` to find the `outline_bid` and build it on demand.
 2. Use `show <shifu_bid>` to get the lesson `outline_bid`, then check each lesson's Teaching Prompt, variable collection, and interaction logic.
 

--- a/skills/ai-shifu-course-creator/references/generation-workflow.md
+++ b/skills/ai-shifu-course-creator/references/generation-workflow.md
@@ -82,9 +82,7 @@ When Course Design Intake resolves to pure slides / classroom interactive slides
 - Generate slide-facing blocks only: slide title, 2-4 short bullets, and a visual/layout instruction. When the interaction policy permits an interaction, also include its prompt, options, and concise feedback states.
 - Keep policy-permitted interactions runnable with the normal MarkdownFlow syntax, but keep the surrounding content presentation-oriented. When the policy calls for the non-interactive substitute, render only the slide-facing content defined by `pedagogy.md#interaction-policy-precedence`.
 - Do not instruct the runtime LLM to narrate or verbally explain the slides. Omit long spoken paragraphs and instructions such as "explain to the learner", "walk through", "向学习者说明", "讲解", "用文字解释", or "讲清".
-- Do not require the normal visual-text explanation pair. The visual itself and
-  the short on-slide labels carry the projection content; any explanation
-  belongs to the human instructor, not the Teaching Prompt.
+- Do not require the normal visual-text explanation pair. The visual itself and the short on-slide labels carry the projection content; any explanation belongs to the human instructor, not the Teaching Prompt.
 - The Course Prompt must describe the runtime role as producing classroom slides, using "interactive slides" only when the interaction policy permits interactions, not as conducting one-on-one tutoring. Do not include course-level instructions that ask the AI to verbally explain the lesson to a single learner.
 
 ### Outputs
@@ -113,7 +111,7 @@ Raw SVG, HTML drawings, Mermaid, PlantUML, and Graphviz source are not image-emb
 Every uploaded image URL embedded in a Teaching Prompt uses `https://res.ai-shifu.cn/<uuid32>`. Choose one of these forms after the lesson's visual intent is known:
 
 | Authoring intent | Form |
-|---|---|
+| --- | --- |
 | Display the uploaded image as authored, without layout customization | Wrap standard Markdown image syntax in the single-line deterministic form: `===![informative alt](url)===` |
 | Control width, alignment, caption, or multi-image layout | Write a natural-language HTML-view instruction and leave it generative |
 
@@ -123,6 +121,7 @@ For an HTML-view image, do not put generated HTML or the instruction inside `===
 
 ```markdown
 必须在此处以 HTML-view 方式插入一张带图注的图片,不得省略,并使用 HTML <figure>/<figcaption> 结构。
+
 - URL(必须原样保留):https://res.ai-shifu.cn/<uuid32>
 - 图片内容(必须用于生成语义化 alt,不得省略):图片传达的具体概念或关系
 - 图注文字(必须原样输出,不要改写):图注原文
@@ -144,7 +143,7 @@ Before finalizing a generated Teaching Prompt that embeds images:
 
 ### Working with Author-Provided Images
 
-When the author supplies image assets — local files (any format incl. heic/heif) or remote URLs — three steps apply *within* Generation (and any later phase that touches the same lessons):
+When the author supplies image assets — local files (any format incl. heic/heif) or remote URLs — three steps apply _within_ Generation (and any later phase that touches the same lessons):
 
 1. **Understand each image before placing it.** You cannot choose the lesson, position, or alt text without knowing what the image shows. Two regimes:
    - **You can see the image** (attached in this conversation and your model is multimodal): describe it to yourself in one sentence — what concept, relation, or example it conveys — then choose the lesson and position per `pedagogy.md#visual-text-coordination`.

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -50,10 +50,7 @@ MarkdownFlow recognizes two preservation forms:
 - Multi-line fence:
 
 ```markdown
-!===
-Line 1
-Line 2
-!===
+!=== Line 1 Line 2 !===
 ```
 
 A standalone `===...===` line and a complete `!===...!===` fence produce deterministic output without requiring any additional boundary syntax. The runtime removes the markers, substitutes variables without adding quoting wrappers, restores protected code, and emits the result without an LLM call.

--- a/skills/ai-shifu-course-creator/references/markdownflow.md
+++ b/skills/ai-shifu-course-creator/references/markdownflow.md
@@ -49,8 +49,12 @@ MarkdownFlow recognizes two preservation forms:
 - Single-line or inline marker: `===fixed text===`
 - Multi-line fence:
 
+<!-- prettier-ignore -->
 ```markdown
-!=== Line 1 Line 2 !===
+!===
+Line 1
+Line 2
+!===
 ```
 
 A standalone `===...===` line and a complete `!===...!===` fence produce deterministic output without requiring any additional boundary syntax. The runtime removes the markers, substitutes variables without adding quoting wrappers, restores protected code, and emits the result without an LLM call.

--- a/skills/ai-shifu-course-creator/references/pedagogy.md
+++ b/skills/ai-shifu-course-creator/references/pedagogy.md
@@ -45,7 +45,7 @@ A lesson missing a phase required by its selected loop is incomplete. The follow
 Keep the three patterns and their step order. The interaction-policy matrix decides whether each pattern's interaction slot remains interactive or uses the corresponding non-interactive replacement:
 
 | Pattern | Interaction slot | Non-interactive replacement |
-|---|---|---|
+| --- | --- | --- |
 | Pattern A: Evidence Chain | Step 4 learner interaction | Worked application |
 | Pattern B: Misconception Repair | Step 4 interaction check | Worked boundary check |
 | Pattern C: Comparison-Driven Learning | Step 1 baseline response capture | Worked baseline |
@@ -117,7 +117,7 @@ These are the teaching decisions for whether to collect an answer, how often to 
 This section defines how slides and explanatory text divide teaching responsibility. Encode the selected visual form through [generation-workflow.md#image-authoring](generation-workflow.md#image-authoring); MarkdownFlow's resulting runtime behavior is defined in [markdownflow.md#images](markdownflow.md#images). Use [generation-workflow.md#working-with-author-provided-images](generation-workflow.md#working-with-author-provided-images) for author-provided asset handling.
 
 | Scenario | Authority and requirements |
-|---|---|
+| --- | --- |
 | Standard non-slide-only teaching | Keep every core concept paired with a slide and textual explanation. The slide carries structural prompting; the text carries the complete explanation and remains understandable when the learner has not seen the slide. Pair each slide direction with a brief explanation of what it should convey. |
 | Author-provided image file | Use the asset as part of the teaching explanation rather than as decoration. In standard teaching, follow it with the complete explanatory paragraph. If the course is slide-only, the next row overrides that paragraph requirement. |
 | Pure slides | Follow the [Slide-Only Generation Override](generation-workflow.md#slide-only-generation-override). Produce concise, projection-ready slide content; do not require AI narration or a full standalone explanatory paragraph paired with every slide. |

--- a/skills/ai-shifu-course-creator/references/prompt-contracts.md
+++ b/skills/ai-shifu-course-creator/references/prompt-contracts.md
@@ -27,7 +27,7 @@ Apply lesson-level teaching decisions through [Pedagogy](pedagogy.md) and materi
 Use each linked source directly. Workflow files apply these authorities through phase-specific actions and checks; they do not redefine them.
 
 | Concern | Authoritative source |
-|---|---|
+| --- | --- |
 | Prompt audience, instruction voice, addressee, and second-person meaning | [Prompt Semantics](#prompt-semantics) |
 | Lesson loop, teaching patterns, interaction decisions, variable-persistence decisions, and teaching-side visual coordination | [Pedagogy](pedagogy.md) |
 | MarkdownFlow preprocessing, syntax recognition, variable substitution, interaction execution, branch limitations, deterministic output, and image runtime behavior | [MarkdownFlow Spec](markdownflow.md) |

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -154,20 +154,29 @@ The fenced snippets below are illustrative templates only. In the generated repo
 
 - `Admin console:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `管理后台`)
 
+  <!-- prettier-ignore -->
   ```md
-  - [<course name> - <localized admin-console label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized admin-console label>](<URL from script>)
+    <URL from script>
+    <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 - `Course preview:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `预览课程`)
 
+  <!-- prettier-ignore -->
   ```md
-  - [<course name> - <localized course-preview label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized course-preview label>](<URL from script>)
+    <URL from script>
+    <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 - `Published URL:` (only when the script printed it) → localize the purpose label in `resolved_target_language` (Simplified Chinese: `课程学习`)
 
+  <!-- prettier-ignore -->
   ```md
-  - [<course name> - <localized published-course label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized published-course label>](<URL from script>)
+    <URL from script>
+    <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one sentence in `resolved_target_language` explaining that the course is not yet published and that `publish <shifu_bid>` will produce the shareable address.

--- a/skills/ai-shifu-course-creator/references/report-template.md
+++ b/skills/ai-shifu-course-creator/references/report-template.md
@@ -14,8 +14,7 @@ These rules apply to every report produced from this template, and to any other 
 - **Exception — deployment / management Verification URLs.** When transcribing the `Verification URLs:` block printed by `shifu-cli.py` (`publish` / `import` / `create` / `show`), emit each URL as **three lines**:
   1. A Markdown link — `[<course name> - <purpose label in resolved_target_language>](<URL>)`
   2. The same URL again on its own line (intentionally bare), indented two spaces — so the user can long-press / select to copy it cleanly.
-  3. The script's following Chinese `# ...` hint, copied verbatim without the leading `#`.
-  The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients. The script-owned Chinese hint on line 3 is a verbatim-output exception to the report-language rule; do not translate or rewrite it.
+  3. The script's following Chinese `# ...` hint, copied verbatim without the leading `#`. The bare URL on line 2 is the only place a bare URL is allowed; it exists because copying out of a rendered Markdown link is unreliable on some clients. The script-owned Chinese hint on line 3 is a verbatim-output exception to the report-language rule; do not translate or rewrite it.
 
 ## Segmentation Report
 
@@ -156,25 +155,19 @@ The fenced snippets below are illustrative templates only. In the generated repo
 - `Admin console:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `管理后台`)
 
   ```md
-  - [<course name> - <localized admin-console label>](<URL from script>)
-    <URL from script>
-    <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized admin-console label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 - `Course preview:` → localize the purpose label in `resolved_target_language` (Simplified Chinese: `预览课程`)
 
   ```md
-  - [<course name> - <localized course-preview label>](<URL from script>)
-    <URL from script>
-    <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized course-preview label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 - `Published URL:` (only when the script printed it) → localize the purpose label in `resolved_target_language` (Simplified Chinese: `课程学习`)
 
   ```md
-  - [<course name> - <localized published-course label>](<URL from script>)
-    <URL from script>
-    <Chinese hint copied verbatim from the script output, without "#">
+  - [<course name> - <localized published-course label>](<URL from script>) <URL from script> <Chinese hint copied verbatim from the script output, without "#">
   ```
 
 When the script did **not** print `Published URL:` (typical for fresh `create` / `import` runs), show only the two existing blocks and add one sentence in `resolved_target_language` explaining that the course is not yet published and that `publish <shifu_bid>` will produce the shareable address.

--- a/skills/ai-shifu-course-creator/references/session-controls.md
+++ b/skills/ai-shifu-course-creator/references/session-controls.md
@@ -19,8 +19,7 @@ Do **not** include a contact mention in routine phase reports, ordinary progress
 
 ## Version Check
 
-Once per session, before the first task, run:
-`python3 scripts/shifu-cli.py check-update`
+Once per session, before the first task, run: `python3 scripts/shifu-cli.py check-update`
 
 - Treat the command output as internal control data. In normal conversation, never expose raw JSON or terms such as `status`, `manifest`, `source`, `SemVer`, or “local/remote version”.
 - If frontmatter sets `version_management: plugin`, the CLI returns a skipped result before contacting the remote manifest because the containing plugin owns versioning and updates. `version_management: standalone` or a missing field uses the normal skill-level check.
@@ -41,7 +40,7 @@ Write routine progress updates, blocking and non-blocking error explanations, re
 Use this table for human-facing skill concept labels in user-visible prose, reports, artifact labels, and handoff instructions. Use the corresponding language column when available; otherwise localize the terms naturally in `resolved_target_language`. Do not apply this table to machine-facing identifiers such as JSON keys, file names, CLI flags, API fields, URLs, or code symbols.
 
 | Canonical term | English | 简体中文 | Français | Usage |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `AI-Shifu` | AI-Shifu | AI 师傅 | AI Shifu | Product name in human-facing prose. |
 | `Lesson` | Lesson | 节 / 课节 | Leçon | Course lesson unit in human-facing prose. |
 | `Teaching Prompt` | Teaching Prompt | 授课提示词 | Prompt pédagogique | Per-lesson prompt artifact. Use plural naturally when needed. |

--- a/skills/course-direction-advisor/SKILL.md
+++ b/skills/course-direction-advisor/SKILL.md
@@ -12,15 +12,18 @@ Turn messy or complete source materials into a course-topic decision that is sel
 ## What This Skill Actually Does
 
 This skill is not a generic naming tool. It performs a constrained commercial translation:
+
 - Content constraint: the core of the course must come from the user's materials.
 - Market constraint: the recommendation must match real demand, competition, and buying logic.
 
 The goal is not to find the biggest possible topic. The goal is to find the smallest topic that is still credibly sellable:
+
 - `Minimum Sellable Topic`: a topic the author can truly teach and the market can plausibly buy.
 
 ## Core Capabilities
 
 This skill is designed to:
+
 - translate an author's real material into market-aware course directions
 - identify target users, market stage, competing solutions, and credible gaps
 - judge whether a topic is too crowded, tool-replaced, weakly differentiated, or better downgraded
@@ -28,6 +31,7 @@ This skill is designed to:
 - judge whether the material is substantial enough to sustain a real course rather than only a topic claim
 
 This skill can optionally expand into:
+
 - `demand-density`
 - `seo-gap`
 - `trend-cycle`
@@ -35,6 +39,7 @@ This skill can optionally expand into:
 - `content-validation`
 
 This skill should not pretend it can do:
+
 - precise TAM / SAM / SOM modeling
 - strong demand claims based on one viral post or one hot keyword
 - direct conversion from traffic heat to paid-course demand
@@ -43,42 +48,50 @@ This skill should not pretend it can do:
 ## What Is Allowed vs. Not Allowed
 
 Allowed:
+
 - reorganizing the source material
 - reframing the angle
 - extracting audience, problem, and result from the material
 - adjusting the packaging level to fit market language
 
 Not allowed:
+
 - inventing methods that are not in the material
 - fabricating cases, results, authority, or credentials
 - turning scattered experience into a fake complete system
 - replacing real capability with trendy market language
 
 In short:
+
 - commercial reframing is allowed
 - content fabrication is not
 
 ## Minimum Invocation Pattern
 
 ### Minimum Input
+
 - one or more source documents, transcripts, notes, drafts, or outlines
 - optional: author background, case proof, market preference, known competitors
 
 ### Typical Output
+
 - `topic-selection-report.md`
 - `topic_candidates.json`
 
 ### Typical Failure Pattern
+
 - Failure: the material contains opinions but no stable audience, method, case, or proof, yet gets packaged as a high-promise results course.
 - Fix: pull the recommendation back to the real evidence ceiling, or downgrade the product.
 
 ## Analysis Modes
 
 Use two modes, with `B-market-scan` as default:
+
 - `A-material-only`: analyze only the provided materials; useful when the user explicitly forbids external scanning
 - `B-market-scan`: combine material analysis with current public market signals
 
 Rules:
+
 - Use `A-material-only` only when the user explicitly asks for material-only analysis or blocks external research.
 - Use `B-market-scan` by default when you need to recommend pricing, market opportunity, validation strength, competition, or final prioritization.
 - In `A-material-only`, do not make strong market claims. Use conservative labels such as “plausible,” “needs market validation,” or “not ready for final recommendation.”
@@ -89,6 +102,7 @@ Rules:
 This skill is written in English, but report delivery follows the user's instruction language.
 
 Course-topic-specific language rules:
+
 - The final report should be written in the same language the user used to issue the task, unless the user asks otherwise.
 - Market research must include, and should prioritize, countries and markets that match the instruction language.
 - Example: if the user asks in Chinese, research should include and prioritize Chinese-language markets; if the user asks in English, research should include and prioritize English-language markets.
@@ -97,6 +111,7 @@ Course-topic-specific language rules:
 ## Standard Lifecycle Labels
 
 Use these five labels as the canonical lifecycle taxonomy:
+
 - `information-explosion`
 - `segmented-understanding`
 - `methodology-phase`
@@ -110,26 +125,32 @@ If older labels appear in historical templates, map them to the canonical set in
 Do not jump to title ideas too early. Make these judgments first:
 
 1. `content compression`
+
 - What does the material consistently do well?
 - What does it clearly not support?
 
 2. `user mapping`
+
 - Who is the material best suited to help?
 - Who has both the need and the willingness to pay?
 
 3. `market positioning`
+
 - What stage is the market in?
 - What kinds of solutions dominate the space?
 
 4. `sellable packaging`
+
 - What is the right product form and promise level for the evidence available?
 
 5. `content sufficiency`
+
 - Does the material contain enough distinctive viewpoints, methods, cases, experience, or teaching assets to support an actual course?
 - Can the topic sustain at least three meaningful lessons without filler?
 - Is there a self-consistent knowledge spine rather than scattered observations?
 
 6. `validation strength`
+
 - Is this topic merely logical, or does it already show enough public market support to justify building?
 
 If any of these six steps fails, do not finalize the topic.
@@ -137,6 +158,7 @@ If any of these six steps fails, do not finalize the topic.
 ## Evidence Discipline
 
 Every important claim should be tagged by source type:
+
 - `source-direct`: stated explicitly in the material
 - `source-inferred`: inferred from multiple parts of the material without exceeding it
 - `market-observed`: drawn from current public market evidence
@@ -147,11 +169,13 @@ Never present `market-observed` or `synthesis-judgment` as if it came directly f
 ## Evidence Indexing
 
 Before analysis, build an evidence index:
+
 - assign `source_ref` IDs to material chunks, such as `SRC-001`, `SRC-002`
 - maintain a short `trace_map`: `source_ref -> excerpt / summary / location`
 - record market evidence separately as `market_ref`, with concrete dates and links
 
 Output rules:
+
 - every major claim should be traceable to `source_ref[]`, `market_ref[]`, or both
 - recommendations, unique-value claims, audience claims, risk claims, and no-go conclusions should all be traceable at the claim level
 - `source_evidence_map.json` is recommended by default for decision-oriented reports
@@ -161,11 +185,13 @@ Output rules:
 When “bigger market” conflicts with “truer material,” prioritize the material boundary.
 
 The same material may legitimately be translated:
+
 - from expression-oriented material into a problem-oriented course
 - from experience-oriented material into a method-oriented course
 - from a broad theme into a narrower segment
 
 But only if:
+
 - the new topic can still be proven directly or indirectly by the material
 - the author can genuinely teach it without sounding empty
 - the material contains enough internal structure to support a course, not just a catchy title
@@ -175,6 +201,7 @@ But only if:
 Finding a plausible topic is not enough. The material must also be able to carry a course.
 
 Before finalizing any recommended topic, test all of the following:
+
 - `knowledge depth`: are there enough real concepts, judgments, or principles to teach?
 - `knowledge breadth`: is there enough material to cover at least three meaningful lessons?
 - `internal coherence`: do the viewpoints, methods, cases, and examples form a self-consistent whole?
@@ -182,24 +209,28 @@ Before finalizing any recommended topic, test all of the following:
 - `distinctive kernel`: compared with competitors, does the material contain a real teachable edge such as a distinct viewpoint, specific method, unusual experience, or an interest-triggering angle?
 
 Do not approve a course topic when the material has only one of the following:
+
 - a marketable headline without enough teaching substance
 - generic opinions that competitors can also say
 - fragmented notes without a stable method or teaching path
 - inspiration value but no repeatable knowledge structure
 
 Minimum rule:
+
 - a full course recommendation should normally be able to support at least three lessons with non-redundant knowledge points
 - if the material cannot support that threshold, downgrade the recommendation to a lighter product form
 
 ## Market Scan Rules
 
 If you use `B-market-scan` or make market claims:
+
 - research current public discussion rather than relying on memory or general intuition
 - prioritize the last 90 days; extend to 12 months for mature topics
 - write concrete dates instead of “recently” or “now”
 - state clearly when evidence is insufficient
 
 See also:
+
 - [input-contract.md](references/input-contract.md)
 - [decision-model.md](references/decision-model.md)
 - [market-analysis.md](references/market-analysis.md)
@@ -236,6 +267,7 @@ The quality of the topic decision depends on how it is communicated.
 `1 main + 2 backups` does not mean three headline variations of the same idea.
 
 Backup directions should differ from the main direction on at least one of:
+
 - target audience
 - topic angle
 - teaching objective
@@ -246,6 +278,7 @@ If the difference is only wording, treat it as the same direction.
 ### Competitor analysis must answer the real buying question
 
 Do not stop at names and links. For each competitor or substitute, explain:
+
 - what problem it solves
 - who it serves
 - why people buy it
@@ -253,10 +286,12 @@ Do not stop at names and links. For each competitor or substitute, explain:
 - where that leaves room for this topic
 
 Then make one more comparison:
+
 - what teachable kernel this material has that those competitors do not clearly provide
 - whether that kernel is strong enough to support a course, not just a positioning sentence
 
 Competitors are not limited to “similar courses.” They also include:
+
 - tools
 - free tutorials
 - training camps
@@ -266,6 +301,7 @@ Competitors are not limited to “similar courses.” They also include:
 ### Human-facing reports should not read like API output
 
 If the report is meant for people rather than downstream systems:
+
 - use natural language first
 - avoid field-name overload, placeholder-style presentation, and excessive shorthand
 - make the conclusion obvious on the first screen
@@ -273,6 +309,7 @@ If the report is meant for people rather than downstream systems:
 - repeat the full topic name at key points rather than overusing vague references such as “this direction”
 
 When helpful, produce two versions:
+
 - a structured version for traceability and reuse
 - a readable version for decision-making and communication
 
@@ -286,6 +323,7 @@ When helpful, produce two versions:
 ## Valid Downgrade Paths
 
 If the material does not support a full course, downgrade rather than forcing one:
+
 - case breakdown
 - experience sharing
 - conceptual clarification
@@ -297,6 +335,7 @@ Downgrading is not failure. It preserves truth.
 ## Failure Handling
 
 When the material is weak, fragmented, or under-evidenced:
+
 - say that the material is currently not strong enough for a competitive course topic
 - or recommend the smallest version that still holds
 - explicitly list what additional material would strengthen the recommendation

--- a/skills/course-direction-advisor/references/decision-model.md
+++ b/skills/course-direction-advisor/references/decision-model.md
@@ -3,19 +3,23 @@
 ## Core Idea
 
 The job is not to simply name a course. The job is to complete a commercially useful translation under two hard constraints:
+
 - content reality: stay inside the material
 - market reality: stay inside real demand and real competition
 
 Failure usually comes from satisfying only one side:
+
 - content-only thinking produces topics that sound thoughtful but do not sell
 - market-only thinking produces topics that sound sellable but the author cannot truly teach
 
 The correct target is:
+
 - `Minimum Sellable Topic`
 
 ## What Counts as a Minimum Sellable Topic
 
 A direction qualifies only if all four are true:
+
 - the material has a stable content core
 - the market shows a recognizable demand
 - a specific audience could plausibly pay for the outcome or efficiency gain
@@ -45,6 +49,7 @@ If one of these is missing, do not finalize the topic.
 ### 1. Content Compression
 
 Answer:
+
 - what the material consistently covers
 - what problem it is genuinely good at addressing
 - what themes, moves, cases, and judgments recur
@@ -53,10 +58,12 @@ Answer:
 ### 2. User Mapping
 
 Find the overlap between:
+
 - people who need this
 - people likely to pay for this
 
 For each serious audience candidate, answer:
+
 - current state
 - desired outcome
 - what they do not want to do
@@ -67,6 +74,7 @@ For each serious audience candidate, answer:
 ### 3. Market Positioning
 
 Answer:
+
 - current market stage
 - dominant solution types
 - competitive density and pattern
@@ -77,6 +85,7 @@ Answer:
 Do not default to a full course.
 
 Possible packaging modes:
+
 - cognitive
 - method
 - case
@@ -89,10 +98,12 @@ The evidence ceiling determines the packaging ceiling.
 ### 5. Validation Strength
 
 Judge whether the direction is:
+
 - merely logical
 - or already meaningfully validated by public signals
 
 Ask:
+
 - is there recurring discussion, not just a spike
 - are users repeatedly asking for templates, examples, execution help, or clarification
 - is there stable supply of comparable solutions
@@ -102,6 +113,7 @@ Ask:
 ## When a Course Topic Should Be Rejected
 
 Any of the following is enough to reject or downgrade a course direction:
+
 - the material is too scattered to form a stable problem core
 - demand exists but the material does not contain a matching solution
 - market attention exists but competition is saturated and the material has no real edge
@@ -115,6 +127,7 @@ Rejecting the course direction is a valid result, not a failure of the analysis.
 ## Downgrade Logic
 
 If a full course does not hold, test whether the material can support:
+
 - a case breakdown
 - an experience share
 - a conceptual clarification
@@ -122,6 +135,7 @@ If a full course does not hold, test whether the material can support:
 - an observation report
 
 Even a downgraded direction must still answer:
+
 - who it is for
 - why they would care
 - why they might buy it
@@ -129,6 +143,7 @@ Even a downgraded direction must still answer:
 ## Buying Logic
 
 Most buyers respond to some combination of:
+
 - `trust`
 - `relevance`
 - `executability`

--- a/skills/course-direction-advisor/references/decision-report-template.md
+++ b/skills/course-direction-advisor/references/decision-report-template.md
@@ -3,6 +3,7 @@
 Use this template when the user needs a decision-oriented course-topic report rather than a loose market summary.
 
 The report should help the user decide:
+
 - which direction to push
 - why that direction wins
 - what the backup routes are
@@ -12,6 +13,7 @@ The report should help the user decide:
 ## When to Use This Template
 
 Use this template only when:
+
 - the material has already been compressed into a stable capability core
 - a basic market scan is complete
 - you can propose at least one main direction and two meaningful backups
@@ -21,16 +23,19 @@ If the material or market evidence is too weak, downgrade to a conservative feas
 ## Analysis Mode
 
 Always state the mode:
+
 - `A-material-only`
 - `B-market-scan`
 
 If the user asks in a specific language:
+
 - write the report in that language unless they ask otherwise
 - include and prioritize markets aligned with that language
 
 ## Lifecycle Labels
 
 Use the canonical lifecycle set:
+
 - `information-explosion`
 - `segmented-understanding`
 - `methodology-phase`
@@ -40,6 +45,7 @@ Use the canonical lifecycle set:
 ## Core Principles
 
 Always preserve these rules:
+
 - material boundary first, market amplification second
 - promise ceiling must not exceed the evidence ceiling
 - market size, sales potential, and breakout potential must remain evidence-constrained judgments
@@ -50,11 +56,13 @@ Always preserve these rules:
 ### 1. Conclusion First
 
 The first screen should give:
+
 - one recommended direction
 - two backup directions
 - two to three directions that should not be pursued
 
 For each recommended direction, include at least:
+
 - what kind of course it is
 - who it is for
 - what problem it solves
@@ -65,6 +73,7 @@ For each recommended direction, include at least:
 Compare all serious directions in one place.
 
 At minimum include:
+
 - direction name
 - course type
 - target audience
@@ -77,6 +86,7 @@ At minimum include:
 The main and backup directions must be genuinely different.
 
 They should differ on at least one of:
+
 - target audience
 - problem framing
 - teaching objective
@@ -87,6 +97,7 @@ If they are merely title variants, treat them as the same direction.
 ### 3. Why the Decision Was Reached
 
 Explain:
+
 - what user-problem cluster was identified in the market
 - how the source material maps back to that cluster
 - why the recommended direction beats the alternatives
@@ -97,11 +108,13 @@ This section should make the reasoning obvious, not just the conclusion.
 ### 4. Competitor and Substitute Analysis
 
 Analyze at least three competitors or substitutes from different categories:
+
 - method/content products
 - tools or platform features
 - services, training camps, or free-content substitutes
 
 For each one, explain:
+
 - what problem it solves
 - who it serves
 - why users buy it
@@ -116,6 +129,7 @@ Do not dump links without interpretation.
 ### 5. Market Stage and Buying Logic
 
 Explain plainly:
+
 - the current stage of the market
 - what users now need
 - what they are actually willing to pay for
@@ -124,6 +138,7 @@ Explain plainly:
 ### 5.5 Growth Curve
 
 For each serious direction, explain:
+
 - whether it is more likely to spike, compound steadily, or follow a hybrid curve
 - what would make the direction grow well
 - what would make it stall or fade
@@ -135,6 +150,7 @@ This helps prevent the report from treating all “good topics” as commerciall
 List at least two directions that should not be pursued.
 
 Typical reasons:
+
 - outside the material boundary
 - clearly crowded
 - low willingness to pay for a course
@@ -144,6 +160,7 @@ Typical reasons:
 ### 7. Final Recommendation
 
 For the recommended direction, specify:
+
 - title
 - teaching objective
 - course type
@@ -154,6 +171,7 @@ For the recommended direction, specify:
 - minimum launch scope
 
 For backups, specify:
+
 - title
 - audience
 - teaching objective
@@ -162,6 +180,7 @@ For backups, specify:
 ### 8. Author or Team Advantage
 
 If the material supports a real edge, state it explicitly:
+
 - real background
 - representative proof
 - scarce perspective
@@ -173,6 +192,7 @@ The goal is to explain why this author has a right to teach this topic.
 ### 9. Decision Gate
 
 Add:
+
 - decision status
 - decision reason
 - top risks
@@ -183,11 +203,13 @@ The report should feel like a decision memo, not a brainstorm note.
 ### 10. MVP and Seven-Day Validation Plan
 
 Include:
+
 - the smallest launchable version
 - the initial pricing hypothesis
 - a seven-day validation plan
 
 Typical validation steps:
+
 - interview target users
 - scan comparable offers
 - test three value propositions
@@ -197,6 +219,7 @@ Typical validation steps:
 ### 10.5 Optional Weighted Scorecard
 
 If a sharper decision gate is useful, add a weighted scorecard:
+
 - source strength: 25
 - user-problem fit: 20
 - market opportunity: 20
@@ -208,11 +231,13 @@ Use the scorecard as a support tool, not as a substitute for reasoning.
 ### 11. Evidence Appendix
 
 Add:
+
 - `claim_evidence_map`
 - external links
 - missing-evidence checklist
 
 Also include a short `course-readiness check`:
+
 - whether the material can support at least three lessons
 - what the lesson spine would be
 - what is still missing if the topic is only partially course-ready
@@ -220,6 +245,7 @@ Also include a short `course-readiness check`:
 ## Readability Rules
 
 If the report is meant for human decision-making:
+
 - make the conclusion readable in under one minute
 - make the reasoning readable in the next section
 - avoid field-name-heavy presentation unless the user explicitly wants a structured version

--- a/skills/course-direction-advisor/references/gating-rules.md
+++ b/skills/course-direction-advisor/references/gating-rules.md
@@ -33,56 +33,69 @@ All of the following must hold:
 ## Common Failure Modes
 
 ### Making the topic larger than the material
+
 - Failure: a narrow capability gets packaged as broad market authority
 - Fix: pull the topic back to the real audience, problem, and scenario the material actually covers
 
 ### Overstating the author
+
 - Failure: scattered experience gets upgraded into full methodology
 - Fix: call it a framework only when the material shows repeatable structure, cases, or stable judgment logic
 
 ### Using an audience that is too broad
+
 - Failure: “anyone who wants to improve”
 - Fix: specify at least two of the following: role, stage, current blockage
 
 ### Confusing need with willingness to pay
+
 - Failure: assuming everyone with the pain is a viable customer
 - Fix: test both problem intensity and product-form willingness to pay
 
 ### Mistaking discussion heat for business opportunity
+
 - Failure: “people talk about it, therefore it should be a course”
 - Fix: check saturation, alternatives, and whether the material has real replacement value
 
 ### Mistaking keyword growth for durable demand
+
 - Failure: one rising term becomes a long-term course thesis
 - Fix: compare 90-day and 12-month windows, and test the underlying problem terms
 
 ### Borrowing competitor language as if it were your own edge
+
 - Failure: copying a successful framing that the material cannot support
 - Fix: only reuse a framing if the material supports the promise, audience, and proof behind it
 
 ### Turning content validation into business validation
+
 - Failure: public discussion is treated as proof of conversion
 - Fix: content validation only proves that the topic deserves deeper testing
 
 ### Treating a course as the default product form
+
 - Failure: anything teachable becomes a course by default
 - Fix: test whether the better product is a lighter content product, tool, service, or downgrade
 
 ### Confusing a good topic sentence with a teachable course
+
 - Failure: the title sounds strong, but the material cannot support three solid lessons
 - Fix: audit knowledge points, methods, cases, and exercises before approving the course form
 
 ### Mistaking unique wording for real differentiation
+
 - Failure: the report claims a differentiated angle, but competitors already cover the same substance
 - Fix: compare the material's actual viewpoint, experience, method, and examples against competing offers
 
 ### Writing emotional buying logic in vague language
+
 - Failure: “users are anxious and want growth”
 - Fix: state the real purchase tension, such as fear of wasting time, fear of buying fluff, or fear of unusable output
 
 ## Suggested Scoring Dimensions
 
 Use these as decision aids, not as a fake precision system:
+
 - `source_strength`
 - `audience_clarity`
 - `market_timing`
@@ -94,6 +107,7 @@ Use these as decision aids, not as a fake precision system:
 - `trend_stability`
 
 Optional weighted scorecard for sharper decision-making:
+
 - `source_strength`: 25
 - `user_problem_fit`: 20
 - `market_opportunity`: 20
@@ -107,22 +121,26 @@ Use this only when a weighted score genuinely helps the decision. Do not hide we
 For approval or resource-allocation outputs, add a formal decision status.
 
 ### `GO`
+
 - a clear minimum sellable topic exists
 - no hard gate is broken
 - audience, problem, proof, delivery, and market stage align well enough to proceed
 - the material can support a coherent course with enough substance for at least three meaningful lessons
 
 ### `HOLD`
+
 - the direction may be good, but critical evidence is still missing
 - common gaps include weak proof, unclear payment logic, or weak market evidence
 - use this when the topic looks viable but lesson-level substance is still uncertain
 
 ### `REWORK`
+
 - the material may support something real, but the current packaging is wrong
 - likely fixes include changing the audience, lowering the promise, changing the product form, or narrowing the angle
 - use this when the material has value but needs a smaller or more specific course scope to become teachable
 
 ### `NO-GO`
+
 - no credible minimum sellable topic exists
 - or the space is saturated and the material has no edge
 - or buyers are clearly more likely to choose a tool or service
@@ -132,11 +150,13 @@ For approval or resource-allocation outputs, add a formal decision status.
 ## Risk Output Standard
 
 Decision-oriented reports should explicitly score at least:
+
 - `over_competition_risk`
 - `insufficient_material_risk`
 - `weak_differentiation_risk`
 
 For each risk, include:
+
 - severity
 - trigger
 - supporting evidence

--- a/skills/course-direction-advisor/references/input-contract.md
+++ b/skills/course-direction-advisor/references/input-contract.md
@@ -3,6 +3,7 @@
 ## P0 Required Inputs
 
 At minimum, the analysis needs:
+
 - core source material: transcripts, articles, outlines, notes, interviews, case writeups, or fragmented documents
 - source ownership: whose experience, viewpoint, or method the material represents
 - grouping or order across multiple documents, so different themes do not get merged by accident
@@ -35,6 +36,7 @@ These inputs materially affect audience selection, promise ceiling, and differen
 If the user's instruction language implies a market focus, the research scope should reflect that.
 
 Rules:
+
 - the final report should follow the user's instruction language unless the user says otherwise
 - the market scan must include, and should prioritize, countries and markets aligned with the instruction language
 - if the topic is cross-border, include the instruction-language market plus the most commercially relevant adjacent market
@@ -50,6 +52,7 @@ Rules:
 ## Required Extraction Fields
 
 Every run should extract at least:
+
 - `theme_cue`: core themes and recurring claims
 - `audience_cue`: audience, role, stage, baseline ability
 - `problem_cue`: pain points, failure cases, blocked moments
@@ -63,6 +66,7 @@ Every run should extract at least:
 - `evidence_ref`: the `source_ref[]` that supports each extracted cue
 
 For stronger decision reports, target segments should also capture:
+
 - `current_state`: what is true before the course
 - `job_to_be_done`: the progress the user is trying to make
 - `purchase_motivation`: why this person would actively buy
@@ -73,22 +77,27 @@ For stronger decision reports, target segments should also capture:
 ## Missing-Information Handling
 
 If author-proof material is missing:
+
 - you may say the topic is plausible but differentiation is weak
 - you may not invent authority, years of experience, or proprietary methodology
 
 If audience evidence is missing:
+
 - you may propose 2-3 candidate audience groups
 - each candidate group still needs a material-based reason
 
 If market evidence is missing:
+
 - downgrade the conclusion to “needs market validation”
 - do not make strong opportunity claims
 - if the task is a go/no-go decision, default toward `HOLD`, not `GO`
 
 If keyword or competitor evidence is missing:
+
 - generate an initial search set from the material itself
 - explicitly note that SEO / trend / channel confidence is lower
 
 If content-validation evidence is missing:
+
 - you may judge topic plausibility
 - you may not upgrade the conclusion to “validated to sell”

--- a/skills/course-direction-advisor/references/market-analysis.md
+++ b/skills/course-direction-advisor/references/market-analysis.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-The point of market analysis is not to prove that “this will sell.”
-The point is to constrain topic selection with real public evidence:
+The point of market analysis is not to prove that “this will sell.” The point is to constrain topic selection with real public evidence:
+
 - what the market is currently discussing
 - how far user understanding has already developed
 - what kinds of solutions dominate the space
@@ -16,15 +16,18 @@ Market analysis exists to discipline the recommendation, not to invent a marketi
 You must research current public signals.
 
 Default scope:
+
 - prioritize the last 90 days
 - extend to 12 months for mature or slower-moving topics
 
 Signal categories to cover:
+
 - discussion signals: articles, videos, posts, podcasts, communities, Q&A
 - product signals: courses, bootcamps, consulting offers, tools, memberships
 - demand signals: questions, complaints, “how do I,” “template please,” “example please,” “I bought this but still cannot do it”
 
 Always record:
+
 - concrete dates
 - links
 - the specific market observed
@@ -34,6 +37,7 @@ Always record:
 The market scan must reflect the user's instruction language.
 
 Rules:
+
 - if the user asks in Chinese, include and prioritize Chinese-language markets
 - if the user asks in English, include and prioritize English-language markets
 - if the topic is international, include the instruction-language market plus the most commercially relevant adjacent market
@@ -42,12 +46,14 @@ Rules:
 ## Default vs Optional Depth
 
 The default research level is `core-scan`:
+
 - lifecycle judgment
 - competitor and solution mapping
 - real user pain and unmet demand
 - whether the source material fills a real gap
 
 Add deeper layers only if necessary:
+
 - `sizing-scan`
 - `seo-scan`
 - `trend-scan`
@@ -61,6 +67,7 @@ Do not expand every topic-selection task into a full commercial research project
 At the topic-selection stage, demand density matters more than fake precision on market size.
 
 Check:
+
 - does the same problem appear across platforms
 - is there stable paid supply, not just free discussion
 - will users pay for a course rather than a tool or service
@@ -68,6 +75,7 @@ Check:
 - does the same underlying problem persist across multiple audience groups
 
 Allowed labels:
+
 - `small`
 - `medium`
 - `large`
@@ -80,17 +88,20 @@ Always clarify that this is a public-signal estimate, not a precise market model
 Do not scan a topic with a single keyword.
 
 At minimum, search across:
+
 - core topic terms
 - problem terms
 - result terms
 - alternative phrasing and competitor phrasing
 
 Trend checks should compare:
+
 - 30 days
 - 90 days
 - 12 months
 
 Look for:
+
 - `event-spike`
 - `seasonal`
 - `steady-demand`
@@ -104,26 +115,31 @@ If the visible heat is only in the framing while the underlying problem is stabl
 Use one primary stage, with an optional secondary stage if needed.
 
 ### `information-explosion`
+
 - lots of broad discussion
 - shallow understanding
 - high visibility, weak differentiation
 
 ### `segmented-understanding`
+
 - the broad idea is accepted
 - different user groups now have different questions
 - this is often the best stage for a sharp segment play
 
 ### `methodology-phase`
+
 - the market wants repeatable process, not just explanation
 - framework-heavy solutions appear
 - weakly structured material tends to fail here
 
 ### `toolification-phase`
+
 - tools, templates, or semi-automation increasingly replace manual work
 - users want speed and convenience more than more theory
 - pure content products face replacement risk
 
 ### `red-ocean`
+
 - repetitive headlines
 - repetitive promises
 - pricing pressure
@@ -135,6 +151,7 @@ Use one primary stage, with an optional secondary stage if needed.
 Judge not only stage, but also what type of competitor is strongest.
 
 ### Content competitors
+
 - courses
 - tutorials
 - cohorts
@@ -142,24 +159,28 @@ Judge not only stage, but also what type of competitor is strongest.
 - knowledge products
 
 ### Tool competitors
+
 - SaaS
 - AI writing tools
 - templates
 - workflow products
 
 ### Service competitors
+
 - consultants
 - ghostwriters
 - done-for-you services
 - coaching or implementation help
 
 The report should say:
+
 - which type dominates
 - why a course still has room, or why it does not
 
 ## Competitor Analysis Standard
 
 For each serious competitor or substitute, answer:
+
 - what problem it solves
 - who it serves
 - what it promises
@@ -168,12 +189,12 @@ For each serious competitor or substitute, answer:
 - what it does not solve
 - what room remains for this topic
 
-Do not limit competitors to “courses like mine.”
-Include tools, free content, training camps, platform features, and service substitutes.
+Do not limit competitors to “courses like mine.” Include tools, free content, training camps, platform features, and service substitutes.
 
 ## When a Market Is “Too Crowded”
 
 You can classify a space as crowded or close to red ocean when several of these are true:
+
 - top and mid-tier competitors make nearly the same promise
 - keywords and framing are repetitive
 - users describe offerings as “all the same”
@@ -182,6 +203,7 @@ You can classify a space as crowded or close to red ocean when several of these 
 - the material has no extra proof, sharper audience, or structural advantage
 
 Useful labels:
+
 - `under-contested`
 - `segmentable`
 - `red-ocean`
@@ -190,6 +212,7 @@ Useful labels:
 ## Solution Mapping
 
 For each major solution type, note:
+
 - `solution_type`
 - `target_user`
 - `promise`
@@ -204,6 +227,7 @@ This is where you explain what the market is already solving, and what still rem
 ## Opportunity Logic
 
 A real opportunity usually looks like one of these:
+
 - many people talk about the theme, but the audience segmentation is still weak
 - the market explains the topic, but the material offers a more executable path
 - the market overpromises results, while the material offers stronger process credibility
@@ -211,6 +235,7 @@ A real opportunity usually looks like one of these:
 - the market is tool-heavy, but users still need judgment and refinement
 
 These do **not** count as real opportunities:
+
 - merely changing the headline
 - making the topic broader
 - pretending weak material can compete with strong proof-based offers
@@ -221,6 +246,7 @@ These do **not** count as real opportunities:
 Prioritize user language, not creator language.
 
 Look for:
+
 - repeated questions
 - complaints and failure reports
 - requests for templates, cases, examples, or process
@@ -228,6 +254,7 @@ Look for:
 - “the tool is fast, but the output is unusable”
 
 Map those pains to:
+
 - `trust`
 - `relevance`
 - `executability`
@@ -238,6 +265,7 @@ Map those pains to:
 Only do this when the user asks for channel strategy.
 
 Check:
+
 - active platforms and positioning
 - title structures and keyword clusters
 - what content pulls attention vs. what content converts
@@ -247,16 +275,17 @@ The purpose is to help select the market entry angle, not to copy anyone's conte
 
 ## Content Validation
 
-Content validation does not mean “guaranteed to sell.”
-It means there is enough public signal to justify going deeper.
+Content validation does not mean “guaranteed to sell.” It means there is enough public signal to justify going deeper.
 
 Useful labels:
+
 - `validated`
 - `partially-validated`
 - `weakly-validated`
 - `unvalidated`
 
 At minimum, validate against:
+
 - recurring problems inside the source material
 - recurring market demand
 - stable supply of comparable offers
@@ -265,6 +294,7 @@ At minimum, validate against:
 ## Emotional Purchase Logic
 
 Beyond rational need, identify the emotional purchase driver:
+
 - `trust`
 - `relevance`
 - `executability`

--- a/skills/course-direction-advisor/references/output-contract.md
+++ b/skills/course-direction-advisor/references/output-contract.md
@@ -3,6 +3,7 @@
 ## Required Outcome
 
 The result must end in one of two states:
+
 - viable: one recommended topic plus two to three backup directions
 - not viable: a formal `not-viable` conclusion, optionally with downgrade paths
 
@@ -46,6 +47,7 @@ The result must end in one of two states:
 ## Optional Additions for Deeper Market Work
 
 Add only when the user asks for more depth:
+
 - `demand_density`: `small / medium / large / unknown`
 - `market_size_note`: a rough market-size note grounded in public signals
 - `trend_pattern`: `event-spike / seasonal / steady-demand / declining / reframed-demand`
@@ -58,6 +60,7 @@ Add only when the user asks for more depth:
 ## Required Additions for the Recommended Direction
 
 The recommended topic must also explain:
+
 - `why_this_one`: why it wins over larger, hotter, or more obvious directions
 - `fit_reason`: how it matches the material, the user problem, and the market stage at the same time
 - `go_to_market_hint`: the best packaging angle for entering the market
@@ -70,6 +73,7 @@ The recommended topic must also explain:
 ## Human-Facing Report Rules
 
 If the report is meant for humans rather than downstream systems:
+
 - the main and backup directions must differ meaningfully in audience, angle, teaching objective, or product form
 - competitor analysis cannot stop at links; it must explain what problem each product actually solves
 - the report should explicitly state whether the material is topic-ready only or genuinely course-ready
@@ -81,6 +85,7 @@ If the report is meant for humans rather than downstream systems:
 ## `not-viable` Output
 
 If no competitive topic can be justified:
+
 - use `viability_status: not-viable`
 - state whether the failure is due to content, audience, market, or delivery weakness
 - include downgrade options where appropriate
@@ -88,11 +93,13 @@ If no competitive topic can be justified:
 ## Title Rules
 
 A title should express at least two of the following:
+
 - audience
 - problem
 - result
 
 It must not:
+
 - exceed the material boundary
 - promise results the evidence cannot support
 - become abstract or “high-level” at the cost of specificity
@@ -110,6 +117,7 @@ It must not:
 ## Reusable Output Files
 
 When useful, also generate:
+
 - `topic_candidates.json`
 - `market_scan.md`
 - `source_evidence_map.json`

--- a/tests/test_course_creator_router.py
+++ b/tests/test_course_creator_router.py
@@ -313,6 +313,20 @@ class CourseCreatorRouterTests(unittest.TestCase):
             "ordinary Markdown without the surrounding fence",
             verification_templates,
         )
+        for purpose_label in (
+            "localized admin-console label",
+            "localized course-preview label",
+            "localized published-course label",
+        ):
+            with self.subTest(purpose_label=purpose_label):
+                self.assertIn(
+                    f"  - [<course name> - <{purpose_label}>]"
+                    "(<URL from script>)\n"
+                    "    <URL from script>\n"
+                    '    <Chinese hint copied verbatim from the script output, '
+                    'without "#">',
+                    verification_templates,
+                )
         self.assertIn(
             "translate every non-placeholder instruction",
             (references / "optimization-workflow.md").read_text(encoding="utf-8"),

--- a/tests/test_validate_skill_quality.py
+++ b/tests/test_validate_skill_quality.py
@@ -1126,6 +1126,9 @@ class PedagogyContractTests(unittest.TestCase):
             "Single-line or inline marker: `===fixed text===`", deterministic
         )
         self.assertIn(
+            "```markdown\n!===\nLine 1\nLine 2\n!===\n```", deterministic
+        )
+        self.assertIn(
             "without requiring any additional boundary syntax", deterministic
         )
         self.assertIn("without an LLM call", deterministic)


### PR DESCRIPTION
## Changed

- Added a pinned Prettier pre-commit hook for Markdown files.
- Configured `proseWrap: never` so prose is not soft-wrapped.
- Formatted the existing Markdown files with the new policy.
- Excluded the `CLAUDE.md` symlink from direct Prettier processing.

## Benefit

Markdown formatting is applied consistently before commits, and future prose stays readable without artificial soft line breaks.

## Validation

- `pre-commit run --all-files`
- `python3 scripts/validate_skill_quality.py`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
- `git diff --check`