### PR TITLE
feat: initialize AI-Shifu CLI environment settings

### DIFF
--- a/skills/ai-shifu-course-creator/.env.example
+++ b/skills/ai-shifu-course-creator/.env.example
@@ -1,0 +1,5 @@
+# Optional. The CLI uses this production URL when SHIFU_BASE_URL is empty.
+SHIFU_BASE_URL=https://app.ai-shifu.cn
+
+# Saved automatically by `shifu-cli.py login`; leave empty before first login.
+SHIFU_TOKEN=

--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Initialize a missing `.env` from `.env.example` before every course CLI command, allow an optional `SHIFU_BASE_URL`, keep `https://app.ai-shifu.cn` as the fallback, and preserve the configured URL when SMS login updates the token.
 - Add a low-friction teacher-avatar follow-up after teacher identity intake and a version-aware `set-avatar` CLI path that accepts JPG/PNG, auto-compresses to 2 MB, warns on non-square images, binds without Chrome, and verifies the saved URL by readback.
 - Materialize Teaching Prompts directly as ordered learner-time teaching instructions, keeping fixed execution plans, personalization controls, and exact-preservation classifications in the authoring handoff while preserving page order, interactions, and exact content in place.
 - Make AI-Shifu contact mentions conditional on high-value task intent or meaningful journey milestones, place them after the primary response, suppress adjacent repeats, and keep them out of generated course content.

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -12,7 +12,16 @@ All commands use:
 python3 {skillDir}/scripts/shifu-cli.py <command>
 ```
 
-Authenticated commands accept `--token <jwt>` and otherwise read `SHIFU_TOKEN` from `{skillDir}/.env`. The CLI always uses `https://app.ai-shifu.cn`.
+Authenticated commands accept `--token <jwt>` and otherwise read `SHIFU_TOKEN` from `{skillDir}/.env`. The CLI uses `https://app.ai-shifu.cn` by default. Use `{skillDir}/.env.example` as the reference when creating or editing `{skillDir}/.env`:
+
+```dotenv
+SHIFU_BASE_URL=https://app.ai-shifu.cn
+SHIFU_TOKEN=
+```
+
+Change `SHIFU_BASE_URL` in the process environment or `{skillDir}/.env` to use another deployment. An unset, empty, whitespace-only, or slash-only value falls back to the default production URL. Leading and trailing whitespace and trailing slashes are removed from a custom value before requests and verification URLs are built. A process environment value takes precedence over the value loaded from `{skillDir}/.env`.
+
+Before every command, the CLI checks for `{skillDir}/.env`. When it is missing, the CLI copies `{skillDir}/.env.example` to `{skillDir}/.env`, sets owner-only permissions, and then loads it. An existing `.env` is never replaced, so an author or agent can change `SHIFU_BASE_URL` before requesting an SMS code. Successful SMS verification updates only `SHIFU_TOKEN` and preserves the configured base URL.
 
 ## Contents
 
@@ -48,7 +57,7 @@ login --phone 13800138000 --sms-code 1234
 
 - `verify` exits `0` when the token is accepted, `1` when it is expired or invalid, and `2` when network, service, or response errors make its state unknown.
 - `login --phone` sends an SMS code and exits without prompting.
-- `login --phone --sms-code` verifies the code and writes `SHIFU_TOKEN=<jwt>` to `{skillDir}/.env`.
+- `login --phone --sms-code` verifies the code and updates only `SHIFU_TOKEN=<jwt>` in `{skillDir}/.env`; other values such as `SHIFU_BASE_URL` are preserved.
 - A saved token is valid for seven days; successful authenticated API calls refresh that expiry.
 
 Agent decisions about when to send or resend SMS are defined in `../authentication.md`; this section defines only CLI inputs and effects.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -29,6 +29,7 @@ except Exception:  # noqa: BLE001 - fail-open: any tracker breakage must not tak
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 ENV_FILE = Path(__file__).resolve().parent.parent / ".env"
+ENV_EXAMPLE_FILE = ENV_FILE.with_name(".env.example")
 
 DEFAULT_BASE_URL = "https://app.ai-shifu.cn"
 
