### PR TITLE
feat: explain the effect of each course design choice

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Explain what every Course Design Intake answer changes and what experience each option creates, so authors see AI-Shifu's one-on-one guidance, classroom projection, answer-informed teaching, AI voice with slides, and lesson-granularity tradeoffs while choosing.
 - Let course authors choose one of five Teaching Prompt personalization levels, from near-final learner-facing content to more intent-led, learner-adaptive expression, while keeping the teaching sequence, slide structure, and teaching purpose of every content slot and slide fixed at every level; pure classroom-slide courses resolve an otherwise missing choice to high determinism without an extra question.
 - Centralize Prompt audience and addressee semantics so Teaching Prompts and Course Prompts are written to the runtime LLM, Course Prompts call the lesson input the current user message, and learner-visible `?[]` or standalone deterministic output is the explicit exception where second-person references may mean the learner.
 - Keep lesson pedagogy in Teaching Prompts and limit Course Prompts to following that pedagogy while adjusting course-wide presentation style.

--- a/skills/ai-shifu-course-creator/evals/evals.json
+++ b/skills/ai-shifu-course-creator/evals/evals.json
@@ -210,11 +210,13 @@
     {
       "id": 18,
       "prompt": "我要把一份门店新人培训材料做成标准 AI 一对一自学课程。使用场景已经确定为标准一对一授课，interaction_policy 已选择 disabled，Listen Mode 关闭，结构固定为 1 章 3 节；只有 teaching_prompt_personalization_level 还没决定。请先完成 Course Design Intake，这一轮不要开始分段、生成授课提示词或部署。",
-      "expected_output": "Pauses authoring to ask one localized five-level Teaching Prompt personalization question instead of guessing a level or starting downstream work.",
+      "expected_output": "Pauses authoring to ask one localized, effect-aware five-level Teaching Prompt personalization question instead of guessing a level or starting downstream work.",
       "files": [],
       "expectations": [
         "The response asks for the missing teaching_prompt_personalization_level before Segmentation, Orchestration, Teaching Prompt generation, or deployment.",
         "The question presents exactly five ordered choices numbered 1 through 5, with level 1 described as the most deterministic or concrete and level 5 as the most personalized or adaptive.",
+        "Before requesting the choice, the response explains that this answer controls how much learner-facing expression the author fixes in advance versus how much AI-Shifu may adapt to available learner context; every level description states its practical author- or learner-visible effect rather than showing only a number and name.",
+        "The explanation says that the level uses only learner context already available and never authorizes new context collection, interactions, variables, or branches.",
         "The choices make the progression observable only in content expression: higher levels emphasize intent for the same title, ordinary explanation, already-required example identity and detail, transition, and feedback slots while every level keeps the same teaching sequence, slide count, slide order and placement, the teaching purpose of each slide and content slot, required example-slot presence and placement, content grouping, semantic layout, and interaction, image, and close placement.",
         "The localized question describes the invariant meaning as each slide's and content slot's 教学目的, and does not call it instructional role or 教学角色.",
         "The response reuses the supplied usage scenario, interaction policy, Listen Mode, and structure choices without asking them again or silently selecting a personalization level."
@@ -262,6 +264,56 @@
         "Because delivery is slide-only and no level was provided, the response normalizes teaching_prompt_personalization_level to the integer 1 and identifies it as High determinism for content expression, not as permission to change teaching sequence, slide count, slide order or placement, the teaching purpose of any slide or content slot, content grouping, semantic layout, or interaction, image, and close placement.",
         "The response reuses the supplied usage scenario, interaction policy, Listen Mode, and structure choices without asking them again.",
         "The workflow does not start Segmentation, Orchestration, Teaching Prompt generation, or deployment."
+      ]
+    },
+    {
+      "id": 22,
+      "prompt": "我要把一份门店新人培训材料做成课程。teaching_prompt_personalization_level=3，interaction_policy 已选择 disabled，Listen Mode 关闭，结构固定为 1 章 3 节；只有使用场景还没决定。请先继续 Course Design Intake，这一轮只问当前缺少的一项，不要开始分段、生成授课提示词或部署。",
+      "expected_output": "Asks only for the missing usage scenario and explains the learner-visible effect of personalized one-on-one study, instructor-paced classroom slides, and supporting both experiences.",
+      "files": [],
+      "expectations": [
+        "The response asks exactly one current intake question about the usage scenario before any downstream authoring or deployment work.",
+        "Personalized AI one-on-one self-study is described by its concrete effect: AI-Shifu guides one learner directly and may adapt ordinary explanation or feedback to learner context already available.",
+        "Interactive classroom slides are described as projection-ready content paced by a human instructor, and the combined option explicitly prepares the course for both learner experiences.",
+        "The response does not show only the three option names, add a separate sales pitch, or promise an unsupported outcome.",
+        "The supplied personalization, interaction, Listen Mode, and structure answers are reused without being asked again."
+      ]
+    },
+    {
+      "id": 23,
+      "prompt": "我要做标准 AI 一对一自学课程，teaching_prompt_personalization_level=3，Listen Mode 关闭，结构固定为 1 章 3 节；只有互动用途还没决定。请先继续 Course Design Intake，这一轮只问当前缺少的一项，不要开始分段、生成授课提示词或部署。",
+      "expected_output": "Asks only what interactions should accomplish and explains the teaching effect of learner-context collection, pre-content thinking, lesson-end self-check, and choosing no interactions.",
+      "files": [],
+      "expectations": [
+        "The response asks exactly one current intake question about interaction purpose before any downstream authoring or deployment work.",
+        "Learner-context collection is explained as occurring at an early course or module point and giving later teaching selected context to use; pre-content thinking or misconception activation is explained as giving the following explanation an initial judgment to refine.",
+        "Lesson-end self-check is explained as helping the learner check or consolidate core understanding.",
+        "Choosing no interactions is explained as replacing learner-answer controls with worked applications, model-led demonstrations, or consolidation rather than leaving a teaching gap.",
+        "Every option has a practical effect description, and the supplied scenario, personalization, Listen Mode, and structure answers are reused without being asked again."
+      ]
+    },
+    {
+      "id": 24,
+      "prompt": "我要做标准 AI 一对一自学课程，teaching_prompt_personalization_level=3，interaction_policy 已选择 disabled，结构固定为 1 章 3 节；只有 Listen Mode 还没决定。请先继续 Course Design Intake，这一轮请询问我，不要直接采用默认值，也不要开始分段、生成授课提示词或部署。",
+      "expected_output": "Asks only whether to enable Listen Mode and explains both the AI voice with slides experience and its additional AI-Shifu credit consumption.",
+      "files": [],
+      "expectations": [
+        "The response asks exactly one current intake question about Listen Mode before any downstream authoring or deployment work.",
+        "Enabling Listen Mode is explained as adding AI voice with slides and consuming more AI-Shifu credits.",
+        "Disabling Listen Mode is explained as leaving the course available without Listen Mode and avoiding that additional credit consumption.",
+        "The response does not show only enabled and disabled labels or silently apply the fallback, and it reuses the supplied scenario, personalization, interaction, and structure answers."
+      ]
+    },
+    {
+      "id": 25,
+      "prompt": "我要做标准 AI 一对一自学课程，teaching_prompt_personalization_level=3，interaction_policy 已选择 disabled，Listen Mode 关闭；只有章数和节数还没决定。请先继续 Course Design Intake，这一轮只问当前缺少的一项，不要开始分段、生成授课提示词或部署。",
+      "expected_output": "Asks only for chapter and lesson counts after explaining how the answer changes lesson grouping, course granularity, and the amount of material each single-question lesson must resolve without changing required source coverage.",
+      "files": [],
+      "expectations": [
+        "The response asks exactly one current intake question about chapter and lesson counts before any downstream authoring or deployment work.",
+        "Before asking for numbers, it explains that chapter count changes how lessons are grouped into broader topics, while fewer lessons concentrate more material into each single-question lesson and more lessons distribute it across more single-question units.",
+        "The response does not invent fixed count options or imply that either choice may drop required material or break source order.",
+        "The supplied scenario, personalization, interaction, and Listen Mode answers are reused without being asked again."
       ]
     }
   ]

