### PR TITLE
chore: ignore local skill creator workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 # Design / process docs and eval reports (local notes, not for version control)
 design/
 eval_report/
+ai-shifu-course-creator-workspace/


### PR DESCRIPTION
## What changed

Ignored the ai-shifu-course-creator-workspace/ directory, which stores local evaluation snapshots and generated review artifacts.

## Why

These files are temporary local outputs and should not appear in repository status or future pull requests.

## Validation

- git diff --cached --check
- Reviewed the isolated one-file commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude workspace files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->