### PR TITLE
feat: umami usage tracking for course-creator CLI

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add fail-open anonymous usage tracking to the CLI via the AI-Shifu umami instance, reporting command name, skill version, host agent, and platform info with a stable per-person id (platform user id when logged in, anonymous UUID otherwise); never sends course content or command arguments, and `AISHIFU_ANALYTICS=off` disables it.
 - Remove pedagogy and optimization rules that reject cover pages and page-type prohibitions on decorative or objective-only pages, while retaining padding-only rejection for newly generated and existing visual units.
 - Require first-slide covers created by Teaching Prompts to include lesson title and author information.
 - Keep general presentation requirements shared by every slide in the Course Prompt while leaving first-slide cover treatment and other position-specific decisions in Teaching Prompts.

--- a/skills/ai-shifu-course-creator/references/session-controls.md
+++ b/skills/ai-shifu-course-creator/references/session-controls.md
@@ -39,8 +39,9 @@ When the active request explicitly requires offline or no-network execution, ski
 
 ## Usage Analytics
 
-The CLI reports anonymous usage events (command name, skill version, host
-agent, OS/architecture/Python version, and a stable per-person id) to the
+The CLI reports usage events (command name, skill version, host agent,
+OS/architecture/Python version, and a stable per-person id — the platform
+user id when logged in, otherwise an anonymous UUID) to the
 AI-Shifu umami instance so the team can see which skills and commands are
 used. It never sends course content, titles, file paths, tokens, or command
 arguments. Reporting is fail-open: it never blocks or breaks a command.

--- a/skills/ai-shifu-course-creator/references/session-controls.md
+++ b/skills/ai-shifu-course-creator/references/session-controls.md
@@ -37,6 +37,18 @@ When the active request explicitly requires offline or no-network execution, ski
 - Never execute an update on the user's behalf.
 - If Python cannot run, fetch `https://ai-shifu.cn/skill-manifests/ai-shifu-course-creator.json` and compare MAJOR, MINOR, and PATCH as integers. If that also fails, stay silent.
 
+## Usage Analytics
+
+The CLI reports anonymous usage events (command name, skill version, host
+agent, OS/architecture/Python version, and a stable per-person id) to the
+AI-Shifu umami instance so the team can see which skills and commands are
+used. It never sends course content, titles, file paths, tokens, or command
+arguments. Reporting is fail-open: it never blocks or breaks a command.
+Setting `AISHIFU_ANALYTICS=off` disables it entirely; when the user asks
+about analytics, explain the above and mention that switch. When the active
+request explicitly requires offline or no-network execution, prefix every CLI
+invocation with `AISHIFU_ANALYTICS=off` so no network attempt is made.
+
 ## Progress, Errors, and Handoffs
 
 - Give a concise progress update at meaningful phase boundaries during work that continues across multiple steps. State what completed and what comes next.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -19,6 +19,14 @@ from dotenv import load_dotenv, set_key
 
 from skill_update import DEV_CACHE_FILE, check_for_update
 
+# Usage tracking is strictly optional: a broken tracker must never take the
+# CLI down with it.
+try:
+    from usage_tracker import track
+except Exception:  # pragma: no cover - defensive import guard
+    def track(event_name, data=None):
+        return None
+
 # ── Constants ──────────────────────────────────────────────────────────────────
 ENV_FILE = Path(__file__).resolve().parent.parent / ".env"
 
@@ -2996,6 +3004,13 @@ def main():
 
     handler = commands.get(args.command)
     if handler:
+        # check-update runs once per session (session-controls.md), so it
+        # doubles as the session-start marker; every other command reports
+        # its own name. Only the command name is sent, never its arguments.
+        if args.command == "check-update":
+            track("skill_start")
+        else:
+            track(f"cli_{args.command}")
         handler(args)
     else:
         parser.print_help()

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -23,8 +23,8 @@ from skill_update import DEV_CACHE_FILE, check_for_update
 # CLI down with it.
 try:
     from usage_tracker import track
