### PR TITLE
fix: treat backend timestamps as UTC and display in local timezone

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add fail-open anonymous usage tracking to the CLI via the AI-Shifu umami instance, reporting command name, skill version, host agent, and platform info with a stable per-person id (platform user id when logged in, anonymous UUID otherwise); never sends course content or command arguments, and `AISHIFU_ANALYTICS=off` disables it.
+- Treat backend timestamps as UTC across the CLI: `fmt_time` interprets offsetless values as UTC and renders them in the machine-local timezone; internal manifest stamps (`exported_at`, `uploaded_at`, sync timestamps) are written as Z-suffixed UTC; analytics presentation docs state the UTC-to-local rule.
 - Remove pedagogy and optimization rules that reject cover pages and page-type prohibitions on decorative or objective-only pages, while retaining padding-only rejection for newly generated and existing visual units.
 - Require first-slide covers created by Teaching Prompts to include lesson title and author information.
 - Keep general presentation requirements shared by every slide in the Course Prompt while leaving first-slide cover treatment and other position-specific decisions in Teaching Prompts.

--- a/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
+++ b/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
@@ -111,7 +111,7 @@ Pass every result through these checks before showing it to the user:
 1. **Integer / string enums** (status, type, scene, mode) → translate via the code tables in `tables.md`. Never show raw codes like `601`, `502`, `1101`, `"read"`.
 2. **ID fields** → apply the ID Field Translation Rules in `tables.md`: never display a raw `*_bid`; `user_bid` → ordinal labels ("Learner A / B / C"); `outline_item_bid` → "Lesson X.Y: \<title\>"
 3. **Monetary values** → add currency unit (¥/CNY/USD), 2 decimal places
-4. **Timestamps** (`created_at`, `updated_at` etc.) → backend timestamps are UTC (treat values without an explicit offset as UTC); convert to the user's local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps. The local timezone is the machine's (check once per session, e.g. `date +%z`) — never assume one from the conversation language
+4. **Timestamps** (`created_at`, `updated_at` etc.) → backend timestamps are UTC (treat values without an explicit offset as UTC); convert to the user's local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps. Convert using the machine's timezone rules; do not substitute a session-fixed numeric UTC offset (DST-observing zones shift), and never assume a timezone from the conversation language
 5. **Ratios / percentages** → use percent form ("62%" not "0.623")
 6. **Credits** → round to 2 decimal places (e.g. `154.05 积分`); take credit values only from `credit-detail` output (`credits` / `total_credits`) — never invent or re-derive them (`bill_daily_usage_metrics.consumed_credits` applies only once the daily aggregation cron is enabled)
 

--- a/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
+++ b/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
@@ -111,7 +111,7 @@ Pass every result through these checks before showing it to the user:
 1. **Integer / string enums** (status, type, scene, mode) → translate via the code tables in `tables.md`. Never show raw codes like `601`, `502`, `1101`, `"read"`.
 2. **ID fields** → apply the ID Field Translation Rules in `tables.md`: never display a raw `*_bid`; `user_bid` → ordinal labels ("Learner A / B / C"); `outline_item_bid` → "Lesson X.Y: \<title\>"
 3. **Monetary values** → add currency unit (¥/CNY/USD), 2 decimal places
-4. **Timestamps** (`created_at`, `updated_at` etc.) → convert to local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps
+4. **Timestamps** (`created_at`, `updated_at` etc.) → backend timestamps are UTC (treat values without an explicit offset as UTC); convert to the user's local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps
 5. **Ratios / percentages** → use percent form ("62%" not "0.623")
 6. **Credits** → round to 2 decimal places (e.g. `154.05 积分`); take credit values only from `credit-detail` output (`credits` / `total_credits`) — never invent or re-derive them (`bill_daily_usage_metrics.consumed_credits` applies only once the daily aggregation cron is enabled)
 