--- a/skills/ai-shifu-course-creator/references/course-design-intake.md
+++ b/skills/ai-shifu-course-creator/references/course-design-intake.md
@@ -1,12 +1,14 @@
 # Course Design Intake
 
-Collect and normalize the author's design choices before course structure or Teaching Prompt generation begins. This file does not define the course pipeline, artifact schemas, or teaching effects.
+Collect and normalize the author's design choices before course structure or Teaching Prompt generation begins. This file owns the author-facing preview of what each choice changes; the course pipeline, artifact schemas, and actual teaching effects remain defined by their downstream owners.
 
 ## Required References
 
 - `language-policy.md`
 - `data-contracts.md#interaction-policy`
 - `data-contracts.md#teaching-prompt-personalization-level`
+- `pedagogy.md#interaction-policy-precedence`
+- `pedagogy.md#visual-text-coordination`
 - `teaching-prompt.md#personalization-levels`
 
 ## Intake Scope
@@ -15,11 +17,13 @@ Collect only the unresolved design choices requested by the selected authoring r
 
 Before asking anything, extract answers already present in the user's instruction, source material, or pulled course directory. Ask only for missing items, one choice at a time and in the order below. Do not invent defaults from a sparse topic or brief, and do not proactively offer to bypass a required choice or “decide for the author.” Apply a listed fallback only after the author explicitly skips that question or asks to continue without answering.
 