-except Exception:  # pragma: no cover - defensive import guard
-    def track(event_name, data=None):
+except Exception:  # noqa: BLE001 - fail-open: any tracker breakage must not take the CLI down
+    def track(event_name):
         return None
 
 # ── Constants ──────────────────────────────────────────────────────────────────

--- a/skills/ai-shifu-course-creator/scripts/usage_tracker.py
+++ b/skills/ai-shifu-course-creator/scripts/usage_tracker.py
@@ -140,12 +140,18 @@ def _anonymous_id() -> str:
 
 
 def distinct_id() -> str:
-    """Stable per-person id: platform user_id first, anonymous UUID fallback."""
+    """Stable per-person id: platform user_id first, anonymous UUID fallback.
+
+    The logged-in value is the raw user_bid, exactly what the ai-shifu web
+    frontend passes to umami.identify() — so the same person tracked from the
+    skill and from the website shares one distinct id. Only the anonymous
+    fallback carries an `a:` prefix.
+    """
     token = os.environ.get("SHIFU_TOKEN") or _token_from_env_file()
     if token:
         user_id = _jwt_user_id(token)
         if user_id:
-            return f"u:{user_id}"[:DISTINCT_ID_MAX]
+            return user_id[:DISTINCT_ID_MAX]
     return f"a:{_anonymous_id()}"[:DISTINCT_ID_MAX]
 
 

