### PR TITLE
chore: bump ai-shifu-course-creator to 1.2.1

### DIFF
--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: AI-Shifu Course Creator
 description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing Teaching Prompts (per-lesson) and Course Prompts (course-level) — both written in MarkdownFlow (MDF). Covers the full course lifecycle — from converting raw material into structured lessons, to authoring interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Also covers post-deployment analytics on those courses — learner count, completion rate, stuck lessons, orders, revenue, ratings, credit consumption, audience profiles, and individual learner tracking. Trigger on any mention of AI-Shifu, AI师傅, MarkdownFlow, Teaching Prompt, Course Prompt authoring, course analytics, creator analytics, 学习人数, 完成率, 卡课节, 订单收入, 积分消耗, or learner progress.
-version: 1.2.0
+version: 1.2.1
 version_management: standalone
 ---
 


### PR DESCRIPTION
Changed:
Raised the ai-shifu-course-creator skill version from 1.2.0 to 1.2.1.

Benefit:
Channels and users can identify and receive the 1.2.1 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI Shifu course creator documentation version to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->