-1. Ask which usage scenarios the course should support. Allow personalized AI one-on-one self-study, interactive classroom slides, or both.
-2. Unless the course is slide-only, ask how much personalization freedom the final learner-facing course should allow. Explain that a higher level makes the Teaching Prompt emphasize teaching intent and key points while fixing less exact learner-facing wording, example identity and detail, and feedback wording. State that the complete teaching sequence, exact slide count, each slide's position and teaching purpose, and which content slots appear, where they appear, and what teaching purpose each serves — including whether an example is required — stay fixed at every level; only expression inside those slots varies. Present all five ordered choices from `teaching-prompt.md#personalization-levels`: `1` — High determinism, `2` — Determinism-leaning, `3` — Balanced, `4` — Personalization-leaning, and `5` — High personalization. Render the question, option names, and owner-defined behavior descriptions in `resolved_target_language`. Do not silently skip this question for standard or combined delivery. For slide-only delivery with no already-provided level, do not ask it and use level `1` (High determinism).
-3. Ask what interactions should do. Allow learner-context collection, pre-content thinking or misconception activation, and lesson-end self-check. Choosing none means no interactions.
-4. Unless the course is slide-only, ask whether Listen Mode should be enabled and state that it consumes more AI-Shifu credits. An unanswered question defaults to disabled.
-5. Ask for the desired chapter and lesson counts.
+Before every applicable question, give a concise effect preview in `resolved_target_language`. Name the downstream course decision that the answer controls and describe the learner- or author-visible effect of every option presented. Surface the relevant AI-Shifu capability through that concrete consequence — such as one-on-one guidance, classroom projection, answer-informed teaching, AI voice with slides, or lesson granularity — without adding a separate sales pitch or an unsupported outcome. Never present only bare option labels, numbers, or names. When the answer is a free-form value such as a chapter or lesson count, explain the tradeoff dimensions before asking instead of inventing choices.
+
+1. Ask which usage scenarios the course should support. Explain that this answer controls the learner's delivery experience: personalized AI one-on-one self-study lets AI-Shifu guide one learner directly and adapt ordinary explanation or feedback to available learner context; interactive classroom slides produce projection-ready content paced by a human instructor; the combined option prepares the course for both experiences.
+2. Unless the course is slide-only, ask how much personalization freedom the final learner-facing course should allow. Explain that a higher level makes the Teaching Prompt emphasize teaching intent and key points while fixing less exact learner-facing wording, example identity and detail, and feedback wording. State that the complete teaching sequence, exact slide count, each slide's position and teaching purpose, and which content slots appear, where they appear, and what teaching purpose each serves — including whether an example is required — stay fixed at every level; only expression inside those slots varies. State that the level uses only learner context already available and never authorizes new context collection, interactions, variables, or branches. Present all five ordered choices from `teaching-prompt.md#personalization-levels`: `1` — High determinism, `2` — Determinism-leaning, `3` — Balanced, `4` — Personalization-leaning, and `5` — High personalization. Render the question, option names, and owner-defined behavior descriptions in `resolved_target_language`; each description must say what the author will see fixed in advance and what the runtime LLM may adapt for the learner. Do not silently skip this question for standard or combined delivery. For slide-only delivery with no already-provided level, do not ask it and use level `1` (High determinism).
+3. Ask what interactions should do. Explain each purpose's effect from `pedagogy.md#interaction-policy-precedence`: learner-context collection occurs at an early course or module point and gives later teaching selected context to use, pre-content thinking or misconception activation gives the following explanation an initial judgment to refine, and lesson-end self-check lets the learner check or consolidate the lesson's core understanding. Explain that choosing none removes learner-answer controls and uses worked applications, model-led demonstrations, or consolidation instead of leaving a teaching gap.
+4. Unless the course is slide-only, ask whether Listen Mode should be enabled. Explain that enabling it adds AI voice with slides and consumes more AI-Shifu credits, while disabling it leaves the course available without Listen Mode and avoids that additional credit consumption. An unanswered question defaults to disabled.
+5. Ask for the desired chapter and lesson counts. Explain that the chapter count controls how lessons are grouped into broader topics, while the lesson count controls course granularity and how much material each single-question lesson must resolve: fewer lessons concentrate more material into each lesson, while more lessons distribute it across more single-question units. Neither choice may drop required source material or break source order.
 
 ## Normalized Design Controls
 