--- a/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
+++ b/skills/ai-shifu-course-creator/references/analytics/privacy-and-presentation.md
@@ -111,7 +111,7 @@ Pass every result through these checks before showing it to the user:
 1. **Integer / string enums** (status, type, scene, mode) → translate via the code tables in `tables.md`. Never show raw codes like `601`, `502`, `1101`, `"read"`.
 2. **ID fields** → apply the ID Field Translation Rules in `tables.md`: never display a raw `*_bid`; `user_bid` → ordinal labels ("Learner A / B / C"); `outline_item_bid` → "Lesson X.Y: \<title\>"
 3. **Monetary values** → add currency unit (¥/CNY/USD), 2 decimal places
-4. **Timestamps** (`created_at`, `updated_at` etc.) → backend timestamps are UTC (treat values without an explicit offset as UTC); convert to the user's local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps
+4. **Timestamps** (`created_at`, `updated_at` etc.) → backend timestamps are UTC (treat values without an explicit offset as UTC); convert to the user's local-timezone readable format (`2026-05-12 14:23`); never show raw ISO timestamps. The local timezone is the machine's (check once per session, e.g. `date +%z`) — never assume one from the conversation language
 5. **Ratios / percentages** → use percent form ("62%" not "0.623")
 6. **Credits** → round to 2 decimal places (e.g. `154.05 积分`); take credit values only from `credit-detail` output (`credits` / `total_credits`) — never invent or re-derive them (`bill_daily_usage_metrics.consumed_credits` applies only once the daily aggregation cron is enabled)
 

--- a/skills/ai-shifu-course-creator/references/analytics/recipes.md
+++ b/skills/ai-shifu-course-creator/references/analytics/recipes.md
@@ -493,7 +493,7 @@ Apply the Translation Gate in `privacy-and-presentation.md`:
 
 - Never paste the raw `user_bid`; replace with ordinal labels (`Learner A / B / C`).
 - Translate `progress_record_bid` to a chapter/lesson name via the two-step lookup in `tables.md`.
-- Convert `created_at` to local-timezone (`2026-05-13 21:42`).
+- Convert `created_at` (UTC; offsetless values are UTC) to local-timezone (`2026-05-13 21:42`).
 - Display the masked `user_identify` as-is — do not strip the `*****`.
 
 Final shape per row:

--- a/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
+++ b/skills/ai-shifu-course-creator/references/cli/course-directory-spec.md
@@ -221,7 +221,7 @@ The course and lesson revisions are cloud baselines. `content_sha256` is the las
 ```json
 {
   "version": "1.0",
-  "exported_at": "2026-01-01T00:00:00",
+  "exported_at": "2026-01-01T00:00:00Z",
   "shifu": {
     "shifu_bid": "generated_uuid",
     "title": "Course Title",

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -292,12 +292,19 @@ def safe_join_path(base_dir, filename):
 
 
 def fmt_time(ts):
-    """Format an ISO timestamp for display, return '' if missing."""
+    """Format a backend timestamp for display in the local timezone.
+
+    Backend timestamps are UTC; values without an explicit offset are
+    interpreted as UTC, then converted to the machine-local timezone.
+    Returns '' if missing.
+    """
     if not ts:
         return ""
     try:
-        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        return dt.strftime("%Y-%m-%d %H:%M")
+        dt = datetime.fromisoformat(str(ts).strip().replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M")
     except Exception:
         return ts[:16] if len(ts) >= 16 else ts
 
@@ -339,7 +346,7 @@ SYNC_MANIFEST_NAME = ".shifu-sync.json"
 
 def _now_iso():
     """UTC timestamp, second precision, Z-suffixed — matches image-manifest style."""
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _mask_phone(phone):
@@ -2237,7 +2244,7 @@ def _build_import_json(course_dir, title=None, description=None,
 
     import_data = {
         "version": "1.0",
-        "exported_at": datetime.now().isoformat(),
+        "exported_at": _now_iso(),
         "shifu": {
             "shifu_bid": shifu_bid,
             "title": title,
@@ -2656,7 +2663,7 @@ def cmd_upload_image(args):
                 "local": local_rel,
                 "remote": remote_url,
                 "alt": alt,
-                "uploaded_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "uploaded_at": _now_iso(),
                 "bytes": len(file_bytes),
                 "original_bytes": original_bytes,
                 "mime": mime,
@@ -2673,7 +2680,7 @@ def cmd_upload_image(args):
             "source_url": args.url,
             "remote": remote_url,
             "alt": alt,
-            "uploaded_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "uploaded_at": _now_iso(),
         })
 
 

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -203,5 +203,57 @@ class CourseCreatorCliPaginationTests(unittest.TestCase):
         )
 
 
+class FmtTimeTests(unittest.TestCase):
+    """Backend timestamps are UTC; fmt_time must render them in local time."""
+
+    @contextlib.contextmanager
+    def _local_tz(self, tz: str):
+        import os
+        import time as time_module
+
+        if not hasattr(time_module, "tzset"):
+            self.skipTest("time.tzset is unavailable on this platform")
+        original = os.environ.get("TZ")
+        os.environ["TZ"] = tz
+        time_module.tzset()
+        try:
+            yield
+        finally:
+            if original is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = original
+            time_module.tzset()
+
+    def test_z_suffixed_utc_converts_to_local(self) -> None:
+        with self._local_tz("Asia/Shanghai"):
+            self.assertEqual(
+                course_creator_cli.fmt_time("2026-05-12T06:23:00Z"),
+                "2026-05-12 14:23",
+            )
+
+    def test_offsetless_value_is_treated_as_utc(self) -> None:
+        with self._local_tz("Asia/Shanghai"):
+            self.assertEqual(
+                course_creator_cli.fmt_time("2026-05-12T06:23:00"),
+                course_creator_cli.fmt_time("2026-05-12T06:23:00Z"),
+            )
+
+    def test_explicit_offset_is_respected(self) -> None:
+        with self._local_tz("Asia/Shanghai"):
+            self.assertEqual(
+                course_creator_cli.fmt_time("2026-05-12T06:23:00+08:00"),
+                "2026-05-12 06:23",
+            )
+
+    def test_missing_and_unparsable_values(self) -> None:
+        self.assertEqual(course_creator_cli.fmt_time(""), "")
+        self.assertEqual(course_creator_cli.fmt_time(None), "")
+        self.assertEqual(
+            course_creator_cli.fmt_time("not-a-timestamp-value"),
+            "not-a-timestamp-",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Split out of #123 (which now carries only the umami usage tracking). Ported from the reference branch `aichy/time-260626` onto current main.

Backend timestamps are stored and returned as UTC, mostly as offsetless ISO strings. The CLI previously rendered them verbatim (showing UTC as if it were local), and `exported_at` wrote a naive local `datetime.now()` with no offset.

- `fmt_time` now interprets offsetless values as UTC and converts to the machine-local timezone before display (`list` / `history` / version-sync messages).
- All internal manifest stamps (`exported_at`, `uploaded_at`, sync timestamps) are written as Z-suffixed UTC via `_now_iso()`; the deprecated `datetime.utcnow()` calls are replaced with `datetime.now(timezone.utc)`.
- Analytics presentation docs (Translation Gate, recipes) state the rule explicitly: offsetless backend timestamps are UTC; convert using the machine's timezone rules (not a session-fixed numeric offset, which breaks under DST) and never assume a timezone from the conversation language. This matches the web frontend, which appends `Z` to offsetless values before parsing.
- `course-directory-spec.md` example updated to the Z-suffixed form.

## Testing
- 129 unit tests green, including 4 new `fmt_time` tests (UTC→local with pinned `TZ=Asia/Shanghai`, offsetless≡Z, explicit-offset respected, fallback).
- `scripts/validate_skill_quality.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling in the CLI by consistently treating backend timestamps as UTC and displaying them in local time.
  * Standardized generated export and upload timestamps with an explicit UTC indicator.
  * Improved handling of timestamps with missing or explicit timezone information.

* **Documentation**
  * Updated analytics and import documentation to clarify UTC timestamp handling and local-time display rules.

* **Tests**
  * Added coverage for UTC conversion, timezone offsets, invalid values, and missing timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->