### PR TITLE
refactor: rename telemetry env vars to AI_SHIFU_SKILL_ prefix

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add fail-open anonymous usage tracking to the CLI via the AI-Shifu umami instance, reporting command name, skill version, host agent, and platform info with a stable per-person id (platform user id when logged in, anonymous UUID otherwise); never sends course content or command arguments, and `AISHIFU_ANALYTICS=off` disables it.
+- Add fail-open anonymous usage tracking to the CLI via the AI-Shifu umami instance, reporting command name, skill version, host agent, and platform info with a stable per-person id (platform user id when logged in, anonymous UUID otherwise); never sends course content or command arguments, and `AI_SHIFU_SKILL_TELEMETRY=off` disables it.
 - Treat backend timestamps as UTC across the CLI: `fmt_time` interprets offsetless values as UTC and renders them in the machine-local timezone; internal manifest stamps (`exported_at`, `uploaded_at`, sync timestamps) are written as Z-suffixed UTC; analytics presentation docs state the UTC-to-local rule.
 - Remove pedagogy and optimization rules that reject cover pages and page-type prohibitions on decorative or objective-only pages, while retaining padding-only rejection for newly generated and existing visual units.
 - Require first-slide covers created by Teaching Prompts to include lesson title and author information.

--- a/skills/ai-shifu-course-creator/references/session-controls.md
+++ b/skills/ai-shifu-course-creator/references/session-controls.md
@@ -45,10 +45,10 @@ user id when logged in, otherwise an anonymous UUID) to the
 AI-Shifu umami instance so the team can see which skills and commands are
 used. It never sends course content, titles, file paths, tokens, or command
 arguments. Reporting is fail-open: it never blocks or breaks a command.
-Setting `AISHIFU_ANALYTICS=off` disables it entirely; when the user asks
+Setting `AI_SHIFU_SKILL_TELEMETRY=off` disables it entirely; when the user asks
 about analytics, explain the above and mention that switch. When the active
 request explicitly requires offline or no-network execution, prefix every CLI
-invocation with `AISHIFU_ANALYTICS=off` so no network attempt is made.
+invocation with `AI_SHIFU_SKILL_TELEMETRY=off` so no network attempt is made.
 
 ## Progress, Errors, and Handoffs
 

--- a/skills/ai-shifu-course-creator/scripts/usage_tracker.py
+++ b/skills/ai-shifu-course-creator/scripts/usage_tracker.py
@@ -9,7 +9,7 @@ What is sent per event: event name (CLI command), skill name/version, host
 agent (Claude Code / opencode / codex / ...), OS/arch/Python version, and a
 distinct id (platform user_id when logged in, otherwise a random anonymous
 UUID persisted in ~/.ai-shifu/analytics-id). No course content, titles, file
-paths, or tokens are ever sent. Set AISHIFU_ANALYTICS=off to disable.
+paths, or tokens are ever sent. Set AI_SHIFU_SKILL_TELEMETRY=off to disable.
 """
 
 from __future__ import annotations
@@ -243,7 +243,7 @@ def _user_agent(agent: str) -> str:
 
 def _opted_out() -> bool:
     return (
-        os.environ.get("AISHIFU_ANALYTICS", "").strip().lower()
+        os.environ.get("AI_SHIFU_SKILL_TELEMETRY", "").strip().lower()
         in _OPT_OUT_VALUES
     )
 
@@ -259,10 +259,10 @@ def track(event_name: str) -> None:
     try:
         if _opted_out():
             return
-        website = os.environ.get("AISHIFU_UMAMI_WEBSITE_ID") or WEBSITE_ID
+        website = os.environ.get("AI_SHIFU_SKILL_UMAMI_WEBSITE_ID") or WEBSITE_ID
         if not website:
             return
-        url = os.environ.get("AISHIFU_UMAMI_URL") or UMAMI_URL
+        url = os.environ.get("AI_SHIFU_SKILL_UMAMI_URL") or UMAMI_URL
         agent = detect_agent()
         payload = {
             "website": website,

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -128,7 +128,7 @@ class UserAgentTests(unittest.TestCase):
 
 class TrackTests(unittest.TestCase):
     def _env(self, **extra: str) -> dict[str, str]:
-        env = {"AISHIFU_UMAMI_WEBSITE_ID": "site-1"}
+        env = {"AI_SHIFU_SKILL_UMAMI_WEBSITE_ID": "site-1"}
         env.update(extra)
         return env
 
@@ -176,7 +176,7 @@ class TrackTests(unittest.TestCase):
     def test_opt_out_disables_tracking(self) -> None:
         with mock.patch.dict(
             usage_tracker.os.environ,
-            self._env(AISHIFU_ANALYTICS="off"),
+            self._env(AI_SHIFU_SKILL_TELEMETRY="off"),
             clear=True,
         ), mock.patch.object(usage_tracker.requests, "post") as post:
             usage_tracker.track("cli_list")


### PR DESCRIPTION
## Summary

Follow-up to #123. Renames the three telemetry-related environment variables:

| Old | New |
|---|---|
| `AISHIFU_ANALYTICS` | `AI_SHIFU_SKILL_TELEMETRY` |
| `AISHIFU_UMAMI_WEBSITE_ID` | `AI_SHIFU_SKILL_UMAMI_WEBSITE_ID` |
| `AISHIFU_UMAMI_URL` | `AI_SHIFU_SKILL_UMAMI_URL` |

Rationale:
- **`ANALYTICS` was ambiguous** — the skill has a whole course-analytics feature (`analytics-query`, learner data); a switch named `AISHIFU_ANALYTICS` reads like it toggles that. `TELEMETRY` names what it actually controls: the skill's own usage reporting.
- **One namespaced prefix** (`AI_SHIFU_SKILL_`) for everything the skill itself defines, so future switches have an obvious home and can't collide with platform/app variables.

No backward compatibility for the old names — they shipped only hours ago in #123 and are still unreleased.

Updated: `usage_tracker.py`, `session-controls.md`, `CHANGELOG.md` (unreleased entry edited in place), tests.

## Testing
- 145 unit tests green; `scripts/validate_skill_quality.py` passes.
- `grep -r AISHIFU_` confirms zero references to the old names remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry configuration guidance to use `AI_SHIFU_SKILL_TELEMETRY=off`.
  * Updated offline usage instructions to disable telemetry for each CLI invocation when required.
* **Bug Fixes**
  * Standardized telemetry and analytics environment-variable names, including overrides for the reporting endpoint and website ID.
  * Confirmed telemetry remains disabled without network requests when opted out.
  * Telemetry continues to fail safely and does not transmit course content or command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->