@@ -35,6 +39,8 @@ Produce these controls once and pass them unchanged to downstream workflows:
 
 - Every answer available from existing context is reused rather than asked again.
 - Every missing applicable question is asked before its fallback is applied.
+- Every asked question includes an effect preview that identifies its downstream course decision, and every presented option describes its learner- or author-visible consequence rather than showing a bare label.
+- Effect previews match their owning references, surface relevant AI-Shifu capabilities through concrete course behavior, and make no promotional or unsupported promise.
 - Pure-slide delivery resolves an otherwise missing `teaching_prompt_personalization_level` to level `1` without asking the personalization question.
 - The normalized `teaching_prompt_personalization_level` passes `data-contracts.md#teaching-prompt-personalization-level`; invalid values are rejected rather than converted or treated as a skip.
 - The normalized interaction policy passes the data-contract invariants.

--- a/tests/test_validate_skill_quality.py
+++ b/tests/test_validate_skill_quality.py
@@ -1337,10 +1337,11 @@ class CourseCreatorContractTests(unittest.TestCase):
                 "more lessons distribute it across more single-question units",
             ),
         }
-        step_starts = {
-            number: re.search(rf"(?m)^{number}\.\s+", scope).start()
-            for number in question_effects
-        }
+        step_starts = {}
+        for number in question_effects:
+            match = re.search(rf"(?m)^{number}\.\s+", scope)
+            self.assertIsNotNone(match, f"Step {number} not found in scope")
+            step_starts[number] = match.start()
         for number, fragments in question_effects.items():
             end = step_starts.get(number + 1, len(scope))
             step = " ".join(scope[step_starts[number] : end].split())

--- a/tests/test_validate_skill_quality.py
+++ b/tests/test_validate_skill_quality.py
@@ -1286,6 +1286,72 @@ class CourseCreatorContractTests(unittest.TestCase):
         )
         self.assertIn("absence alone is not a skip", controls)
 
