### PR TITLE
fix: make skill names comply with the Agent Skills standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ skills/
 
 ## Usage
 
-Each skill keeps `SKILL.md` as the behavior source of truth. The directory name is the stable machine slug; the `name` frontmatter field is the human-readable display name.
+Each skill keeps `SKILL.md` as the behavior source of truth. Following the [Agent Skills](https://agentskills.io/specification) standard, the `name` frontmatter field must match the directory name: lowercase letters, digits, and hyphens only. Human-readable display names live in the skill list above.
 
 ## Course Authoring & Deployment Paths
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ skills/
 
 ## Usage
 
-Each skill keeps `SKILL.md` as the behavior source of truth. Following the [Agent Skills](https://agentskills.io/specification) standard, the `name` frontmatter field must match the directory name: lowercase letters, digits, and hyphens only. Human-readable display names live in the skill list above.
+Each skill keeps `SKILL.md` as the behavior source of truth. The `name` frontmatter field must match the directory name, using lowercase letters, digits, and hyphens only, as required by the [Agent Skills](https://agentskills.io/specification) standard. That format was originally developed by Anthropic and released as an open standard, and the [Claude Code documentation](https://code.claude.com/docs/en/skills) states that its skills follow it. Claude Code itself is more permissive and treats `name` as an optional display label, but this repository follows the stricter standard rule so the skills stay portable across every skills-compatible agent. Human-readable display names live in the skill list above.
 
 ## Course Authoring & Deployment Paths
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@ skills/
 
 ## 使用说明
 
-skill 以 `SKILL.md` 作为行为定义。遵循 [Agent Skills](https://agentskills.io/specification) 标准，`name` frontmatter 字段必须与目录名一致，只允许小写字母、数字和连字符。面向人的展示名维护在上方的 skill 列表中。
+skill 以 `SKILL.md` 作为行为定义。按照 [Agent Skills](https://agentskills.io/specification) 标准，`name` frontmatter 字段必须与目录名一致，只允许小写字母、数字和连字符。该格式最初由 Anthropic 开发并作为开放标准发布，[Claude Code 官方文档](https://code.claude.com/docs/en/skills)声明其 skill 遵循这一标准。Claude Code 自身的实现更宽松，把 `name` 当作可选的展示标签；本仓库采用标准中更严格的规则，以保证 skill 在所有兼容 Agent Skills 的 agent 中都能正常使用。面向人的展示名维护在上方的 skill 列表中。
 
 ## 课程生产与部署路径
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@ skills/
 
 ## 使用说明
 
-skill 以 `SKILL.md` 作为行为定义。目录名是稳定的机器 slug；`name` frontmatter 字段是面向人的展示名。
+skill 以 `SKILL.md` 作为行为定义。遵循 [Agent Skills](https://agentskills.io/specification) 标准，`name` frontmatter 字段必须与目录名一致，只允许小写字母、数字和连字符。面向人的展示名维护在上方的 skill 列表中。
 
 ## 课程生产与部署路径
 

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 RE_KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-RE_HUMAN_READABLE_NAME = re.compile(r"^\S[^\r\n<>]*$")
 RE_XML_TAG = re.compile(r"[<>]")
 RE_REF_PATH = re.compile(r"references/[A-Za-z0-9_./-]+\.md")
 RE_MD_ANCHOR_REF = re.compile(
@@ -202,15 +201,11 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
     if not name:
         issues.add_error(f"{skill_md}: frontmatter 'name' field is required")
     else:
-        if name == slug:
+        if name != slug:
             issues.add_error(
-                f"{skill_md}: frontmatter 'name' must be a human-readable "
-                f"display name, but it matches the folder slug '{name}'"
-            )
-        elif not RE_HUMAN_READABLE_NAME.match(name):
-            issues.add_error(
-                f"{skill_md}: frontmatter 'name' contains unsupported display "
-                f"name characters, got '{name}'"
+                f"{skill_md}: frontmatter 'name' must match the folder slug "
+                f"'{slug}' (Agent Skills spec: lowercase alphanumerics and "
+                f"hyphens only), got '{name}'"
             )
         name_lower = name.lower()
         for word in FORBIDDEN_WORDS:

--- a/scripts/validate_skill_quality.py
+++ b/scripts/validate_skill_quality.py
@@ -197,6 +197,11 @@ def validate_skill(skill_dir: Path, issues: IssueBag) -> None:
     if front is None:
         return
 
+    # The Agent Skills standard (https://agentskills.io/specification) requires
+    # `name` to match the directory name. Anthropic originally developed that
+    # format and released it as an open standard, and the Claude Code docs state
+    # that its skills follow it. Claude Code alone would accept a free-form
+    # display name here, but matching the slug keeps these skills portable.
     name = front.get("name", "").strip()
     if not name:
         issues.add_error(f"{skill_md}: frontmatter 'name' field is required")

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: AI-Shifu Course Creator
+name: ai-shifu-course-creator
 description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing Teaching Prompts (per-lesson) and Course Prompts (course-level) — both written in MarkdownFlow (MDF). Covers the full course lifecycle — from converting raw material into structured lessons, to authoring interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Also covers post-deployment analytics on those courses — learner count, completion rate, stuck lessons, orders, revenue, ratings, credit consumption, audience profiles, and individual learner tracking. Trigger on any mention of AI-Shifu, AI师傅, MarkdownFlow, Teaching Prompt, Course Prompt authoring, course analytics, creator analytics, 学习人数, 完成率, 卡课节, 订单收入, 积分消耗, or learner progress.
 version: 1.2.2
 version_management: standalone

--- a/skills/course-direction-advisor/SKILL.md
+++ b/skills/course-direction-advisor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Course Direction Advisor（课程选题顾问）
+name: course-direction-advisor
 description: Turn user-provided source materials into market-fit course-topic decisions without exceeding the evidence boundary of the materials. Use when the user needs course topic selection, competitor analysis, pricing guidance, audience targeting, market positioning, or a decision on whether the material is strong and complete enough to support a course. Avoid when the topic is already fixed and the user only needs lesson breakdowns, scripts, or copy polishing.
 metadata:
   short-description: Select and validate market-fit course topics from source materials


### PR DESCRIPTION
## Summary

Aligns both skills' frontmatter `name` fields with the [Agent Skills](https://agentskills.io/specification) standard, so they stay portable across skills-compatible agents beyond Claude Code.

| File | Before | After |
| --- | --- | --- |
| `skills/ai-shifu-course-creator/SKILL.md` | `AI-Shifu Course Creator` | `ai-shifu-course-creator` |
| `skills/course-direction-advisor/SKILL.md` | `Course Direction Advisor（课程选题顾问）` | `course-direction-advisor` |

## Why

The two specifications that apply here do not agree on `name`, so it is worth stating both:

| | Agent Skills standard | Claude Code documentation |
| --- | --- | --- |
| Required | Yes | No |
| Meaning | Machine identifier | "Display name shown in skill listings. Defaults to the directory name." |
| Constraints | Lowercase alphanumerics and hyphens; must match the parent directory name | None stated |

The Agent Skills format was originally developed by Anthropic and released as an open standard, and the Claude Code documentation states that its skills follow it while extending it. But Claude Code's own implementation is the more permissive of the two: for personal and project skills `name` is only a display label and the command name always comes from the directory. So the previous values were valid under Claude Code's own rules — nothing was broken — and this is not a bug fix.

It matters because this repository publishes skills for outside use. Under the open standard the previous values are invalid (uppercase, spaces, and previously CJK characters), and `skills-ref validate` rejects them today. Adopting the stricter of the two rules costs nothing: Claude Code defaults `name` to the directory name anyway, and neither skill's display name was ever rendered.

The repository validator was enforcing the exact opposite of the standard, so it is reversed here too.

## Changes

- `skills/ai-shifu-course-creator/SKILL.md`, `skills/course-direction-advisor/SKILL.md`: set `name` to the directory slug.
- `scripts/validate_skill_quality.py`: the rule that rejected `name == slug` now requires it, with an error message and comment recording where the rule comes from. The now-unused `RE_HUMAN_READABLE_NAME` pattern was removed. The `FORBIDDEN_WORDS` check is untouched.
- `README.md`, `README.zh-CN.md`: the usage note states the rule, its origin, and why the stricter reading was chosen. Bilingual display names remain in the skill list at the top of each README.

Display names were deliberately not moved into `metadata`. Claude Code never renders the `name` field for these skills and both READMEs already carry the bilingual names, so a `metadata.display-name` entry would be pure duplication. Happy to add one if it is wanted for other tooling.

## Verification

- `python3 scripts/validate_skill_quality.py` → `Validated 2 skills -- all passed`, exit code 0.
- `python3 -m pytest tests/ -q` → 141 passed, 5 failed.

The 5 failures are pre-existing and unrelated. Confirmed by stashing this branch's changes and re-running against the same base commit: the identical 5 tests fail. They all stem from `skills/ai-shifu-course-creator/design/i18n/zh/` translations having drifted from the English source (for example `references/analytics/tables.md` still carrying the retired `teacher/ai` wording). Left untouched as a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)