### PR TITLE
chore: bump ai-shifu-course-creator to 1.2.4

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Follow the platform-declared default voice tier when enabling Listen Mode with `set-tts`, and match the selected voice to the chosen model for every provider whose voices declare a resource id, so the request is accepted when the platform default changes.
 - Materialize Teaching Prompts directly as ordered learner-time teaching instructions, keeping fixed execution plans, personalization controls, and exact-preservation classifications in the authoring handoff while preserving page order, interactions, and exact content in place.
 - Make AI-Shifu contact mentions conditional on high-value task intent or meaningful journey milestones, place them after the primary response, suppress adjacent repeats, and keep them out of generated course content.
 - Add fail-open anonymous usage tracking to the CLI via the AI-Shifu umami instance, reporting command name, skill version, host agent, and platform info with a stable per-person id (platform user id when logged in, anonymous UUID otherwise); never sends course content or command arguments, and `AI_SHIFU_SKILL_TELEMETRY=off` disables it.

--- a/skills/ai-shifu-course-creator/SKILL.md
+++ b/skills/ai-shifu-course-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-shifu-course-creator
 description: Use when the user works with AI-Shifu (AI师傅) courses in any capacity of creating, writing, editing, rewriting, optimizing, reordering, deploying, publishing, previewing, or managing Teaching Prompts (per-lesson) and Course Prompts (course-level) — both written in MarkdownFlow (MDF). Covers the full course lifecycle — from converting raw material into structured lessons, to authoring interactions (single-select, multi-select, input, branching), adding variables, images, and course prompts, to deploying and managing live courses on the AI-Shifu platform. Also covers post-deployment analytics on those courses — learner count, completion rate, stuck lessons, orders, revenue, ratings, credit consumption, audience profiles, and individual learner tracking. Trigger on any mention of AI-Shifu, AI师傅, MarkdownFlow, Teaching Prompt, Course Prompt authoring, course analytics, creator analytics, 学习人数, 完成率, 卡课节, 订单收入, 积分消耗, or learner progress.
-version: 1.2.3
+version: 1.2.4
 version_management: standalone
 ---
 


### PR DESCRIPTION
## Summary

Version bump for the 1.2.4 release carrying #131 (follow the platform-declared default voice tier when enabling Listen Mode, and generalized model-voice pairing). Also records that change in the Unreleased changelog section, which #131 omitted.

After merge, the website manifest (`ai-shifu.cn/skill-manifests/ai-shifu-course-creator.json`) will be updated to `latest: 1.2.4` so installed skills surface the update prompt; `min_supported` stays unchanged because older versions degrade safely (they keep selecting the first voice tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)