--- a/skills/ai-shifu-course-creator/scripts/usage_tracker.py
+++ b/skills/ai-shifu-course-creator/scripts/usage_tracker.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Fail-open skill-usage tracking backed by the self-hosted umami instance.
+
+Every function here must never raise into the caller and never block the CLI:
+tracking is strictly best-effort (short timeout, all exceptions swallowed),
+mirroring the fail-open contract of skill_update.py.
+
+What is sent per event: event name (CLI command), skill name/version, host
+agent (Claude Code / opencode / codex / ...), OS/arch/Python version, and a
+distinct id (platform user_id when logged in, otherwise a random anonymous
+UUID persisted in ~/.ai-shifu/analytics-id). No course content, titles, file
+paths, or tokens are ever sent. Set AISHIFU_ANALYTICS=off to disable.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import platform
+import re
+import subprocess
+import uuid
+from pathlib import Path
+
+import requests
+
+SKILL_NAME = "ai-shifu-course-creator"
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+ENV_FILE = SKILL_ROOT / ".env"
+
+# The umami website id is a public identifier — the same value a browser
+# deployment exposes to every visitor in <script data-website-id> — not a
+# secret. Paste the id of the "ai-shifu-skills" website created in the umami
+# admin UI; tracking stays silently disabled while it is empty.
+UMAMI_URL = "https://umami.ai-shifu.cn/api/send"
+WEBSITE_ID = ""
+
+# hostname is a logical label for the umami website (no DNS resolution needed).
+HOSTNAME = "skills.ai-shifu.cn"
+
+ANALYTICS_ID_FILE = Path.home() / ".ai-shifu" / "analytics-id"
+
+REQUEST_TIMEOUT = 3
+# umami limits payload.id (distinct id) to 50 characters.
+DISTINCT_ID_MAX = 50
+
+_OPT_OUT_VALUES = frozenset({"off", "0", "false", "no"})
+
+# Host-agent env markers, checked in order. The generic AI_AGENT convention
+# (checked first in detect_agent) usually carries name + version already.
+_AGENT_ENV_MARKERS = (
+    ("CLAUDECODE", "claude-code"),
+    ("CLAUDE_CODE", "claude-code"),
+    ("OPENCODE_CLIENT", "opencode"),
+    ("OPENCODE", "opencode"),
+    ("CODEX_SANDBOX", "codex"),
+    ("CODEX_THREAD_ID", "codex"),
+    ("CODEX_CI", "codex"),
+    ("GEMINI_CLI", "gemini-cli"),
+    ("CURSOR_AGENT", "cursor"),
+    ("COPILOT_CLI", "copilot"),
+    ("AUGMENT_AGENT", "augment"),
+    ("AMP_CURRENT_THREAD_ID", "amp"),
+    ("ANTIGRAVITY_AGENT", "antigravity"),
+    ("KIRO_AGENT_PATH", "kiro"),
+    ("REPL_ID", "replit"),
+)
+
+# Fallback for agents without a known env marker (e.g. WorkBuddy): matched
+# against ancestor process names, lowercased.
+_AGENT_PROCESS_PATTERN = re.compile(
+    r"claude|opencode|codex|workbuddy|codebuddy|cursor|gemini|copilot"
+    r"|windsurf|aider|goose|amp"
+)
+_PROCESS_WALK_MAX_DEPTH = 10
+
+
+def _skill_version() -> str:
+    """Read `version:` from SKILL.md frontmatter; '0.0.0' when unreadable."""
+    try:
+        lines = SKILL_MD.read_text(encoding="utf-8").splitlines()
+        if not lines or lines[0].strip() != "---":
+            return "0.0.0"
+        for line in lines[1:]:
+            if line.strip() == "---":
+                break
+            if line.startswith("version:"):
+                return line.split(":", 1)[1].strip().strip("\"'") or "0.0.0"
+    except OSError:
+        pass
+    return "0.0.0"
+
+
+def _jwt_user_id(token: str) -> str | None:
+    """Extract user_id from the ai-shifu JWT payload (no verification)."""
+    try:
+        encoded = token.split(".")[1]
+        encoded = encoded.replace("-", "+").replace("_", "/")
+        encoded += "=" * ((4 - len(encoded) % 4) % 4)
+        payload = json.loads(base64.b64decode(encoded))
+        user_id = payload.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            return user_id
+    except Exception:
+        pass
+    return None
+
+
+def _token_from_env_file() -> str | None:
+    """Read SHIFU_TOKEN from the skill's .env without requiring dotenv."""
+    try:
+        for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+            key, sep, value = line.partition("=")
+            if sep and key.strip() == "SHIFU_TOKEN":
+                value = value.strip().strip("\"'")
+                return value or None
+    except OSError:
+        pass
+    return None
+
+
+def _anonymous_id() -> str:
+    """Read or create the per-machine anonymous UUID (never tied to identity)."""
+    try:
+        existing = ANALYTICS_ID_FILE.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    except OSError:
+        pass
+    generated = str(uuid.uuid4())
+    try:
+        ANALYTICS_ID_FILE.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        ANALYTICS_ID_FILE.write_text(generated + "\n", encoding="utf-8")
+        os.chmod(ANALYTICS_ID_FILE, 0o600)
+    except OSError:
+        pass
+    return generated
+
+
+def distinct_id() -> str:
+    """Stable per-person id: platform user_id first, anonymous UUID fallback."""
+    token = os.environ.get("SHIFU_TOKEN") or _token_from_env_file()
+    if token:
+        user_id = _jwt_user_id(token)
+        if user_id:
+            return f"u:{user_id}"[:DISTINCT_ID_MAX]
+    return f"a:{_anonymous_id()}"[:DISTINCT_ID_MAX]
+
+
+def _walk_parent_process_names(max_depth: int = _PROCESS_WALK_MAX_DEPTH):
+    """Yield ancestor process basenames, nearest first (POSIX ps only)."""
+    pid = os.getppid()
+    for _ in range(max_depth):
+        if pid <= 1:
+            return
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "comm=", "-o", "ppid=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            ).stdout.strip()
+        except Exception:
+            return
+        parts = out.rsplit(None, 1)
+        if len(parts) != 2:
+            return
+        comm, ppid = parts
+        yield Path(comm).name.lower()
+        try:
+            pid = int(ppid)
+        except ValueError:
+            return
+
+
+def detect_agent() -> str:
+    """Identify the host agent running this skill (best effort)."""
+    generic = os.environ.get("AI_AGENT", "").strip()
+    if generic:
+        return generic[:50]
+    for var, name in _AGENT_ENV_MARKERS:
+        if os.environ.get(var):
+            if name == "claude-code":
+                entrypoint = os.environ.get(
+                    "CLAUDE_CODE_ENTRYPOINT", ""
+                ).strip()
+                return f"claude-code/{entrypoint}" if entrypoint else name
+            return name
+    for proc_name in _walk_parent_process_names():
+        match = _AGENT_PROCESS_PATTERN.search(proc_name)
+        if match:
+            return f"proc:{match.group(0)}"
+    return "unknown"
+
+
+def _user_agent(agent: str) -> str:
+    """Build a browser-shaped UA that passes umami's isbot filter.
+
+    Requests without a User-Agent are dropped by umami, and UAs matching
+    isbot patterns (python-requests/, curl/, ...) are silently discarded
+    with HTTP 200 — hence the Mozilla/5.0 prefix and a parsable OS segment.
+    """
+    system = platform.system()
+    machine = platform.machine()
+    if system == "Darwin":
+        mac_version = platform.mac_ver()[0].replace(".", "_") or "10_15_7"
+        os_segment = f"Macintosh; Intel Mac OS X {mac_version}"
+    elif system == "Windows":
+        os_segment = f"Windows NT {platform.release()}"
+    else:
+        os_segment = f"X11; Linux {machine}"
+    return (
+        f"Mozilla/5.0 ({os_segment}) "
+        f"AIShifuSkill/{_skill_version()} ({SKILL_NAME}; {agent})"
+    )
+
+
+def _opted_out() -> bool:
+    return (
+        os.environ.get("AISHIFU_ANALYTICS", "").strip().lower()
+        in _OPT_OUT_VALUES
+    )
+
+
+def track(event_name: str, data: dict | None = None) -> None:
+    """Send one umami event; silent no-op on any failure or when disabled."""
+    try:
+        if _opted_out():
+            return
+        website = os.environ.get("AISHIFU_UMAMI_WEBSITE_ID") or WEBSITE_ID
+        if not website:
+            return
+        url = os.environ.get("AISHIFU_UMAMI_URL") or UMAMI_URL
+        agent = detect_agent()
+        payload = {
+            "website": website,
+            "hostname": HOSTNAME,
+            "url": f"/{SKILL_NAME}/{event_name}",
+            "name": event_name,
+            "id": distinct_id(),
+            "tag": agent,
+            "data": {
+                "skill": SKILL_NAME,
+                "version": _skill_version(),
+                "agent": agent,
+                "os": platform.system().lower(),
+                "arch": platform.machine(),
+                "python": platform.python_version(),
+                **(data or {}),
+            },
+        }
+        requests.post(
+            url,
+            json={"type": "event", "payload": payload},
+            headers={"User-Agent": _user_agent(agent)},
+            timeout=REQUEST_TIMEOUT,
+        )
+    except Exception:
+        pass

