### PR TITLE
feat: sign in through the browser instead of SMS

### DIFF
--- a/skills/ai-shifu-course-creator/.env.example
+++ b/skills/ai-shifu-course-creator/.env.example
@@ -1,5 +1,8 @@
 # Optional. The CLI uses this production URL when SHIFU_BASE_URL is empty.
 SHIFU_BASE_URL=https://app.ai-shifu.cn
 
-# Saved automatically by `shifu-cli.py login`; leave empty before first login.
+# Credentials are no longer stored here. `shifu-cli.py login` writes them to
+# ${XDG_CONFIG_HOME:-~/.config}/ai-shifu/credentials.json so that upgrading or
+# reinstalling the skill does not sign you out. Set SHIFU_TOKEN only to supply
+# a token yourself, for example in CI; it takes precedence when present.
 SHIFU_TOKEN=

--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Replace SMS login with a browser authorization flow: `login` prints a verification link and pairing code, `login --wait` collects the token once the user approves the request on the AI-Shifu approval page, and no command sends a text message any more. Credentials move from the skill's `.env` to `${XDG_CONFIG_HOME:-~/.config}/ai-shifu/credentials.json` so upgrading or reinstalling the skill no longer signs the user out, and a token left behind by an older version is migrated on first run.
 - Use platform-supplied learner context in Course Prompts to personalize open expression while preserving the course author's intended audience, each Teaching Prompt's fixed decisions, and neutral behavior when no relevant learner profile is available.
 - Initialize a missing `.env` from `.env.example` before every course CLI command, allow an optional `SHIFU_BASE_URL`, keep `https://app.ai-shifu.cn` as the fallback, and preserve the configured URL when SMS login updates the token.
 - Add a low-friction teacher-avatar follow-up after teacher identity intake and a version-aware `set-avatar` CLI path that accepts JPG/PNG, auto-compresses to 2 MB, warns on non-square images, binds without Chrome, and verifies the saved URL by readback.

--- a/skills/ai-shifu-course-creator/references/authentication.md
+++ b/skills/ai-shifu-course-creator/references/authentication.md
@@ -12,30 +12,36 @@ Use `scripts/shifu-cli.py`; never read tokens directly, construct authentication
 Run `verify` before deciding whether login is needed:
 
 - Exit `0`: continue the requested platform operation without logging in.
-- Exit `1`: run one SMS login session.
-- Exit `2`: report a network or service problem and retry `verify` later; do not send an SMS code.
+- Exit `1`: run one browser authorization session.
+- Exit `2`: report a network or service problem and retry `verify` later; do not start an authorization session.
 
 If any authenticated command returns token error `1001`, `1004`, or `1005`, run `verify` and apply the same decision again. After a successful login, run `verify` once before continuing.
 
-## Agent SMS Login Flow
+## Agent Browser Authorization Flow
 
-Protect the SMS quota: one phone number can receive at most five codes per day. Send one code per login session unless the user has entered three consecutive wrong codes.
+1. Run `login` exactly once.
+2. In one short turn, give the user the verification link exactly as printed and explain that opening it signs this device in, that the page shows which device is asking, and that they must press the approve button there. Mention that the link already carries the pairing code, that an account is created on first use, and that a browser session already signed in will not have to sign in again.
+3. Run `login --wait`.
+4. Act on the exit code:
+   - `0`: authorized and stored. Run `verify` once, then continue the original operation.
+   - `3`: still waiting. Ask the user to finish approving, then run `login --wait` again.
+   - `1`: denied, expired, or never started. Explain what happened, and start over with `login` only if the user wants to retry.
 
-1. In one short turn, explain that login uses SMS without a password, a four-digit code will arrive, the user should reply with it next, the saved local token completes login, and a new phone number creates an account on first use. Ask for the phone number in that same turn.
-2. Run `login --phone <phone>` exactly once.
-3. Ask only for the four-digit code.
-4. Run `login --phone <phone> --sms-code <code>`.
-5. On success, run `verify` once and continue the original operation.
+Do not insert readiness checks, account-status questions, acknowledgements, recaps, or other pauses between these steps.
 
-Do not insert readiness checks, account-status questions, acknowledgements, recaps, or other pauses between these steps. Each user turn supplies only the next required value.
-
-## SMS Failure Handling
+## Failure Handling
 
 | Result | Agent action |
 | --- | --- |
-| SMS send succeeds | Wait for the code; do not send another SMS. |
-| User asks to resend before entering three wrong codes | Explain that delivery can take 60 seconds and wait. |
-| `smsSendTooFrequent` | Wait 60 seconds, then retry the same command without asking for the phone again. |
-| First or second wrong code | Ask the user to re-enter the code; do not resend. |
-| Third consecutive wrong code | Run `login --phone <phone>` once more; this is the final SMS for the session. |
-| Login or verification has a network failure | Stop the login attempt and retry `verify` later; do not spend another SMS slot. |
+| `login` printed a link | Hand the link to the user unchanged and wait. Do not start a second request. |
+| `login --wait` exits `3` | Ask the user to approve in the browser, then run `login --wait` again. |
+| User says the page reports an invalid or expired code | Run `login` once more to issue a fresh link. |
+| User denied the request by mistake | Run `login` once more to issue a fresh link. |
+| Network failure during `login` or `login --wait` | Stop and retry `verify` later; do not open repeated authorization requests. |
+
+Never run `login` again while the user is still looking at an earlier link: a new request replaces the pending one on disk, so approving the older link would leave nothing to collect.
+
+## Never Do
+
+- Never print, echo, or repeat the contents of the credentials file.
+- Never ask the user for a phone number, verification code, or password. The CLI does not collect any of them, and no agent-driven flow needs them.

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -21,7 +21,7 @@ SHIFU_TOKEN=
 
 Change `SHIFU_BASE_URL` in the process environment or `{skillDir}/.env` to use another deployment. An unset, empty, whitespace-only, or slash-only value falls back to the default production URL. Leading and trailing whitespace and trailing slashes are removed from a custom value before requests and verification URLs are built. A process environment value takes precedence over the value loaded from `{skillDir}/.env`.
 