+    def test_intake_explains_the_effect_of_every_design_question(self):
+        required = markdown_section(self.course_design_intake, "Required References")
+        scope = markdown_section(self.course_design_intake, "Intake Scope")
+        validation = markdown_section(self.course_design_intake, "Validation")
+        normalized_scope = " ".join(scope.split())
+
+        self.assertIn("pedagogy.md#interaction-policy-precedence", required)
+        self.assertIn("pedagogy.md#visual-text-coordination", required)
+        for fragment in (
+            "Before every applicable question, give a concise effect preview",
+            "downstream course decision",
+            "learner- or author-visible effect of every option presented",
+            "without adding a separate sales pitch or an unsupported outcome",
+            "Never present only bare option labels, numbers, or names",
+            "explain the tradeoff dimensions before asking",
+        ):
+            self.assertIn(fragment, normalized_scope)
+
+        question_effects = {
+            1: (
+                "controls the learner's delivery experience",
+                "AI-Shifu guide one learner directly",
+                "projection-ready content paced by a human instructor",
+                "both experiences",
+            ),
+            2: (
+                "uses only learner context already available",
+                "never authorizes new context collection, interactions, variables, or branches",
+                "what the author will see fixed in advance",
+                "what the runtime LLM may adapt for the learner",
+            ),
+            3: (
+                "at an early course or module point",
+                "later teaching selected context to use",
+                "initial judgment to refine",
+                "check or consolidate the lesson's core understanding",
+                "worked applications, model-led demonstrations, or consolidation",
+            ),
+            4: (
+                "adds AI voice with slides",
+                "consumes more AI-Shifu credits",
+                "leaves the course available without Listen Mode",
+                "avoids that additional credit consumption",
+            ),
+            5: (
+                "chapter count controls how lessons are grouped into broader topics",
+                "lesson count controls course granularity",
+                "fewer lessons concentrate more material into each lesson",
+                "more lessons distribute it across more single-question units",
+            ),
+        }
+        step_starts = {
+            number: re.search(rf"(?m)^{number}\.\s+", scope).start()
+            for number in question_effects
+        }
+        for number, fragments in question_effects.items():
+            end = step_starts.get(number + 1, len(scope))
+            step = " ".join(scope[step_starts[number] : end].split())
+            for fragment in fragments:
+                self.assertIn(fragment, step, f"missing effect for intake question {number}")
+
+        normalized_validation = " ".join(validation.split())
+        self.assertIn("Every asked question includes an effect preview", normalized_validation)
+        self.assertIn("rather than showing a bare label", normalized_validation)
+        self.assertIn("make no promotional or unsupported promise", normalized_validation)
+
     def test_slide_only_intake_uses_high_determinism_without_asking(self):
         scope = markdown_section(self.course_design_intake, "Intake Scope")
         normalized_scope = " ".join(scope.split())


### PR DESCRIPTION
## Summary

- Explain which downstream course decision every Course Design Intake answer controls.
- Describe the learner- or author-visible effect of each option without adding marketing claims.
- Add focused contract tests and behavior evals for usage scenario, personalization, interaction purpose, Listen Mode, and course structure.

## Why

The intake previously presented several bare options, so course authors could not tell how an answer would change the generated course or learner experience.

## Impact

Authors now see AI-Shifu's one-on-one guidance, classroom projection, answer-informed teaching, AI voice with slides, and lesson-granularity tradeoffs while choosing. Downstream behavior remains owned by the existing pedagogy and Teaching Prompt contracts.

## Validation

- `python3 scripts/validate_skill_quality.py`
- `python3 -m unittest discover -s tests -p 'test_*.py'` (122 tests)
- `git diff --check`
- Paired behavior evaluation: new skill 25/25, previous skill 10/25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Course Design Intake choices affect course behavior and learner experience.
  * Added effect previews and tradeoff guidance for interaction, personalization, Listen Mode, usage scenario, and course structure options.
  * Added references and validation guidance to prevent unsupported or promotional promises.

* **Tests**
  * Added coverage ensuring every applicable intake question explains the learner-visible impact of each option.

* **Evaluation**
  * Expanded incomplete-intake scenarios to verify focused follow-up questions, option explanations, and appropriate defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->