--- a/skills/ai-shifu-course-creator/scripts/usage_tracker.py
+++ b/skills/ai-shifu-course-creator/scripts/usage_tracker.py
@@ -248,8 +248,14 @@ def _opted_out() -> bool:
     )
 
 
-def track(event_name: str, data: dict | None = None) -> None:
-    """Send one umami event; silent no-op on any failure or when disabled."""
+def track(event_name: str) -> None:
+    """Send one umami event; silent no-op on any failure or when disabled.
+
+    The payload is built entirely from module-generated fields — track()
+    deliberately takes no free-form data, so the "never sends course
+    content, titles, file paths, or tokens" promise is structural rather
+    than a matter of call-site discipline.
+    """
     try:
         if _opted_out():
             return
@@ -272,7 +278,6 @@ def track(event_name: str, data: dict | None = None) -> None:
                 "os": platform.system().lower(),
                 "arch": platform.machine(),
                 "python": platform.python_version(),
-                **(data or {}),
             },
         }
         requests.post(

--- a/skills/ai-shifu-course-creator/scripts/usage_tracker.py
+++ b/skills/ai-shifu-course-creator/scripts/usage_tracker.py
@@ -30,12 +30,13 @@ SKILL_ROOT = Path(__file__).resolve().parent.parent
 SKILL_MD = SKILL_ROOT / "SKILL.md"
 ENV_FILE = SKILL_ROOT / ".env"
 
-# The umami website id is a public identifier — the same value a browser
-# deployment exposes to every visitor in <script data-website-id> — not a
-# secret. Paste the id of the "ai-shifu-skills" website created in the umami
-# admin UI; tracking stays silently disabled while it is empty.
+# The umami website id is a public identifier — the same value the ai-shifu
+# web frontend exposes to every visitor in <script data-website-id> — not a
+# secret. Skill events deliberately share the main-site website so that one
+# user_bid links skill and website sessions; skill traffic stays separable
+# via hostname/url/data.skill.
 UMAMI_URL = "https://umami.ai-shifu.cn/api/send"
-WEBSITE_ID = ""
+WEBSITE_ID = "f3108c8f-6898-4404-b6d7-fd076ad011db"
 
 # hostname is a logical label for the umami website (no DNS resolution needed).
 HOSTNAME = "skills.ai-shifu.cn"
@@ -201,12 +202,29 @@ def detect_agent() -> str:
     return "unknown"
 
 
+# Words that umami's isbot filter matches anywhere in the UA. Verified live:
+# "claude-code_2-1-215_agent" was silently discarded ({"beep":"boop"}) purely
+# because of the "agent" substring; the same UA without it was accepted.
+_ISBOT_RISKY_WORDS = re.compile(
+    r"(?i)bot|agent|spider|crawl|scan|search|monitor|fetch|http|client"
+)
+
+
+def _ua_safe(value: str) -> str:
+    """Strip isbot-triggering substrings before embedding a value in the UA."""
+    cleaned = _ISBOT_RISKY_WORDS.sub("", value)
+    cleaned = re.sub(r"[-_ ]{2,}", "-", cleaned).strip("-_ ")
+    return cleaned or "unknown"
+
+
 def _user_agent(agent: str) -> str:
     """Build a browser-shaped UA that passes umami's isbot filter.
 
     Requests without a User-Agent are dropped by umami, and UAs matching
-    isbot patterns (python-requests/, curl/, ...) are silently discarded
-    with HTTP 200 — hence the Mozilla/5.0 prefix and a parsable OS segment.
+    isbot patterns (python-requests/, curl/, "agent", ...) are silently
+    discarded with HTTP 200 — hence the Mozilla/5.0 prefix, a parsable OS
+    segment, and _ua_safe() on the embedded agent name. The raw agent value
+    still travels in payload.tag and data.agent.
     """
     system = platform.system()
     machine = platform.machine()
@@ -219,7 +237,7 @@ def _user_agent(agent: str) -> str:
         os_segment = f"X11; Linux {machine}"
     return (
         f"Mozilla/5.0 ({os_segment}) "
-        f"AIShifuSkill/{_skill_version()} ({SKILL_NAME}; {agent})"
+        f"AIShifuSkill/{_skill_version()} ({SKILL_NAME}; {_ua_safe(agent)})"
     )
 
 

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -64,12 +64,12 @@ class DetectAgentTests(unittest.TestCase):
 
 
 class DistinctIdTests(unittest.TestCase):
-    def test_prefers_platform_user_id_from_env_token(self) -> None:
+    def test_uses_raw_user_bid_matching_web_identify(self) -> None:
         token = fake_jwt({"user_id": "user-123", "time_stamp": 1})
         with mock.patch.dict(
             usage_tracker.os.environ, {"SHIFU_TOKEN": token}, clear=True
         ):
-            self.assertEqual(usage_tracker.distinct_id(), "u:user-123")
+            self.assertEqual(usage_tracker.distinct_id(), "user-123")
 
     def test_truncates_to_umami_limit(self) -> None:
         token = fake_jwt({"user_id": "x" * 80, "time_stamp": 1})

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -141,7 +141,7 @@ class TrackTests(unittest.TestCase):
         ), mock.patch.object(
             usage_tracker.requests, "post"
         ) as post:
-            usage_tracker.track("cli_publish", {"extra": "1"})
+            usage_tracker.track("cli_publish")
 
         self.assertEqual(post.call_count, 1)
         args, kwargs = post.call_args
@@ -154,7 +154,11 @@ class TrackTests(unittest.TestCase):
         self.assertEqual(payload["id"], "u:user-123")
         self.assertEqual(payload["tag"], "opencode")
         self.assertEqual(payload["data"]["agent"], "opencode")
-        self.assertEqual(payload["data"]["extra"], "1")
+        # data must contain only module-generated fields (privacy contract)
+        self.assertEqual(
+            set(payload["data"]),
+            {"skill", "version", "agent", "os", "arch", "python"},
+        )
         self.assertTrue(
             kwargs["headers"]["User-Agent"].startswith("Mozilla/5.0 (")
         )

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -117,6 +117,14 @@ class UserAgentTests(unittest.TestCase):
         for marker in ("python-requests", "curl", "bot"):
             self.assertNotIn(marker, ua.lower())
 
+    def test_isbot_risky_words_are_stripped_from_agent(self) -> None:
+        ua = usage_tracker._user_agent("claude-code_2-1-215_agent")
+        self.assertNotIn("agent", ua.lower())
+        self.assertIn("claude-code_2-1-215", ua)
+
+    def test_fully_risky_agent_falls_back_to_unknown(self) -> None:
+        self.assertEqual(usage_tracker._ua_safe("agent"), "unknown")
+
 
 class TrackTests(unittest.TestCase):
     def _env(self, **extra: str) -> dict[str, str]:
@@ -152,9 +160,11 @@ class TrackTests(unittest.TestCase):
         )
         self.assertEqual(kwargs["timeout"], usage_tracker.REQUEST_TIMEOUT)
 
-    def test_no_request_without_website_id(self) -> None:
+    def test_no_request_when_website_id_blank(self) -> None:
         with mock.patch.dict(
             usage_tracker.os.environ, {}, clear=True
+        ), mock.patch.object(
+            usage_tracker, "WEBSITE_ID", ""
         ), mock.patch.object(usage_tracker.requests, "post") as post:
             usage_tracker.track("cli_list")
         post.assert_not_called()

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = (
+    REPO_ROOT / "skills" / "ai-shifu-course-creator" / "scripts"
+)
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import usage_tracker  # noqa: E402
+
+
+def fake_jwt(payload: dict) -> str:
+    body = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return f"header.{body}.signature"
+
+
+class DetectAgentTests(unittest.TestCase):
+    def test_generic_ai_agent_wins(self) -> None:
+        env = {"AI_AGENT": "claude-code_2-1-215_agent", "CLAUDECODE": "1"}
+        with mock.patch.dict(usage_tracker.os.environ, env, clear=True):
+            self.assertEqual(
+                usage_tracker.detect_agent(), "claude-code_2-1-215_agent"
+            )
+
+    def test_claude_code_marker_with_entrypoint(self) -> None:
+        env = {"CLAUDECODE": "1", "CLAUDE_CODE_ENTRYPOINT": "cli"}
+        with mock.patch.dict(usage_tracker.os.environ, env, clear=True):
+            self.assertEqual(usage_tracker.detect_agent(), "claude-code/cli")
+
+    def test_opencode_marker(self) -> None:
+        env = {"OPENCODE": "1"}
+        with mock.patch.dict(usage_tracker.os.environ, env, clear=True):
+            self.assertEqual(usage_tracker.detect_agent(), "opencode")
+
+    def test_process_walk_fallback(self) -> None:
+        with mock.patch.dict(usage_tracker.os.environ, {}, clear=True), \
+                mock.patch.object(
+                    usage_tracker,
+                    "_walk_parent_process_names",
+                    return_value=iter(["zsh", "workbuddy-helper"]),
+                ):
+            self.assertEqual(usage_tracker.detect_agent(), "proc:workbuddy")
+
+    def test_unknown_when_no_signal(self) -> None:
+        with mock.patch.dict(usage_tracker.os.environ, {}, clear=True), \
+                mock.patch.object(
+                    usage_tracker,
+                    "_walk_parent_process_names",
+                    return_value=iter(["zsh", "launchd"]),
+                ):
+            self.assertEqual(usage_tracker.detect_agent(), "unknown")
+
+
+class DistinctIdTests(unittest.TestCase):
+    def test_prefers_platform_user_id_from_env_token(self) -> None:
+        token = fake_jwt({"user_id": "user-123", "time_stamp": 1})
+        with mock.patch.dict(
+            usage_tracker.os.environ, {"SHIFU_TOKEN": token}, clear=True
+        ):
+            self.assertEqual(usage_tracker.distinct_id(), "u:user-123")
+
+    def test_truncates_to_umami_limit(self) -> None:
+        token = fake_jwt({"user_id": "x" * 80, "time_stamp": 1})
+        with mock.patch.dict(
+            usage_tracker.os.environ, {"SHIFU_TOKEN": token}, clear=True
+        ):
+            self.assertEqual(len(usage_tracker.distinct_id()), 50)
+
+    def test_anonymous_fallback_is_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            id_file = Path(tmp) / "analytics-id"
+            with mock.patch.dict(
+                usage_tracker.os.environ, {}, clear=True
+            ), mock.patch.object(
+                usage_tracker, "ANALYTICS_ID_FILE", id_file
+            ), mock.patch.object(
+                usage_tracker, "ENV_FILE", Path(tmp) / "missing.env"
+            ):
+                first = usage_tracker.distinct_id()
+                second = usage_tracker.distinct_id()
+        self.assertTrue(first.startswith("a:"))
+        self.assertEqual(first, second)
+
+    def test_malformed_token_falls_back_to_anonymous(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            id_file = Path(tmp) / "analytics-id"
+            with mock.patch.dict(
+                usage_tracker.os.environ,
+                {"SHIFU_TOKEN": "not-a-jwt"},
+                clear=True,
+            ), mock.patch.object(
+                usage_tracker, "ANALYTICS_ID_FILE", id_file
+            ):
+                self.assertTrue(
+                    usage_tracker.distinct_id().startswith("a:")
+                )
+
+
+class UserAgentTests(unittest.TestCase):
+    def test_shape_passes_isbot_conventions(self) -> None:
+        ua = usage_tracker._user_agent("claude-code")
+        self.assertTrue(ua.startswith("Mozilla/5.0 ("))
+        self.assertIn("AIShifuSkill/", ua)
+        self.assertIn("claude-code", ua)
+        for marker in ("python-requests", "curl", "bot"):
+            self.assertNotIn(marker, ua.lower())
+
+
+class TrackTests(unittest.TestCase):
+    def _env(self, **extra: str) -> dict[str, str]:
+        env = {"AISHIFU_UMAMI_WEBSITE_ID": "site-1"}
+        env.update(extra)
+        return env
+
+    def test_sends_event_with_custom_user_agent(self) -> None:
+        with mock.patch.dict(
+            usage_tracker.os.environ, self._env(AI_AGENT="opencode"),
+            clear=True,
+        ), mock.patch.object(
+            usage_tracker, "distinct_id", return_value="u:user-123"
+        ), mock.patch.object(
+            usage_tracker.requests, "post"
+        ) as post:
+            usage_tracker.track("cli_publish", {"extra": "1"})
+
+        self.assertEqual(post.call_count, 1)
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], usage_tracker.UMAMI_URL)
+        body = kwargs["json"]
+        self.assertEqual(body["type"], "event")
+        payload = body["payload"]
+        self.assertEqual(payload["website"], "site-1")
+        self.assertEqual(payload["name"], "cli_publish")
+        self.assertEqual(payload["id"], "u:user-123")
+        self.assertEqual(payload["tag"], "opencode")
+        self.assertEqual(payload["data"]["agent"], "opencode")
+        self.assertEqual(payload["data"]["extra"], "1")
+        self.assertTrue(
+            kwargs["headers"]["User-Agent"].startswith("Mozilla/5.0 (")
+        )
+        self.assertEqual(kwargs["timeout"], usage_tracker.REQUEST_TIMEOUT)
+
+    def test_no_request_without_website_id(self) -> None:
+        with mock.patch.dict(
+            usage_tracker.os.environ, {}, clear=True
+        ), mock.patch.object(usage_tracker.requests, "post") as post:
+            usage_tracker.track("cli_list")
+        post.assert_not_called()
+
+    def test_opt_out_disables_tracking(self) -> None:
+        with mock.patch.dict(
+            usage_tracker.os.environ,
+            self._env(AISHIFU_ANALYTICS="off"),
+            clear=True,
+        ), mock.patch.object(usage_tracker.requests, "post") as post:
+            usage_tracker.track("cli_list")
+        post.assert_not_called()
+
+    def test_network_failure_is_swallowed(self) -> None:
+        with mock.patch.dict(
+            usage_tracker.os.environ, self._env(), clear=True
+        ), mock.patch.object(
+            usage_tracker, "distinct_id", return_value="a:x"
+        ), mock.patch.object(
+            usage_tracker.requests,
+            "post",
+            side_effect=OSError("network down"),
+        ):
+            usage_tracker.track("cli_list")  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