-Before every command, the CLI checks for `{skillDir}/.env`. When it is missing, the CLI copies `{skillDir}/.env.example` to `{skillDir}/.env`, sets owner-only permissions, and then loads it. An existing `.env` is never replaced, so an author or agent can change `SHIFU_BASE_URL` before requesting an SMS code. Successful SMS verification updates only `SHIFU_TOKEN` and preserves the configured base URL.
+Before every command, the CLI checks for `{skillDir}/.env`. When it is missing, the CLI copies `{skillDir}/.env.example` to `{skillDir}/.env`, sets owner-only permissions, and then loads it. An existing `.env` is never replaced, so an author or agent can change `SHIFU_BASE_URL` before starting an authorization request. The `.env` file holds configuration only; the issued token is stored separately under the user's config directory (see [Authentication](#authentication)).
 
 ## Contents
 
@@ -51,16 +51,18 @@ check-update [--force] [--dev-manifest-url <loopback-url>]
 
 ```bash
 verify
-login --phone 13800138000
-login --phone 13800138000 --sms-code 1234
+login
+login --wait [--timeout 120]
 ```
 
 - `verify` exits `0` when the token is accepted, `1` when it is expired or invalid, and `2` when network, service, or response errors make its state unknown.
-- `login --phone` sends an SMS code and exits without prompting.
-- `login --phone --sms-code` verifies the code and updates only `SHIFU_TOKEN=<jwt>` in `{skillDir}/.env`; other values such as `SHIFU_BASE_URL` are preserved.
-- A saved token is valid for seven days; successful authenticated API calls refresh that expiry.
+- `login` starts a browser authorization request and exits immediately. It prints the verification link and a pairing code, and opens a browser when the machine has one. The link already carries the pairing code, so the user normally does not type it.
+- `login --wait` polls the pending request. It exits `0` once the request is approved and the token is stored, `1` when the request was denied, expired, or never started, and `3` while the request is still valid but nobody has approved it yet. Exit `3` means the same command can simply be run again.
+- `--timeout` bounds a single `--wait` invocation in seconds; it does not shorten the request's own lifetime.
+- Credentials are stored in `${XDG_CONFIG_HOME:-~/.config}/ai-shifu/credentials.json` with owner-only permissions, so upgrading or reinstalling the skill no longer signs the user out. `AI_SHIFU_CONFIG_DIR` overrides that location. A token left in `{skillDir}/.env` by an older version is migrated on first run; an exported `SHIFU_TOKEN` is never rewritten and still takes precedence.
+- A stored token is valid for thirty days; successful authenticated API calls refresh that expiry.
 
-Agent decisions about when to send or resend SMS are defined in `../authentication.md`; this section defines only CLI inputs and effects.
+Agent behavior during a login session is defined in `../authentication.md`; this section defines only CLI inputs and effects.
 
 ## Query Commands
 

--- a/skills/ai-shifu-course-creator/references/cli/cli-reference.md
+++ b/skills/ai-shifu-course-creator/references/cli/cli-reference.md
@@ -59,6 +59,7 @@ login --wait [--timeout 120]
 - `login` starts a browser authorization request and exits immediately. It prints the verification link and a pairing code, and opens a browser when the machine has one. The link already carries the pairing code, so the user normally does not type it.
 - `login --wait` polls the pending request. It exits `0` once the request is approved and the token is stored, `1` when the request was denied, expired, or never started, and `3` while the request is still valid but nobody has approved it yet. Exit `3` means the same command can simply be run again.
 - `--timeout` bounds a single `--wait` invocation in seconds; it does not shorten the request's own lifetime.
+- `SHIFU_BASE_URL` must use `https`; only a loopback host may use `http`, for local development. Authorization carries credentials, so the CLI refuses to send them in the clear. A request is also bound to the host that issued it: changing `SHIFU_BASE_URL` between `login` and `login --wait` fails rather than sending the device code elsewhere.
 - Credentials are stored in `${XDG_CONFIG_HOME:-~/.config}/ai-shifu/credentials.json` with owner-only permissions, so upgrading or reinstalling the skill no longer signs the user out. `AI_SHIFU_CONFIG_DIR` overrides that location. A token left in `{skillDir}/.env` by an older version is migrated on first run; an exported `SHIFU_TOKEN` is never rewritten and still takes precedence.
 - A stored token is valid for thirty days; successful authenticated API calls refresh that expiry.
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -546,16 +546,42 @@ def _login_post(base_url, path, payload, error_prefix):
     return data
 
 
+def _friendly_os_name():
+    """Name the operating system the way its owner would.
+
+    The approval page exists so a person can recognise their own machine, so it
+    must not show what `platform.release()` returns on macOS: that is the Darwin
+    kernel version ("25.5.0"), which no Mac owner recognises.
+    """
+    system = (platform.system() or "").strip()
+    if system == "Darwin":
+        release = ""
+        try:
+            release = (platform.mac_ver()[0] or "").strip()
+        except Exception:  # noqa: BLE001 - display only, never fail login
+            release = ""
+        return f"macOS {release}".strip() if release else "macOS"
+    if system == "Linux":
+        pretty = ""
+        try:
+            pretty = (
+                platform.freedesktop_os_release().get("PRETTY_NAME", "") or ""
+            ).strip()
+        except Exception:  # noqa: BLE001 - not every distro ships os-release
+            pretty = ""
+        if pretty:
+            return pretty
+    release = (platform.release() or "").strip()
+    return f"{system} {release}".strip() or "unknown"
+
+
 def _device_description():
     """Describe this machine for the approval page. Display only."""
     try:
         device_name = socket.gethostname() or "unknown"
     except OSError:
         device_name = "unknown"
