### PR TITLE
fix: follow the platform default voice when enabling Listen Mode

### DIFF
--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -155,7 +155,7 @@ The command maps `guest`, `trial`, and `normal` to the platform learning-access 
 
 ### `set-tts`
 
-Disabling sends only `tts_enabled=false`. Enabling fetches platform TTS defaults and sends provider, model, voice, speed, normalized pitch `0`, and empty emotion; `--speed` overrides the default. Invalid or incomplete settings exit `1`.
+Disabling sends only `tts_enabled=false`. Enabling fetches the platform TTS configuration and selects the model option the platform declares as default (`is_default`), falling back to the first option on backends without the marker, plus the first voice compatible with that model. It sends provider, model, voice, speed, normalized pitch `0`, and empty emotion; `--speed` overrides the default. Invalid or incomplete settings exit `1`.
 
 With a matching sync manifest, the command checks the course revision before writing, then refreshes `course-config.json` and the manifest after success. On conflict it records the intended metadata, pulls the cloud course, and exits `2`.
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -1504,10 +1504,17 @@ def _tts_model_options(tts_config):
 
 
 def _filter_tts_voices_for_model(provider, voices, model):
-    if _tts_provider_name(provider) != "volcengine":
-        return voices
     model_key = _string_tts_value(model)
     if not model_key:
+        return voices
+    # Providers whose voices declare a resource_id (volcengine resources,
+    # tencent TextToVoice tiers) require the voice to match the selected
+    # model; providers without the annotation keep their full list. This
+    # mirrors the platform editor's filterTtsVoicesForModel behavior.
+    has_resource_annotations = any(
+        _string_tts_value(v.get("resource_id")) for v in voices
+    )
+    if not has_resource_annotations:
         return voices
     return [
         v for v in voices
@@ -1528,7 +1535,12 @@ def _select_platform_tts_defaults(speed, tts_config):
     """Mirror the platform editor's default provider/model/voice selection."""
     providers = _tts_providers_by_name(tts_config)
     model_options = _tts_model_options(tts_config)
-    default_model_option = model_options[0] if model_options else None
+    # Prefer the option the platform declares as default (is_default); older
+    # backends without the marker fall back to the first option.
+    default_model_option = next(
+        (o for o in model_options if o.get("is_default")),
+        model_options[0] if model_options else None,
+    )
     provider = ""
     model = ""
 

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -255,5 +255,103 @@ class FmtTimeTests(unittest.TestCase):
         )
 
 
+class CourseCreatorCliTtsDefaultsTests(unittest.TestCase):
+    TENCENT_VOICES = [
+        {"value": "101001", "label": "Zhiyu", "resource_id": "premium"},
+        {"value": "501001", "label": "Zhilan", "resource_id": "large-model"},
+        {"value": "601002", "label": "Aiyue", "resource_id": "large-model"},
+    ]
+
+    def _tts_config(self, model_options):
+        return {
+            "providers": [
+                {
+                    "name": "tencent_texttovoice",
+                    "models": [
+                        {"value": "premium"},
+                        {"value": "large-model"},
+                    ],
+                    "voices": self.TENCENT_VOICES,
+                    "speed": {"default": 1.0},
+                },
+                {
+                    "name": "minimax",
+                    "models": [{"value": "speech-2.8-turbo"}],
+                    "voices": [
+                        {"value": "voice-a", "label": "Voice A"},
+                        {"value": "voice-b", "label": "Voice B"},
+                    ],
+                    "speed": {"default": 1.0},
+                },
+            ],
+            "model_options": model_options,
+        }
+
+    def test_voice_filter_scopes_resource_annotated_voices_to_model(self):
+        filtered = course_creator_cli._filter_tts_voices_for_model(
+            "tencent_texttovoice", self.TENCENT_VOICES, "large-model"
+        )
+        self.assertEqual([v["value"] for v in filtered], ["501001", "601002"])
+
+    def test_voice_filter_keeps_unannotated_voices(self):
+        plain_voices = [
+            {"value": "voice-a", "label": "Voice A"},
+            {"value": "voice-b", "label": "Voice B"},
+        ]
+        filtered = course_creator_cli._filter_tts_voices_for_model(
+            "minimax", plain_voices, "speech-2.8-turbo"
+        )
+        self.assertEqual(filtered, plain_voices)
+
+    def test_defaults_prefer_platform_declared_default_option(self):
+        config = self._tts_config(
+            [
+                {
+                    "provider": "tencent_texttovoice",
+                    "value": "tencent_texttovoice/premium",
+                    "model": "premium",
+                    "is_default": False,
+                },
+                {
+                    "provider": "tencent_texttovoice",
+                    "value": "tencent_texttovoice/large-model",
+                    "model": "large-model",
+                    "is_default": True,
+                },
+            ]
+        )
+        provider, model, voice_id, speed = (
+            course_creator_cli._select_platform_tts_defaults(None, config)
+        )
+        self.assertEqual(provider, "tencent_texttovoice")
+        self.assertEqual(model, "large-model")
+        # The default voice must match the default model tier, not the first
+        # voice in the provider list (which belongs to the premium tier).
+        self.assertEqual(voice_id, "501001")
+        self.assertEqual(speed, 1.0)
+
+    def test_defaults_fall_back_to_first_option_without_marker(self):
+        config = self._tts_config(
+            [
+                {
+                    "provider": "tencent_texttovoice",
+                    "value": "tencent_texttovoice/premium",
+                    "model": "premium",
+                },
+                {
+                    "provider": "minimax",
+                    "value": "minimax/speech-2.8-turbo",
+                    "model": "speech-2.8-turbo",
+                },
+            ]
+        )
+        provider, model, voice_id, _speed = (
+            course_creator_cli._select_platform_tts_defaults(None, config)
+        )
+        self.assertEqual(provider, "tencent_texttovoice")
+        self.assertEqual(model, "premium")
+        self.assertEqual(voice_id, "101001")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`set-tts --enabled true` currently hardcodes "first `model_options` entry + first provider voice" as the default. This PR aligns the CLI with the new backend contract (ai-shifu/ai-shifu#2242) where the platform declares its default voice tier via `is_default` on `/tts/config` model options, and fixes a latent voice-pairing bug that would break `set-tts` once the platform default is no longer the first tier.

## Changes

- `_select_platform_tts_defaults` prefers the option marked `is_default`; backends without the marker (older deployments) fall back to the first option, so behavior is unchanged until the platform ships the marker.
- `_filter_tts_voices_for_model` no longer special-cases volcengine: any voice list with `resource_id` annotations (e.g. Tencent TextToVoice premium/large-model tiers) is scoped to the selected model, mirroring the platform editor's `filterTtsVoicesForModel`. Without this fix, a non-first default tier would pair the first (wrong-tier) voice and the backend's strict validation would reject the request.
- CLI reference updated; unit tests added for both behaviors (voice scoping, default preference, first-option fallback).

## Tests

`python -m pytest tests/test_course_creator_cli.py` — 12 passed (4 new).

## Rollout

Safe to merge independently: with today's backend the fallback keeps current behavior. Must be released before production sets `TTS_DEFAULT_MODEL` to a non-first tier (standard voice), otherwise old CLI builds would keep selecting the first tier and, worse, the unfixed voice filter would send mismatched voices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text-to-speech now selects the platform-designated default model when enabled.
  * If no default model is specified, the first available model is selected automatically.
  * Voice selection now filters model-specific voices while preserving providers without voice annotations.

* **Documentation**
  * Updated command documentation to describe the new text-to-speech model and voice selection behavior.

* **Tests**
  * Added coverage for default model selection, fallback behavior, and voice filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->