> Split: the UTC timestamp fixes that used to live in this PR moved to #124. This PR now carries only the umami usage tracking.

- New `scripts/usage_tracker.py`: fail-open event reporting to `https://umami.ai-shifu.cn/api/send` (no auth needed; same endpoint the JS tracker uses). Any failure is swallowed and never blocks or breaks a CLI command.
- **Distinct id = raw platform `user_bid`** (decoded from the JWT), exactly what the web frontend passes to `umami.identify()` — so one person's skill usage and website sessions correlate under the same distinct id in the shared main-site website (`f3108c8f-…`). Anonymous fallback: persistent UUID in `~/.ai-shifu/analytics-id` with an `a:` prefix.
- **Host-agent detection** (Claude Code / opencode / codex / Gemini / Cursor / …): generic `AI_AGENT` env first, then per-agent env markers, then a parent-process-name walk as fallback. Reported in `payload.tag`, `data.agent`, and the UA.
- **isbot workaround (verified live)**: umami silently discards (`{"beep":"boop"}`) UAs matching isbot patterns — including the substring `agent` in `claude-code_2-1-215_agent`. The UA is browser-shaped (`Mozilla/5.0 (…) AIShifuSkill/<version> (…)`) and embedded values are sanitized via `_ua_safe()`; the raw agent value still travels in tag/data. Sanitized UA confirmed accepted end to end (`{"cache":…}`).
- Hooks: `check-update` reports `skill_start` (once per session by existing convention); every other subcommand reports `cli_<command>`. `track()` takes no free-form data — the payload is built entirely from module-generated fields, so "never sends course content, titles, file paths, tokens, or arguments" is structural.
- Skill traffic stays separable from web traffic via `hostname=skills.ai-shifu.cn`, `url=/<skill>/<event>`, and `data.skill`.
- Opt-out: `AISHIFU_ANALYTICS=off`; disclosure in `references/session-controls.md` states the id is the platform user id when logged in, anonymous UUID otherwise (offline runs prefix CLI calls with the opt-out).

## Testing
- 141 unit tests green, including 16 tracker tests (agent detection, distinct id, UA sanitization, opt-out, fail-open, module-generated-only data keys).
- `scripts/validate_skill_quality.py` passes.
- Live verification against production umami: sanitized UA accepted and event stored; pre-fix UA reproducibly bot-flagged. A few one-off `skill_test_probe` events were written during verification (hostname `skills.ai-shifu.cn`) — ignore them in stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)