-    system = (platform.system() or "").strip()
-    release = (platform.release() or "").strip()
-    device_os = f"{system} {release}".strip() or "unknown"
-    return device_name[:64], device_os[:64]
+    return device_name[:64], _friendly_os_name()[:64]
 
 
 def _client_version():

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -12,11 +12,13 @@ import platform
 import shutil
 import socket
 import sys
+import tempfile
 import time
 import uuid
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 from dotenv import dotenv_values, load_dotenv, set_key
@@ -89,10 +91,29 @@ def load_env():
     migrate_legacy_token()
 
 
+# Loopback stays available over http so the CLI can be pointed at a local
+# development server; every other host must use TLS.
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
 def resolve_base_url():
     """Resolve the AI-Shifu service URL with the production URL as fallback."""
     value = os.environ.get("SHIFU_BASE_URL", "").strip().rstrip(" /\t\r\n")
     return value or DEFAULT_BASE_URL
+
+
+def require_secure_base_url(base_url):
+    """Refuse to carry the device code or token over plaintext HTTP."""
+    parsed = urlparse(base_url)
+    if parsed.scheme == "https":
+        return base_url
+    if parsed.scheme == "http" and (parsed.hostname or "") in LOOPBACK_HOSTS:
+        return base_url
+    print(
+        f"Error: SHIFU_BASE_URL must use https, got '{base_url}'. "
+        "Authorization carries credentials and will not be sent in the clear."
+    )
+    sys.exit(1)
 
 
 def config_dir():
@@ -120,10 +141,24 @@ def pending_auth_path():
 
 
 def _write_private_json(path, payload):
-    """Write JSON readable only by the current user."""
+    """Write JSON readable only by the current user, atomically.
+
+    The content is written to a fresh 0600 temporary file and moved into place.
+    Writing directly would expose the credential twice: a permissive umask
+    leaves the new file readable until the chmod lands, and rewriting an
+    existing file keeps whatever mode it already had while it is truncated.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.chmod(path, 0o600)
+    fd, temp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-")
+    try:
+        os.chmod(temp_name, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        os.replace(temp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(temp_name)
+        raise
 
 
 def _read_json_file(path):
@@ -190,7 +225,8 @@ def _jwt_payload(token):
 def resolve_auth(args):
     """Resolve the service URL and token from CLI args or .env.
 
-    When the JWT carries a ``time_stamp`` older than 7 days, a warning is printed
+    When the JWT carries a ``time_stamp`` older than the token lifetime, a
+    warning is printed
     to stderr (the authoritative expiry check is the backend's DB record, so this
     is only a nudge — the call still proceeds).
     """
@@ -208,7 +244,8 @@ def resolve_auth(args):
     if isinstance(payload, dict):
         ts = payload.get("time_stamp")
         if isinstance(ts, (int, float)) and (time.time() - ts) > TOKEN_EXPIRE_SECONDS:
-            print("Warning: token may be expired (issued > 7 days ago). "
+            print("Warning: token may be expired "
+                  f"(issued > {TOKEN_EXPIRE_SECONDS // 86400} days ago). "
                   "Run `shifu-cli.py verify` to check, or `shifu-cli.py login` "
                   "to re-login.",
                   file=sys.stderr)
@@ -658,6 +695,10 @@ def _start_device_authorization(base_url):
         {
             "device_code": device_code,
             "user_code": user_code,
+            # Remember which host issued this code. Polling a different host
+            # after SHIFU_BASE_URL changed would hand the code to a service
+            # that never issued it.
+            "base_url": base_url,
             "interval": int(data.get("interval") or 5),
             "expires_at": time.time() + int(data.get("expires_in") or 600),
         },
@@ -682,6 +723,15 @@ def _wait_for_device_authorization(base_url, timeout_seconds):
     pending = _read_json_file(pending_auth_path())
     if not isinstance(pending, dict) or not pending.get("device_code"):
         print("No authorization is in progress. Run 'shifu-cli.py login' first.")
+        sys.exit(1)
+
+    issuing_base_url = str(pending.get("base_url") or "")
+    if issuing_base_url and issuing_base_url != base_url:
+        print(
+            "Error: SHIFU_BASE_URL changed since this authorization started "
+            f"('{issuing_base_url}' -> '{base_url}'). "
+            "Run 'shifu-cli.py login' again to start a new one."
+        )
         sys.exit(1)
 
     device_code = str(pending.get("device_code") or "")
@@ -725,7 +775,7 @@ def _wait_for_device_authorization(base_url, timeout_seconds):
 
 def cmd_login(args):
     """Authorize this device through the browser and store the issued token."""
-    base_url = resolve_base_url()
+    base_url = require_secure_base_url(resolve_base_url())
     if getattr(args, "wait", False):
         _wait_for_device_authorization(base_url, getattr(args, "timeout", 120))
         return

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -3,19 +3,23 @@
 
 import argparse
 import base64
+import contextlib
 import hashlib
 import json
 import math
 import os
+import platform
 import shutil
+import socket
 import sys
 import time
 import uuid
+import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
-from dotenv import load_dotenv, set_key
+from dotenv import dotenv_values, load_dotenv, set_key
 
 from skill_update import DEV_CACHE_FILE, check_for_update
 
@@ -47,10 +51,14 @@ DRAFT_CONFLICT_CODE = 4007
 #   0 = success, 1 = hard error (api() default), 2 = conflict auto-pulled, redo
 EXIT_CONFLICT = 2
 
-# Token lifetime (matches backend TOKEN_EXPIRE_TIME = 604800 = 7 days) and the
+# `login --wait` returns this when the request is still valid but nobody has
+# approved it yet, so a caller can distinguish "keep waiting" from a failure.
+EXIT_AUTH_PENDING = 3
+
+# Token lifetime (matches backend TOKEN_EXPIRE_TIME = 2592000 = 30 days) and the
 # backend error codes that mean "token is not usable" — used by `verify` and the
 # resolve_auth() early-expiry hint.
-TOKEN_EXPIRE_SECONDS = 604800
+TOKEN_EXPIRE_SECONDS = 2592000
 _TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
 # 1001 = userNotFound, 1004 = userNotLogin, 1005 = userTokenExpired
 
@@ -78,6 +86,7 @@ def load_env():
     """Ensure and load environment variables from the skill's .env file."""
     ensure_env_file()
     load_dotenv(dotenv_path=ENV_FILE, override=False)