@@ -61,10 +62,28 @@ MAX_COURSE_PAGES = 10
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
-def load_env():
-    """Load environment variables from the skill's .env file."""
+def ensure_env_file():
+    """Create the runtime .env from .env.example when it does not exist."""
     if ENV_FILE.exists():
-        load_dotenv(dotenv_path=ENV_FILE, override=False)
+        return
+    if not ENV_EXAMPLE_FILE.exists():
+        print(f"Error: missing environment template: {ENV_EXAMPLE_FILE}",
+              file=sys.stderr)
+        sys.exit(1)
+    shutil.copyfile(ENV_EXAMPLE_FILE, ENV_FILE)
+    os.chmod(ENV_FILE, 0o600)
+
+
+def load_env():
+    """Ensure and load environment variables from the skill's .env file."""
+    ensure_env_file()
+    load_dotenv(dotenv_path=ENV_FILE, override=False)
+
+
+def resolve_base_url():
+    """Resolve the AI-Shifu service URL with the production URL as fallback."""
+    value = os.environ.get("SHIFU_BASE_URL", "").strip().rstrip("/")
+    return value or DEFAULT_BASE_URL
 
 
 def save_env(token):
@@ -96,7 +115,7 @@ def _jwt_payload(token):
 
 
 def resolve_auth(args):
-    """Resolve token from CLI args or .env. Base URL is fixed to DEFAULT_BASE_URL.
+    """Resolve the service URL and token from CLI args or .env.
 
     When the JWT carries a ``time_stamp`` older than 7 days, a warning is printed
     to stderr (the authoritative expiry check is the backend's DB record, so this
@@ -117,7 +136,7 @@ def resolve_auth(args):
                   "to re-login.",
                   file=sys.stderr)
 
-    return DEFAULT_BASE_URL, token
+    return resolve_base_url(), token
 
 
 def api(base_url, token, method, path, **kwargs):
@@ -452,7 +471,7 @@ def _login_post(base_url, path, payload, error_prefix):
 
 def cmd_login(args):
     """SMS login and save token (non-interactive two-step flow)."""
-    base_url = DEFAULT_BASE_URL
+    base_url = resolve_base_url()
 
     phone = args.phone
     if not phone:

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -82,7 +82,7 @@ def load_env():
 
 def resolve_base_url():
     """Resolve the AI-Shifu service URL with the production URL as fallback."""
-    value = os.environ.get("SHIFU_BASE_URL", "").strip().rstrip("/")
+    value = os.environ.get("SHIFU_BASE_URL", "").strip().rstrip(" /\t\r\n")
     return value or DEFAULT_BASE_URL
 
 

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -134,7 +134,9 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
             )
 
     def test_default_base_url_is_used_for_missing_or_empty_configuration(self):
-        for configured in (None, "", "   ", "/", "///", "  ///  "):
+        for configured in (
+            None, "", "   ", "/", "///", "  ///  ", " / / ", "\t/\t/\n"
+        ):
             env = {} if configured is None else {"SHIFU_BASE_URL": configured}
             with self.subTest(configured=configured), mock.patch.dict(
                 course_creator_cli.os.environ, env, clear=True
@@ -145,14 +147,19 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
                 )
 
     def test_custom_base_url_is_trimmed_and_trailing_slashes_are_removed(self):