+    migrate_legacy_token()
 
 
 def resolve_base_url():
@@ -86,14 +95,78 @@ def resolve_base_url():
     return value or DEFAULT_BASE_URL
 
 
-def save_env(token):
-    """Persist token to the skill's .env file."""
-    env_path = str(ENV_FILE)
-    if not ENV_FILE.exists():
-        ENV_FILE.parent.mkdir(parents=True, exist_ok=True)
-        ENV_FILE.touch(mode=0o600)
-    set_key(env_path, "SHIFU_TOKEN", token)
-    os.chmod(env_path, 0o600)
+def config_dir():
+    """Return the directory holding credentials for this user.
+
+    Credentials live outside the skill package so upgrading or reinstalling the
+    skill does not silently sign the user out, which is what happened while the
+    token was kept in the package's own .env file. The location follows the XDG
+    convention other command-line tools use (~/.config/gh, ~/.config/anthropic).
+    """
+    override = os.environ.get("AI_SHIFU_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    xdg_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg_home).expanduser() if xdg_home else Path.home() / ".config"
+    return base / "ai-shifu"
+
+
+def credentials_path():
+    return config_dir() / "credentials.json"
+
+
+def pending_auth_path():
+    return config_dir() / "pending-device-auth.json"
+
+
+def _write_private_json(path, payload):
+    """Write JSON readable only by the current user."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def _read_json_file(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def load_saved_token():
+    """Return the stored token, or an empty string when there is none."""
+    data = _read_json_file(credentials_path())
+    if isinstance(data, dict):
+        token = data.get("token")
+        if isinstance(token, str):
+            return token.strip()
+    return ""
+
+
+def save_token(token):
+    """Persist the issued token to the user's config directory."""
+    _write_private_json(credentials_path(), {"token": token})
+
+
+def migrate_legacy_token():
+    """Move a token written by an older CLI into the config directory.
+
+    Only the .env file is inspected, never the environment: a SHIFU_TOKEN the
+    user exported themselves belongs to them and must not be rewritten.
+    """
+    if load_saved_token() or not ENV_FILE.exists():
+        return
+    try:
+        legacy_token = (dotenv_values(str(ENV_FILE)) or {}).get("SHIFU_TOKEN") or ""
+    except OSError:
+        return
+    legacy_token = legacy_token.strip()
+    if not legacy_token:
+        return
+    save_token(legacy_token)
+    # Leave a single source of truth behind.
+    with contextlib.suppress(OSError):
+        set_key(str(ENV_FILE), "SHIFU_TOKEN", "")
 
 
 def _jwt_payload(token):
@@ -121,10 +194,14 @@ def resolve_auth(args):
     to stderr (the authoritative expiry check is the backend's DB record, so this
     is only a nudge — the call still proceeds).
     """
-    token = getattr(args, "token", None) or os.environ.get("SHIFU_TOKEN")
+    token = (
+        getattr(args, "token", None)
+        or os.environ.get("SHIFU_TOKEN")
+        or load_saved_token()
+    )
     if not token:
         print("Error: no token available. Run 'shifu-cli.py login' first, "
-              "or use --token / set SHIFU_TOKEN in .env")
+              "or use --token / set SHIFU_TOKEN")
         sys.exit(1)
 
     payload = _jwt_payload(token)
@@ -469,44 +546,164 @@ def _login_post(base_url, path, payload, error_prefix):
     return data
 
 
-def cmd_login(args):
-    """SMS login and save token (non-interactive two-step flow)."""
-    base_url = resolve_base_url()
+def _device_description():
+    """Describe this machine for the approval page. Display only."""
+    try:
+        device_name = socket.gethostname() or "unknown"
+    except OSError:
+        device_name = "unknown"
+    system = (platform.system() or "").strip()
+    release = (platform.release() or "").strip()
+    device_os = f"{system} {release}".strip() or "unknown"
+    return device_name[:64], device_os[:64]
 
-    phone = args.phone
-    if not phone:
-        print("Error: --phone is required for login")
+
+def _client_version():
+    try:
+        from skill_update import SKILL_MD, read_skill_metadata
+
+        metadata = read_skill_metadata(SKILL_MD)
+    except Exception:  # noqa: BLE001 - version is cosmetic, never fail login
+        return ""
+    if isinstance(metadata, dict):
+        return str(metadata.get("version") or "")[:32]
+    return ""
+
+
+def _poll_device_authorization(base_url, device_code):
+    """Ask the backend once; transient failures read as "still pending"."""
+    try:
+        resp = requests.post(
+            f"{base_url}/api/user/device/token",
+            json={"device_code": device_code},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+    except requests.RequestException:
+        return "pending", ""
+    if not resp.ok:
+        return "pending", ""
+    try:
+        body = resp.json()
+    except ValueError:
+        return "pending", ""
+    if not isinstance(body, dict):
+        return "pending", ""
+    if body.get("code") != 0:
+        # The request is gone: expired, already collected, or never existed.
+        return "expired", ""
+    data = body.get("data")
+    if not isinstance(data, dict):
+        return "pending", ""
+    return str(data.get("status") or "pending"), str(data.get("token") or "")
+
+
+def _start_device_authorization(base_url):
+    device_name, device_os = _device_description()
+    response = _login_post(
+        base_url,
+        "/api/user/device/authorize",
+        {
+            "device_name": device_name,
+            "device_os": device_os,
+            "client_version": _client_version(),
+        },
+        "Failed to start authorization",
+    )
+    data = response.get("data")
+    if not isinstance(data, dict):
+        print(f"Unexpected authorization response: {response}")
         sys.exit(1)
 
-    sms_code = args.sms_code
-    masked = phone[:3] + "****" + phone[-4:] if len(phone) >= 7 else phone
+    device_code = str(data.get("device_code") or "")
+    user_code = str(data.get("user_code") or "")
+    url = str(
+        data.get("verification_uri_complete") or data.get("verification_uri") or ""
+    )
+    if not device_code or not user_code or not url:
+        print(f"Incomplete authorization response: {data}")
+        sys.exit(1)
 
-    if sms_code:
-        # Step 2: Verify code and save token
-        print("Verifying code...")
-        data = _login_post(base_url, "/api/user/login_sms",
-                           {"mobile": phone, "sms_code": sms_code, "login_context": "admin"}, "Verification failed")
+    # The device code can be exchanged for a token once the request is
+    # approved, so it is stored with owner-only permissions rather than
+    # printed: printing would copy it into the calling agent's transcript.
+    _write_private_json(
+        pending_auth_path(),
+        {
+            "device_code": device_code,
+            "user_code": user_code,
+            "interval": int(data.get("interval") or 5),
+            "expires_at": time.time() + int(data.get("expires_in") or 600),
+        },
+    )
 
-        token = data.get("data")
-        if not token:
-            print(f"No token in response: {data}")
+    opened = False
+    with contextlib.suppress(Exception):
+        opened = bool(webbrowser.open(url))
+
+    print("Open this link in a browser to authorize this device:")
+    print(f"  {url}")
+    print(f"Pairing code: {user_code}")
+    if opened:
+        print("A browser window was opened on this machine.")
+    print(
+        "After approving it there, run 'shifu-cli.py login --wait' "
+        "to finish signing in."
+    )
+
+
+def _wait_for_device_authorization(base_url, timeout_seconds):
+    pending = _read_json_file(pending_auth_path())
+    if not isinstance(pending, dict) or not pending.get("device_code"):
+        print("No authorization is in progress. Run 'shifu-cli.py login' first.")
+        sys.exit(1)
+
+    device_code = str(pending.get("device_code") or "")
+    interval = max(1, int(pending.get("interval") or 5))
+    expires_at = float(pending.get("expires_at") or 0)
+    deadline = time.time() + max(1, int(timeout_seconds))
+    if expires_at:
+        deadline = min(deadline, expires_at)
+
+    while True:
+        status, token = _poll_device_authorization(base_url, device_code)
+        if status == "approved" and token:
+            save_token(token)
+            with contextlib.suppress(OSError):
+                pending_auth_path().unlink()
+            print(f"Authorization complete. Credentials saved to {credentials_path()}")
+            return
+        if status == "denied":
+            with contextlib.suppress(OSError):
+                pending_auth_path().unlink()
+            print("The request was denied in the browser. Nothing was authorized.")
             sys.exit(1)
-        # API may return token as a dict (e.g. {"token": "..."}) or a plain string
-        if isinstance(token, dict):
-            token = token.get("token", "")
-        if not token:
-            print(f"No token string found in response data: {data}")
+        if status == "expired":
+            with contextlib.suppress(OSError):
+                pending_auth_path().unlink()
+            print(
+                "The authorization request expired. "
+                "Run 'shifu-cli.py login' to start a new one."
+            )
             sys.exit(1)
+        if time.time() + interval >= deadline:
+            break
+        time.sleep(interval)
 
-        save_env(token)
-        print(f"Login successful! Token saved to {ENV_FILE}")
-    else:
-        # Step 1: Send SMS code only, then exit
-        print(f"Sending SMS code to {masked}...")
-        _login_post(base_url, "/api/user/console_send_sms_code",
-                    {"mobile": phone}, "Failed to send SMS")
-        print(f"SMS code sent to {masked}. "
-              f"Run again with --sms-code <4-digit-code> to complete login.")
+    print(
+        "Still waiting for approval in the browser. Approve the request, "
+        "then run 'shifu-cli.py login --wait' again."
+    )
+    sys.exit(EXIT_AUTH_PENDING)
+
+
+def cmd_login(args):
+    """Authorize this device through the browser and store the issued token."""
+    base_url = resolve_base_url()
+    if getattr(args, "wait", False):
+        _wait_for_device_authorization(base_url, getattr(args, "timeout", 120))
+        return
+    _start_device_authorization(base_url)
 
 
 # ── Verify Token ────────────────────────────────────────────────────────────────
@@ -2832,10 +3029,11 @@ def build_parser():
 
     # ── login ──
     p = sub.add_parser("login", parents=[parent_parser],
-                       help="SMS login and save token")
-    p.add_argument("--phone", required=True, help="Phone number for SMS login")
-    p.add_argument("--sms-code", default=None,
-                   help="4-digit SMS verification code")
+                       help="Authorize this device through the browser")
+    p.add_argument("--wait", action="store_true",
+                   help="Wait for the pending authorization to be approved")
+    p.add_argument("--timeout", type=int, default=120,
+                   help="Seconds to keep polling when used with --wait")
 
     # ── verify ──
     sub.add_parser("verify", parents=[parent_parser],

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import json
 import sys
 import tempfile
 import types
@@ -223,6 +224,86 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
 
         self.assertEqual(exit_ctx.exception.code, 1)
         self.assertIn("login", stdout.getvalue())
+
+    def test_plaintext_base_url_is_refused(self):
+        """Authorization carries credentials, so it must not go over http."""
+        with self.assertRaises(SystemExit) as exit_ctx, contextlib.redirect_stdout(
+            io.StringIO()
+        ) as stdout:
+            course_creator_cli.require_secure_base_url("http://example.test")
+        self.assertEqual(exit_ctx.exception.code, 1)
+        self.assertIn("https", stdout.getvalue())
+
+    def test_loopback_may_stay_plaintext_for_local_development(self):
+        for url in ("http://localhost:5800", "http://127.0.0.1:5800"):
+            self.assertEqual(course_creator_cli.require_secure_base_url(url), url)
+
+    def test_https_base_url_is_accepted(self):
+        url = "https://app.ai-shifu.cn"
+        self.assertEqual(course_creator_cli.require_secure_base_url(url), url)
+
+    def test_wait_refuses_a_device_code_issued_by_another_host(self):
+        """The device code belongs to the host that issued it."""
+        args = types.SimpleNamespace(wait=True, timeout=30)
+        with (
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": "https://other.example"},
+                clear=True,
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_read_json_file",
+                return_value={
+                    "device_code": "secret",
+                    "base_url": "https://original.example",
+                    "interval": 1,
+                },
+            ),
+            mock.patch.object(
+                course_creator_cli, "_poll_device_authorization"
+            ) as poll,
+            contextlib.redirect_stdout(io.StringIO()),
+            self.assertRaises(SystemExit) as exit_ctx,
+        ):
+            course_creator_cli.cmd_login(args)
+
+        self.assertEqual(exit_ctx.exception.code, 1)
+        poll.assert_not_called()
+
+    def test_credentials_end_up_owner_only(self):
+        """The credential file is owner-only, however permissive the umask."""
+        original_umask = course_creator_cli.os.umask(0o000)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                target = Path(tmp) / "credentials.json"
+                course_creator_cli._write_private_json(target, {"token": "secret"})
+                self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+                # Rewriting an existing file must not leave it wider either.
+                course_creator_cli._write_private_json(target, {"token": "second"})
+                self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+        finally:
+            course_creator_cli.os.umask(original_umask)
+
+    def test_credentials_are_moved_into_place_rather_than_written_in_situ(self):
+        """The mode is only safe if the file is private before it holds data.
+
+        Checking the final mode cannot show that: writing in place and then
+        chmod-ing also ends at 0600, while leaving the secret readable in
+        between. This asserts the implementation instead.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "credentials.json"
+            real_replace = course_creator_cli.os.replace
+            with mock.patch.object(
+                course_creator_cli.os, "replace", wraps=real_replace
+            ) as replace:
+                course_creator_cli._write_private_json(target, {"token": "secret"})
+
+            replace.assert_called_once()
+            source = replace.call_args[0][0]
+            self.assertNotEqual(str(source), str(target))
+            self.assertEqual(json.loads(target.read_text())["token"], "secret")
 
     def test_macos_is_named_the_way_its_owner_would(self):
         """The approval page must not show the Darwin kernel version."""

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -224,6 +224,42 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
         self.assertEqual(exit_ctx.exception.code, 1)
         self.assertIn("login", stdout.getvalue())
 
+    def test_macos_is_named_the_way_its_owner_would(self):
+        """The approval page must not show the Darwin kernel version."""
+        with (
+            mock.patch.object(course_creator_cli.platform, "system", return_value="Darwin"),
+            mock.patch.object(course_creator_cli.platform, "release", return_value="25.5.0"),
+            mock.patch.object(
+                course_creator_cli.platform, "mac_ver", return_value=("15.5", "", "")
+            ),
+        ):
+            self.assertEqual(course_creator_cli._friendly_os_name(), "macOS 15.5")
+
+    def test_linux_prefers_the_distribution_name(self):
+        with (
+            mock.patch.object(course_creator_cli.platform, "system", return_value="Linux"),
+            mock.patch.object(
+                course_creator_cli.platform,
+                "freedesktop_os_release",
+                return_value={"PRETTY_NAME": "Ubuntu 24.04.1 LTS"},
+            ),
+        ):
+            self.assertEqual(
+                course_creator_cli._friendly_os_name(), "Ubuntu 24.04.1 LTS"
+            )
+
+    def test_os_name_falls_back_without_failing_login(self):
+        with (
+            mock.patch.object(course_creator_cli.platform, "system", return_value="Linux"),
+            mock.patch.object(
+                course_creator_cli.platform,
+                "freedesktop_os_release",
+                side_effect=OSError("no os-release"),
+            ),
+            mock.patch.object(course_creator_cli.platform, "release", return_value="6.8.0"),
+        ):
+            self.assertEqual(course_creator_cli._friendly_os_name(), "Linux 6.8.0")
+
     def test_credentials_live_outside_the_skill_package(self):
         with tempfile.TemporaryDirectory() as tmp:
             with mock.patch.dict(

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -22,6 +22,7 @@ if "dotenv" not in sys.modules:
     dotenv_stub = types.ModuleType("dotenv")
     dotenv_stub.load_dotenv = lambda **_kwargs: None
     dotenv_stub.set_key = lambda *_args, **_kwargs: None
+    dotenv_stub.dotenv_values = lambda *_args, **_kwargs: {}
     sys.modules["dotenv"] = dotenv_stub
 
 spec = importlib.util.spec_from_file_location("course_creator_cli", SCRIPT_PATH)
@@ -115,106 +116,8 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
             self.assertEqual(raised.exception.code, 1)
             self.assertIn("missing environment template", stderr.getvalue())
 
-    def test_save_env_updates_only_the_token_key(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            env_file = Path(tmp) / ".env"
-            env_file.write_text(
-                "SHIFU_BASE_URL=https://custom.example\nSHIFU_TOKEN=\n",
-                encoding="utf-8",
-            )
-
-            with (
-                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
-                mock.patch.object(course_creator_cli, "set_key") as set_key,
-            ):
-                course_creator_cli.save_env("new-token")
-
-            set_key.assert_called_once_with(
-                str(env_file), "SHIFU_TOKEN", "new-token"
-            )
-
-    def test_default_base_url_is_used_for_missing_or_empty_configuration(self):
-        for configured in (
-            None, "", "   ", "/", "///", "  ///  ", " / / ", "\t/\t/\n"
-        ):
-            env = {} if configured is None else {"SHIFU_BASE_URL": configured}
-            with self.subTest(configured=configured), mock.patch.dict(
-                course_creator_cli.os.environ, env, clear=True
-            ):
-                self.assertEqual(
-                    course_creator_cli.resolve_base_url(),
-                    course_creator_cli.DEFAULT_BASE_URL,
-                )
-
-    def test_custom_base_url_is_trimmed_and_trailing_slashes_are_removed(self):
-        for configured in (
-            "  https://example.test///  ",
-            "https://example.test/ /",
-            "https://example.test/\t/\n",
-        ):
-            with self.subTest(configured=configured), mock.patch.dict(
-                course_creator_cli.os.environ,
-                {"SHIFU_BASE_URL": configured},
-                clear=True,
-            ):
-                self.assertEqual(
-                    course_creator_cli.resolve_base_url(), "https://example.test"
-                )
-
-    def test_resolve_auth_returns_custom_base_url_and_existing_token(self):
-        with mock.patch.dict(
-            course_creator_cli.os.environ,
-            {
-                "SHIFU_BASE_URL": "https://example.test/",
-                "SHIFU_TOKEN": "stored-token",
-            },
-            clear=True,
-        ):
-            self.assertEqual(
-                course_creator_cli.resolve_auth(types.SimpleNamespace(token=None)),
-                ("https://example.test", "stored-token"),
-            )
-
-    def test_explicit_token_still_overrides_the_stored_token(self):
-        with mock.patch.dict(
-            course_creator_cli.os.environ,
-            {
-                "SHIFU_BASE_URL": "https://example.test",
-                "SHIFU_TOKEN": "stored-token",
-            },
-            clear=True,
-        ):
-            self.assertEqual(
-                course_creator_cli.resolve_auth(
-                    types.SimpleNamespace(token="explicit-token")
-                ),
-                ("https://example.test", "explicit-token"),
-            )
-
-    def test_login_send_uses_custom_base_url(self):
-        args = types.SimpleNamespace(phone="13800138000", sms_code=None)
-        with (
-            mock.patch.dict(
-                course_creator_cli.os.environ,
-                {"SHIFU_BASE_URL": "https://example.test/"},
-                clear=True,
-            ),
-            mock.patch.object(
-                course_creator_cli, "_login_post", return_value={"code": 0}
-            ) as login_post,
-            contextlib.redirect_stdout(io.StringIO()),
-        ):
-            course_creator_cli.cmd_login(args)
-
-        login_post.assert_called_once_with(
-            "https://example.test",
-            "/api/user/console_send_sms_code",
-            {"mobile": "13800138000"},
-            "Failed to send SMS",
-        )
-
-    def test_login_verification_uses_custom_base_url_and_saves_token(self):
-        args = types.SimpleNamespace(phone="13800138000", sms_code="1234")
+    def test_login_starts_device_authorization_on_custom_base_url(self):
+        args = types.SimpleNamespace(wait=False, timeout=120)
         with (
             mock.patch.dict(
                 course_creator_cli.os.environ,
@@ -224,24 +127,162 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
             mock.patch.object(
                 course_creator_cli,
                 "_login_post",
-                return_value={"code": 0, "data": "new-token"},
+                return_value={
+                    "code": 0,
+                    "data": {
+                        "device_code": "secret-device-code",
+                        "user_code": "AC4-7HK",
+                        "verification_uri_complete": "https://example.test/login/device?code=AC4-7HK",
+                        "interval": 5,
+                        "expires_in": 600,
+                    },
+                },
             ) as login_post,
-            mock.patch.object(course_creator_cli, "save_env") as save_env,
+            mock.patch.object(course_creator_cli, "_write_private_json") as write_json,
+            mock.patch.object(course_creator_cli.webbrowser, "open", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            course_creator_cli.cmd_login(args)
+
+        called_base_url, called_path, payload, _ = login_post.call_args[0]
+        self.assertEqual(called_base_url, "https://example.test")
+        self.assertEqual(called_path, "/api/user/device/authorize")
+        self.assertIn("device_name", payload)
+
+        printed = stdout.getvalue()
+        self.assertIn("AC4-7HK", printed)
+        # The device code can be exchanged for a token, so it must stay on disk
+        # and out of the calling agent's transcript.
+        self.assertNotIn("secret-device-code", printed)
+        stored = write_json.call_args[0][1]
+        self.assertEqual(stored["device_code"], "secret-device-code")
+
+    def test_login_wait_saves_the_token_once_approved(self):
+        args = types.SimpleNamespace(wait=True, timeout=30)
+        with (
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": "https://example.test/"},
+                clear=True,
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_read_json_file",
+                return_value={
+                    "device_code": "secret-device-code",
+                    "user_code": "AC4-7HK",
+                    "interval": 1,
+                    "expires_at": course_creator_cli.time.time() + 600,
+                },
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_poll_device_authorization",
+                return_value=("approved", "new-token"),
+            ) as poll,
+            mock.patch.object(course_creator_cli, "save_token") as save_token,
+            mock.patch.object(course_creator_cli.Path, "unlink"),
             contextlib.redirect_stdout(io.StringIO()),
         ):
             course_creator_cli.cmd_login(args)
 
-        login_post.assert_called_once_with(
-            "https://example.test",
-            "/api/user/login_sms",
-            {
-                "mobile": "13800138000",
-                "sms_code": "1234",
-                "login_context": "admin",
-            },
-            "Verification failed",
-        )
-        save_env.assert_called_once_with("new-token")
+        poll.assert_called_once_with("https://example.test", "secret-device-code")
+        save_token.assert_called_once_with("new-token")
+
+    def test_login_wait_reports_a_denied_request(self):
+        args = types.SimpleNamespace(wait=True, timeout=30)
+        with (
+            mock.patch.object(
+                course_creator_cli,
+                "_read_json_file",
+                return_value={"device_code": "secret", "interval": 1},
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_poll_device_authorization",
+                return_value=("denied", ""),
+            ),
+            mock.patch.object(course_creator_cli, "save_token") as save_token,
+            mock.patch.object(course_creator_cli.Path, "unlink"),
+            contextlib.redirect_stdout(io.StringIO()),
+            self.assertRaises(SystemExit) as exit_ctx,
+        ):
+            course_creator_cli.cmd_login(args)
+
+        self.assertEqual(exit_ctx.exception.code, 1)
+        save_token.assert_not_called()
+
+    def test_login_wait_without_a_pending_request_fails_clearly(self):
+        args = types.SimpleNamespace(wait=True, timeout=30)
+        with (
+            mock.patch.object(course_creator_cli, "_read_json_file", return_value=None),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+            self.assertRaises(SystemExit) as exit_ctx,
+        ):
+            course_creator_cli.cmd_login(args)
+
+        self.assertEqual(exit_ctx.exception.code, 1)
+        self.assertIn("login", stdout.getvalue())
+
+    def test_credentials_live_outside_the_skill_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"AI_SHIFU_CONFIG_DIR": tmp},
+                clear=True,
+            ):
+                course_creator_cli.save_token("stored-token")
+                self.assertEqual(course_creator_cli.load_saved_token(), "stored-token")
+                path = course_creator_cli.credentials_path()
+
+            self.assertTrue(str(path).startswith(tmp))
+            # Owner-only permissions: the file holds a live credential.
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
+    def test_legacy_token_is_migrated_out_of_the_env_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / ".env"
+            env_file.write_text("SHIFU_TOKEN=legacy-token\n", encoding="utf-8")
+            config_dir = Path(tmp) / "config"
+
+            with (
+                mock.patch.dict(
+                    course_creator_cli.os.environ,
+                    {"AI_SHIFU_CONFIG_DIR": str(config_dir)},
+                    clear=True,
+                ),
+                mock.patch.object(course_creator_cli, "ENV_FILE", env_file),
+                mock.patch.object(
+                    course_creator_cli,
+                    "dotenv_values",
+                    return_value={"SHIFU_TOKEN": "legacy-token"},
+                ),
+                mock.patch.object(course_creator_cli, "set_key") as set_key,
+            ):
+                course_creator_cli.migrate_legacy_token()
+                self.assertEqual(course_creator_cli.load_saved_token(), "legacy-token")
+
+            set_key.assert_called_once_with(str(env_file), "SHIFU_TOKEN", "")
+
+    def test_migration_never_rewrites_an_exported_token(self):
+        """A SHIFU_TOKEN the user exported is theirs; only the .env is migrated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            config_dir = Path(tmp) / "config"
+            missing_env = Path(tmp) / "absent.env"
+
+            with (
+                mock.patch.dict(
+                    course_creator_cli.os.environ,
+                    {
+                        "AI_SHIFU_CONFIG_DIR": str(config_dir),
+                        "SHIFU_TOKEN": "exported-token",
+                    },
+                    clear=True,
+                ),
+                mock.patch.object(course_creator_cli, "ENV_FILE", missing_env),
+            ):
+                course_creator_cli.migrate_legacy_token()
+                self.assertEqual(course_creator_cli.load_saved_token(), "")
 
 
 class CourseCreatorCliPaginationTests(unittest.TestCase):


### PR DESCRIPTION
## Why

`login` asked for a phone number and a texted verification code, which reached
the backend through an endpoint that exists only for this CLI and deliberately
skips the image captcha the web login requires. Anyone could use it to deliver
SMS to any number. Sign-in now happens in the browser, where the normal login
protections already apply, and the CLI never sends a text message.

A second problem is fixed along the way: the token lived in the skill's own
`.env`, so upgrading or reinstalling the skill silently signed the user out.
That is likely the main reason sign-in felt so frequent.

## What changes

`login` starts an authorization request, prints the verification link and
pairing code, and exits. `login --wait` collects the token once the user
approves the request in the browser. Splitting it in two matters for an agent:
a single blocking command would hold the link until it returned, so the user
would never see it while waiting.

The device code that can be exchanged for the token is written to an
owner-only file rather than printed, so it does not end up in the calling
agent's transcript. `--wait` exits `0` when authorized, `1` when the request
was denied or expired, and `3` while approval is still pending, so a caller can
tell "keep waiting" apart from a failure.

Credentials move to `${XDG_CONFIG_HOME:-~/.config}/ai-shifu/credentials.json`
with owner-only permissions, matching where comparable tools keep theirs
(`~/.config/gh`, `~/.config/anthropic`). A token written by an older version is
migrated on first run; a `SHIFU_TOKEN` the user exported themselves is never
rewritten and still takes precedence.

The reported system name is the one its owner would recognise: `platform.release()`
returns the Darwin kernel version on macOS, so a Mac appeared on the approval
page as "Darwin 25.5.0" instead of "macOS 15.5". The approval page exists so a
person can recognise their own machine, and a kernel version does not let them.

## Verification

Run end to end against the dev01 test environment: `login` started a request,
the approval page showed this machine's real details, a human approved it, and
`login --wait` stored a token that then listed real courses. Also checked that
the device code stays out of stdout, the credential file is owner-only, the
pending file is cleaned up, a collected request cannot be collected twice, and
`--wait` returns 3 before approval.

204 tests pass.

## Note

The backend and approval page are in ai-shifu#2720. This CLI needs that change
deployed before `login` works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced SMS-based sign-in with browser authorization using a verification link and pairing code.
  * Added `login --wait` with configurable waiting time and clearer approval, denial, and expiration handling.
  * Credentials are now stored securely in the user’s configuration directory.
  * Existing credentials are migrated automatically, helping preserve sign-in status across upgrades.
  * Authentication tokens now remain valid for up to 30 days.

* **Documentation**
  * Updated CLI, authentication, environment setup, and changelog documentation for the new sign-in process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->