-        with mock.patch.dict(
-            course_creator_cli.os.environ,
-            {"SHIFU_BASE_URL": "  https://example.test///  "},
-            clear=True,
+        for configured in (
+            "  https://example.test///  ",
+            "https://example.test/ /",
+            "https://example.test/\t/\n",
         ):
-            self.assertEqual(
-                course_creator_cli.resolve_base_url(), "https://example.test"
-            )
+            with self.subTest(configured=configured), mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": configured},
+                clear=True,
+            ):
+                self.assertEqual(
+                    course_creator_cli.resolve_base_url(), "https://example.test"
+                )
 
     def test_resolve_auth_returns_custom_base_url_and_existing_token(self):
         with mock.patch.dict(

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -31,6 +31,212 @@ course_creator_cli = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(course_creator_cli)
 
 
+class CourseCreatorCliBaseUrlTests(unittest.TestCase):
+    def test_env_example_documents_base_url_and_token(self):
+        env_example = SCRIPT_DIR.parent / ".env.example"
+        content = env_example.read_text(encoding="utf-8")
+
+        self.assertIn(
+            f"SHIFU_BASE_URL={course_creator_cli.DEFAULT_BASE_URL}", content
+        )
+        self.assertIn("SHIFU_TOKEN=", content)
+
+    def test_load_env_copies_the_template_when_env_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env_file = root / ".env"
+            env_example = root / ".env.example"
+            template = (
+                "SHIFU_BASE_URL=https://app.ai-shifu.cn\n"
+                "SHIFU_TOKEN=\n"
+            )
+            env_example.write_text(template, encoding="utf-8")
+
+            with (
+                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
+                mock.patch.object(
+                    course_creator_cli, "ENV_EXAMPLE_FILE", env_example
+                ),
+                mock.patch.object(course_creator_cli, "load_dotenv") as load_dotenv,
+            ):
+                course_creator_cli.load_env()
+
+            self.assertEqual(env_file.read_text(encoding="utf-8"), template)
+            self.assertEqual(env_file.stat().st_mode & 0o777, 0o600)
+            load_dotenv.assert_called_once_with(
+                dotenv_path=env_file, override=False
+            )
+
+    def test_load_env_never_replaces_an_existing_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env_file = root / ".env"
+            env_example = root / ".env.example"
+            existing = (
+                "SHIFU_BASE_URL=https://custom.example\n"
+                "SHIFU_TOKEN=existing-token\n"
+            )
+            env_file.write_text(existing, encoding="utf-8")
+            env_example.write_text(
+                "SHIFU_BASE_URL=https://app.ai-shifu.cn\nSHIFU_TOKEN=\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
+                mock.patch.object(
+                    course_creator_cli, "ENV_EXAMPLE_FILE", env_example
+                ),
+                mock.patch.object(course_creator_cli, "load_dotenv") as load_dotenv,
+            ):
+                course_creator_cli.load_env()
+
+            self.assertEqual(env_file.read_text(encoding="utf-8"), existing)
+            load_dotenv.assert_called_once_with(
+                dotenv_path=env_file, override=False
+            )
+
+    def test_load_env_fails_clearly_when_the_template_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env_file = root / ".env"
+            env_example = root / ".env.example"
+
+            with (
+                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
+                mock.patch.object(
+                    course_creator_cli, "ENV_EXAMPLE_FILE", env_example
+                ),
+                self.assertRaises(SystemExit) as raised,
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+            ):
+                course_creator_cli.load_env()
+
+            self.assertEqual(raised.exception.code, 1)
+            self.assertIn("missing environment template", stderr.getvalue())
+
+    def test_save_env_updates_only_the_token_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / ".env"
+            env_file.write_text(
+                "SHIFU_BASE_URL=https://custom.example\nSHIFU_TOKEN=\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
+                mock.patch.object(course_creator_cli, "set_key") as set_key,
+            ):
+                course_creator_cli.save_env("new-token")
+
+            set_key.assert_called_once_with(
+                str(env_file), "SHIFU_TOKEN", "new-token"
+            )
+
+    def test_default_base_url_is_used_for_missing_or_empty_configuration(self):
+        for configured in (None, "", "   ", "/", "///", "  ///  "):
+            env = {} if configured is None else {"SHIFU_BASE_URL": configured}
+            with self.subTest(configured=configured), mock.patch.dict(
+                course_creator_cli.os.environ, env, clear=True
+            ):
+                self.assertEqual(
+                    course_creator_cli.resolve_base_url(),
+                    course_creator_cli.DEFAULT_BASE_URL,
+                )
+
+    def test_custom_base_url_is_trimmed_and_trailing_slashes_are_removed(self):
+        with mock.patch.dict(
+            course_creator_cli.os.environ,
+            {"SHIFU_BASE_URL": "  https://example.test///  "},
+            clear=True,
+        ):
+            self.assertEqual(
+                course_creator_cli.resolve_base_url(), "https://example.test"
+            )
+
+    def test_resolve_auth_returns_custom_base_url_and_existing_token(self):
+        with mock.patch.dict(
+            course_creator_cli.os.environ,
+            {
+                "SHIFU_BASE_URL": "https://example.test/",
+                "SHIFU_TOKEN": "stored-token",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                course_creator_cli.resolve_auth(types.SimpleNamespace(token=None)),
+                ("https://example.test", "stored-token"),
+            )
+
+    def test_explicit_token_still_overrides_the_stored_token(self):
+        with mock.patch.dict(
+            course_creator_cli.os.environ,
+            {
+                "SHIFU_BASE_URL": "https://example.test",
+                "SHIFU_TOKEN": "stored-token",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                course_creator_cli.resolve_auth(
+                    types.SimpleNamespace(token="explicit-token")
+                ),
+                ("https://example.test", "explicit-token"),
+            )
+
+    def test_login_send_uses_custom_base_url(self):
+        args = types.SimpleNamespace(phone="13800138000", sms_code=None)
+        with (
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": "https://example.test/"},
+                clear=True,
+            ),
+            mock.patch.object(
+                course_creator_cli, "_login_post", return_value={"code": 0}
+            ) as login_post,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            course_creator_cli.cmd_login(args)
+
+        login_post.assert_called_once_with(
+            "https://example.test",
+            "/api/user/console_send_sms_code",
+            {"mobile": "13800138000"},
+            "Failed to send SMS",
+        )
+
+    def test_login_verification_uses_custom_base_url_and_saves_token(self):
+        args = types.SimpleNamespace(phone="13800138000", sms_code="1234")
+        with (
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": "https://example.test/"},
+                clear=True,
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_login_post",
+                return_value={"code": 0, "data": "new-token"},
+            ) as login_post,
+            mock.patch.object(course_creator_cli, "save_env") as save_env,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            course_creator_cli.cmd_login(args)
+
+        login_post.assert_called_once_with(
+            "https://example.test",
+            "/api/user/login_sms",
+            {
+                "mobile": "13800138000",
+                "sms_code": "1234",
+                "login_context": "admin",
+            },
+            "Verification failed",
+        )
+        save_env.assert_called_once_with("new-token")
+
+
 class CourseCreatorCliPaginationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.first_page = [


### PR DESCRIPTION
## Summary
- add `SHIFU_BASE_URL` with `https://app.ai-shifu.cn` as the empty-value fallback
- initialize a missing `.env` from the tracked `.env.example` before every CLI command
- preserve an existing Base URL when SMS verification updates `SHIFU_TOKEN`
- document and test the first-run configuration flow

## Validation
- `python3 -m unittest discover -s tests -p "test_course_creator_cli.py"` — 28 tests passed
- `python3 scripts/validate_skill_quality.py` — all 3 skills passed
- `git diff --check` passed
- the full repository suite still reports the same 5 pre-existing failures in `design/i18n/zh`; this change adds no new failures

## Rollout dependency
Merge [ai-shifu-skill-release PR #1](https://github.com/ai-shifu/ai-shifu-skill-release/pull/1) before building or publishing this Skill so packaged installations retain `.env.example`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable deployment URLs for CLI authentication and login, with production fallback.
  * Automatically initializes missing environment configuration from the provided template.
  * Normalizes configured URLs for consistent use.
  * Preserves custom deployment settings when updating login tokens.

* **Documentation**
  * Documented environment setup, URL configuration, precedence, normalization, and SMS login behavior.
  * Added an unreleased changelog entry covering the CLI improvements.

* **Tests**
  * Added coverage for environment initialization, URL handling, authentication, and token persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->