### PR TITLE
feat: attribute Lobster course creation handoffs

### DIFF
--- a/skills/ai-shifu-course-creator/CHANGELOG.md
+++ b/skills/ai-shifu-course-creator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Attribute new registrations and courses created by `create` or `import
+  --new` to the Lobster AI-assisted workflow with a generated cross-system
+  handoff identifier, without reclassifying existing users or existing-course
+  imports.
 - Remove the complete local, artifact-only, author-only course path so a full-course request continues through deployment and publication by default.
 - Open browser URLs in new visible tabs, reusing only exact URL matches so existing pages and unfinished work are preserved.
 - Share built-in browser URL opening across authorization and course handoffs, including host selection, visible interaction, user opt-outs, and opening result handling.

--- a/skills/ai-shifu-course-creator/references/deployment-workflow.md
+++ b/skills/ai-shifu-course-creator/references/deployment-workflow.md
@@ -30,6 +30,10 @@ Existing-course edits and standalone platform-management operations are outside 
 ## Preconditions
 
 - Complete `authentication.md`.
+- Browser authorization carries a generated Lobster handoff identifier. The
+  platform records it as registration attribution only when authorization
+  results in a newly registered account; signing an existing account into the
+  CLI does not change that account's registration source.
 - Confirm the resolved target is `new`.
 - Provide a course directory that conforms to `cli/course-directory-spec.md`, including lesson files. Require a completed `course-prompt.md` for a content-complete deployment; when it is missing, complete the applicable conditional authoring reference before building. A missing course description keeps the CLI's existing empty-description fallback unless the author requests non-empty listing copy. This workflow consumes final artifacts; it does not define their content.
 - Complete the source-file checks in `language-policy.md#language-audit` before the first platform mutation.
@@ -43,7 +47,12 @@ Existing-course edits and standalone platform-management operations are outside 
 5. Before first publication, apply only explicitly selected platform-attribute operations through the conditional management reference, always passing the synchronized `--course-dir <dir>`. This includes enabling Listen Mode by running `set-tts <shifu_bid> --enabled true --course-dir <dir>` when Course Design Intake selected it and running `set-avatar <shifu_bid> --file <course_author_avatar_source> --course-dir <dir>` when an avatar source was accepted; leave every unspecified attribute unchanged.
 6. Run `publish <shifu_bid>` to make the current draft available at the public learner URL.
 
-`import --new` creates the platform course but does not publish it. The public URL is expected to work only after `publish` succeeds.
+`import --new` creates the platform course but does not publish it. The CLI also
+attaches an immutable, generated handoff identifier and the stable
+`ai_assistant` / `lobster` source classification to that new course. This
+creation-only attribution is not written into local course content or reused
+when an existing course is synchronized. The public URL is expected to work
+only after `publish` succeeds.
 
 ## Verify
 

--- a/skills/ai-shifu-course-creator/references/deployment-workflow.md
+++ b/skills/ai-shifu-course-creator/references/deployment-workflow.md
@@ -54,6 +54,11 @@ creation-only attribution is not written into local course content or reused
 when an existing course is synchronized. The public URL is expected to work
 only after `publish` succeeds.
 
+If a create response is lost, the CLI keeps that handoff bound to the exact
+command and payload fingerprint. Repeating the same operation safely asks the
+platform for the same idempotent course result; a different course operation
+receives a new handoff and cannot accidentally claim the earlier course.
+
 ## Verify
 
 1. Run `show <shifu_bid>` and compare the platform title, description, chapter structure, lesson count, and lesson titles with the local course directory. Run `export <shifu_bid>` and compare the exported Course Prompt with `course-prompt.md`.

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -70,6 +70,9 @@ _TOKEN_ERROR_CODES = frozenset({1001, 1004, 1005})
 COURSE_LIST_PAGE_SIZE = 50
 MAX_COURSE_PAGES = 10
 
+COURSE_CREATION_SOURCE = "ai_assistant"
+COURSE_SOURCE_PRODUCT = "lobster"
+
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
 def ensure_env_file():
@@ -236,9 +239,12 @@ def load_saved_token():
     return ""
 
 
-def save_token(token):
+def save_token(token, *, course_handoff_id=""):
     """Persist the issued token to the user's config directory."""
-    _write_private_json(credentials_path(), {"token": token})
+    payload = {"token": token}
+    if course_handoff_id:
+        payload["course_handoff_id"] = course_handoff_id
+    _write_private_json(credentials_path(), payload)
 
 
 def migrate_legacy_token():
@@ -710,6 +716,7 @@ def _poll_device_authorization(base_url, device_code):
 
 def _start_device_authorization(base_url):
     device_name, device_os = _device_description()
+    handoff_id = str(uuid.uuid4())
     response = _login_post(
         base_url,
         "/api/user/device/authorize",
@@ -717,6 +724,11 @@ def _start_device_authorization(base_url):
             "device_name": device_name,
             "device_os": device_os,
             "client_version": _client_version(),
+            "registration_attribution": {
+                "creation_source": COURSE_CREATION_SOURCE,
+                "source_product": COURSE_SOURCE_PRODUCT,
+                "handoff_id": handoff_id,
+            },
         },
         "Failed to start authorization",
     )
@@ -748,6 +760,7 @@ def _start_device_authorization(base_url):
             "base_url": base_url,
             "interval": int(data.get("interval") or 5),
             "expires_at": time.time() + int(data.get("expires_in") or 600),
+            "course_handoff_id": handoff_id,
         },
     )
 
@@ -785,7 +798,11 @@ def _wait_for_device_authorization(base_url, timeout_seconds):
     while True:
         status, token = _poll_device_authorization(base_url, device_code)
         if status == "approved" and token:
-            save_token(token)
+            course_handoff_id = str(pending.get("course_handoff_id") or "")
+            if course_handoff_id:
+                save_token(token, course_handoff_id=course_handoff_id)
+            else:
+                save_token(token)
             with contextlib.suppress(OSError):
                 pending_auth_path().unlink()
             print(f"Authorization complete. Credentials saved to {credentials_path()}")
@@ -1662,9 +1679,19 @@ def _auto_pull_overwrite(base_url, token, shifu_bid, course_dir, *, scope,
 def cmd_create(args):
     """Create a new empty course."""
     base_url, token = resolve_auth(args)
-    result = api(base_url, token, "put", "/shifus",
-                 json={"name": args.name,
-                       "description": args.description or ""})
+    creation_attribution = _new_course_creation_attribution()
+    result = api(
+        base_url,
+        token,
+        "put",
+        "/shifus",
+        json={
+            "name": args.name,
+            "description": args.description or "",
+            "creation_attribution": creation_attribution,
+        },
+    )
+    _consume_course_handoff_id(creation_attribution["handoff_id"])
     bid = result.get("bid") or result.get("shifu_bid")
     print(f"Created course: {bid}")
     print(f"  Name: {args.name}")
@@ -2280,6 +2307,31 @@ def _outline_create_payload(item, parent_bid=None):
     return payload
 
 
+def _new_course_creation_attribution():
+    """Build the stable source-of-truth attribution for one new course."""
+    credentials = _read_json_file(credentials_path())
+    saved_handoff_id = ""
+    if isinstance(credentials, dict):
+        saved_handoff_id = str(credentials.get("course_handoff_id") or "")
+    return {
+        "creation_source": COURSE_CREATION_SOURCE,
+        "source_product": COURSE_SOURCE_PRODUCT,
+        "handoff_id": saved_handoff_id or str(uuid.uuid4()),
+    }
+
+
+def _consume_course_handoff_id(expected_handoff_id):
+    """Clear a registration handoff only after its first course was created."""
+    credentials = _read_json_file(credentials_path())
+    if not isinstance(credentials, dict):
+        return
+    if credentials.get("course_handoff_id") != expected_handoff_id:
+        return
+    token = credentials.get("token")
+    if isinstance(token, str) and token:
+        save_token(token)
+
+
 def _import_flat(base_url, token, json_file, shifu_bid):
     """Import from flat JSON file (original shifu-api-import.py logic)."""
     with open(json_file, "r", encoding="utf-8") as f:
@@ -2293,9 +2345,19 @@ def _import_flat(base_url, token, json_file, shifu_bid):
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        result = api(base_url, token, "put", "/shifus",
-                     json={"name": shifu_info["title"],
-                           "description": shifu_info.get("description", "")})
+        creation_attribution = _new_course_creation_attribution()
+        result = api(
+            base_url,
+            token,
+            "put",
+            "/shifus",
+            json={
+                "name": shifu_info["title"],
+                "description": shifu_info.get("description", ""),
+                "creation_attribution": creation_attribution,
+            },
+        )
+        _consume_course_handoff_id(creation_attribution["handoff_id"])
         shifu_bid = result.get("bid") or result.get("shifu_bid")
         print(f"  Created shifu: {shifu_bid}")
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -72,6 +72,8 @@ MAX_COURSE_PAGES = 10
 
 COURSE_CREATION_SOURCE = "ai_assistant"
 COURSE_SOURCE_PRODUCT = "lobster"
+COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS = 5
+COURSE_HANDOFF_LOCK_STALE_SECONDS = 30
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
@@ -197,6 +199,10 @@ def credentials_path():
     return config_dir() / "credentials.json"
 
 
+def course_handoff_lock_path():
+    return config_dir() / "course-handoff.lock"
+
+
 def pending_auth_path():
     return config_dir() / "pending-device-auth.json"
 
@@ -245,6 +251,41 @@ def save_token(token, *, course_handoff_id=""):
     if course_handoff_id:
         payload["course_handoff_id"] = course_handoff_id
     _write_private_json(credentials_path(), payload)
+
+
+@contextlib.contextmanager
+def _course_handoff_lock():
+    """Serialize the short read-and-reserve credentials operation."""
+    path = course_handoff_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS
+    fd = None
+    while fd is None:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode("ascii"))
+        except FileExistsError:
+            try:
+                stale_stat = path.stat()
+                if time.time() - stale_stat.st_mtime > COURSE_HANDOFF_LOCK_STALE_SECONDS:
+                    current_stat = path.stat()
+                    if (
+                        current_stat.st_dev == stale_stat.st_dev
+                        and current_stat.st_ino == stale_stat.st_ino
+                    ):
+                        path.unlink()
+                        continue
+            except FileNotFoundError:
+                continue
+            if time.monotonic() >= deadline:
+                raise RuntimeError("Timed out reserving the course attribution handoff")
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
 
 
 def migrate_legacy_token():
@@ -1679,19 +1720,18 @@ def _auto_pull_overwrite(base_url, token, shifu_bid, course_dir, *, scope,
 def cmd_create(args):
     """Create a new empty course."""
     base_url, token = resolve_auth(args)
-    creation_attribution = _new_course_creation_attribution()
-    result = api(
-        base_url,
-        token,
-        "put",
-        "/shifus",
-        json={
-            "name": args.name,
-            "description": args.description or "",
-            "creation_attribution": creation_attribution,
-        },
-    )
-    _consume_course_handoff_id(creation_attribution["handoff_id"])
+    with _course_creation_attribution(token) as creation_attribution:
+        result = api(
+            base_url,
+            token,
+            "put",
+            "/shifus",
+            json={
+                "name": args.name,
+                "description": args.description or "",
+                "creation_attribution": creation_attribution,
+            },
+        )
     bid = result.get("bid") or result.get("shifu_bid")
     print(f"Created course: {bid}")
     print(f"  Name: {args.name}")
@@ -2307,29 +2347,40 @@ def _outline_create_payload(item, parent_bid=None):
     return payload
 
 
-def _new_course_creation_attribution():
-    """Build the stable source-of-truth attribution for one new course."""
-    credentials = _read_json_file(credentials_path())
-    saved_handoff_id = ""
-    if isinstance(credentials, dict):
-        saved_handoff_id = str(credentials.get("course_handoff_id") or "")
-    return {
+@contextlib.contextmanager
+def _course_creation_attribution(active_token):
+    """Reserve one handoff for one course request and restore it on failure."""
+    reserved_handoff_id = ""
+    with _course_handoff_lock():
+        credentials = _read_json_file(credentials_path())
+        if (
+            isinstance(credentials, dict)
+            and credentials.get("token") == active_token
+        ):
+            reserved_handoff_id = str(credentials.get("course_handoff_id") or "")
+            if reserved_handoff_id:
+                _write_private_json(credentials_path(), {"token": active_token})
+    attribution = {
         "creation_source": COURSE_CREATION_SOURCE,
         "source_product": COURSE_SOURCE_PRODUCT,
-        "handoff_id": saved_handoff_id or str(uuid.uuid4()),
+        "handoff_id": reserved_handoff_id or str(uuid.uuid4()),
     }
-
-
-def _consume_course_handoff_id(expected_handoff_id):
-    """Clear a registration handoff only after its first course was created."""
-    credentials = _read_json_file(credentials_path())
-    if not isinstance(credentials, dict):
-        return
-    if credentials.get("course_handoff_id") != expected_handoff_id:
-        return
-    token = credentials.get("token")
-    if isinstance(token, str) and token:
-        save_token(token)
+    try:
+        yield attribution
+    except BaseException:
+        if reserved_handoff_id:
+            with _course_handoff_lock():
+                credentials = _read_json_file(credentials_path())
+                if (
+                    isinstance(credentials, dict)
+                    and credentials.get("token") == active_token
+                    and not credentials.get("course_handoff_id")
+                ):
+                    _write_private_json(
+                        credentials_path(),
+                        {"token": active_token, "course_handoff_id": reserved_handoff_id},
+                    )
+        raise
 
 
 def _import_flat(base_url, token, json_file, shifu_bid):
@@ -2345,19 +2396,18 @@ def _import_flat(base_url, token, json_file, shifu_bid):
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        creation_attribution = _new_course_creation_attribution()
-        result = api(
-            base_url,
-            token,
-            "put",
-            "/shifus",
-            json={
-                "name": shifu_info["title"],
-                "description": shifu_info.get("description", ""),
-                "creation_attribution": creation_attribution,
-            },
-        )
-        _consume_course_handoff_id(creation_attribution["handoff_id"])
+        with _course_creation_attribution(token) as creation_attribution:
+            result = api(
+                base_url,
+                token,
+                "put",
+                "/shifus",
+                json={
+                    "name": shifu_info["title"],
+                    "description": shifu_info.get("description", ""),
+                    "creation_attribution": creation_attribution,
+                },
+            )
         shifu_bid = result.get("bid") or result.get("shifu_bid")
         print(f"  Created shifu: {shifu_bid}")
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -73,6 +73,7 @@ MAX_COURSE_PAGES = 10
 COURSE_CREATION_SOURCE = "ai_assistant"
 COURSE_SOURCE_PRODUCT = "lobster"
 COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS = 30
+_ACTIVE_COURSE_CREATION_LEASES = set()
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
@@ -258,12 +259,16 @@ def save_token(token, *, course_handoff_id=""):
 
 
 @contextlib.contextmanager
-def _course_handoff_lock():
+def _course_handoff_lock(
+    path=None,
+    timeout_seconds=COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS,
+    timeout_message="Timed out reserving the course attribution handoff",
+):
     """Serialize credential and course-handoff mutations across processes."""
-    path = course_handoff_lock_path()
+    path = path or course_handoff_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.touch(mode=0o600, exist_ok=True)
-    deadline = time.monotonic() + COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS
+    deadline = time.monotonic() + timeout_seconds
     handle = path.open("r+b")
     if os.name == "nt":
         import msvcrt
@@ -294,7 +299,7 @@ def _course_handoff_lock():
         except OSError:
             if time.monotonic() >= deadline:
                 handle.close()
-                raise RuntimeError("Timed out reserving the course attribution handoff")
+                raise RuntimeError(timeout_message)
             time.sleep(0.05)
     try:
         yield
@@ -2426,11 +2431,34 @@ def _course_directory_import_operation_key(course_dir, json_file):
     )
 
 
+def _course_creation_lease_is_alive(lease):
+    """Return whether a journal lease still belongs to a live invocation."""
+    if not isinstance(lease, dict):
+        return False
+    lease_id = str(lease.get("id") or "")
+    try:
+        process_id = int(lease.get("pid"))
+    except (TypeError, ValueError):
+        return False
+    if not lease_id or process_id <= 0:
+        return False
+    if process_id == os.getpid():
+        return lease_id in _ACTIVE_COURSE_CREATION_LEASES
+    try:
+        os.kill(process_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 @contextlib.contextmanager
 def _course_creation_attribution(active_token, operation_key):
     """Bind one handoff to one operation until creation is confirmed."""
     token_digest = hashlib.sha256(active_token.encode("utf-8")).hexdigest()
     journal_key = f"{token_digest}:{operation_key}"
+    lease_id = str(uuid.uuid4())
     with _course_handoff_lock():
         pending = _read_json_file(pending_course_creations_path())
         if not isinstance(pending, dict):
@@ -2453,9 +2481,14 @@ def _course_creation_attribution(active_token, operation_key):
         ):
             reserved_handoff_id = str(existing_operation.get("handoff_id") or "")
             if reserved_handoff_id:
-                existing_operation["in_flight_count"] = max(
-                    int(existing_operation.get("in_flight_count") or 0), 0
-                ) + 1
+                existing_operation["leases"] = [
+                    lease
+                    for lease in existing_operation.get("leases") or []
+                    if _course_creation_lease_is_alive(lease)
+                ]
+                existing_operation["leases"].append(
+                    {"id": lease_id, "pid": os.getpid()}
+                )
                 pending[journal_key] = existing_operation
                 _write_private_json(pending_course_creations_path(), pending)
         if not reserved_handoff_id:
@@ -2479,7 +2512,7 @@ def _course_creation_attribution(active_token, operation_key):
             pending[journal_key] = {
                 "token_digest": token_digest,
                 "handoff_id": reserved_handoff_id,
-                "in_flight_count": 1,
+                "leases": [{"id": lease_id, "pid": os.getpid()}],
             }
             # Persist the reservation first. If the process exits before the
             # credential slot is cleared, other operations still see this
@@ -2494,6 +2527,7 @@ def _course_creation_attribution(active_token, operation_key):
             # This also handles recovery after interruption between the journal
             # write and the original credential cleanup.
             _write_private_json(credentials_path(), {"token": active_token})
+        _ACTIVE_COURSE_CREATION_LEASES.add(lease_id)
         attribution = {
             "creation_source": COURSE_CREATION_SOURCE,
             "source_product": COURSE_SOURCE_PRODUCT,
@@ -2505,6 +2539,7 @@ def _course_creation_attribution(active_token, operation_key):
         succeeded = True
     finally:
         with _course_handoff_lock():
+            _ACTIVE_COURSE_CREATION_LEASES.discard(lease_id)
             latest_pending = _read_json_file(pending_course_creations_path())
             if isinstance(latest_pending, dict):
                 current = latest_pending.get(journal_key)
@@ -2513,18 +2548,37 @@ def _course_creation_attribution(active_token, operation_key):
                     and current.get("token_digest") == token_digest
                     and current.get("handoff_id") == reserved_handoff_id
                 ):
-                    remaining = max(
-                        int(current.get("in_flight_count") or 1) - 1,
-                        0,
-                    )
-                    if succeeded and remaining == 0:
+                    remaining_leases = [
+                        lease
+                        for lease in current.get("leases") or []
+                        if str(lease.get("id") or "") != lease_id
+                        and _course_creation_lease_is_alive(lease)
+                    ]
+                    if succeeded and not remaining_leases:
                         latest_pending.pop(journal_key, None)
                     else:
-                        current["in_flight_count"] = remaining
+                        current["leases"] = remaining_leases
                         latest_pending[journal_key] = current
                     _write_private_json(
                         pending_course_creations_path(), latest_pending
                     )
+
+
+@contextlib.contextmanager
+def _course_import_operation_lock(token, operation_key):
+    """Serialize destructive writes for one account and import identity."""
+    lock_identity = hashlib.sha256(
+        f"{hashlib.sha256(token.encode('utf-8')).hexdigest()}:{operation_key}".encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    lock_path = config_dir() / "course-import-locks" / f"{lock_identity}.lock"
+    with _course_handoff_lock(
+        path=lock_path,
+        timeout_seconds=600,
+        timeout_message="Timed out waiting for the matching course import",
+    ):
+        yield
 
 
 def _import_flat(
@@ -2533,6 +2587,32 @@ def _import_flat(
     json_file,
     shifu_bid,
     creation_operation_key=None,
+):
+    """Coordinate a complete import for each new-course operation identity."""
+    if shifu_bid:
+        return _import_flat_apply(base_url, token, json_file, shifu_bid)
+    operation_key = creation_operation_key or _course_import_operation_key(
+        "import-new-json",
+        json_file,
+        json_file,
+    )
+    with _course_creation_attribution(token, operation_key) as attribution:
+        with _course_import_operation_lock(token, operation_key):
+            return _import_flat_apply(
+                base_url,
+                token,
+                json_file,
+                None,
+                creation_attribution=attribution,
+            )
+
+
+def _import_flat_apply(
+    base_url,
+    token,
+    json_file,
+    shifu_bid,
+    creation_attribution=None,
 ):
     """Import from flat JSON file (original shifu-api-import.py logic)."""
     with open(json_file, "r", encoding="utf-8") as f:
@@ -2546,25 +2626,17 @@ def _import_flat(
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        operation_key = creation_operation_key or _course_import_operation_key(
-            "import-new-json",
-            json_file,
-            json_file,
+        result = api(
+            base_url,
+            token,
+            "put",
+            "/shifus",
+            json={
+                "name": shifu_info["title"],
+                "description": shifu_info.get("description", ""),
+                "creation_attribution": creation_attribution,
+            },
         )
-        with _course_creation_attribution(
-            token, operation_key
-        ) as creation_attribution:
-            result = api(
-                base_url,
-                token,
-                "put",
-                "/shifus",
-                json={
-                    "name": shifu_info["title"],
-                    "description": shifu_info.get("description", ""),
-                    "creation_attribution": creation_attribution,
-                },
-            )
         shifu_bid = result.get("bid") or result.get("shifu_bid")
         print(f"  Created shifu: {shifu_bid}")
 

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -72,8 +72,7 @@ MAX_COURSE_PAGES = 10
 
 COURSE_CREATION_SOURCE = "ai_assistant"
 COURSE_SOURCE_PRODUCT = "lobster"
-COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS = 5
-COURSE_HANDOFF_LOCK_STALE_SECONDS = 30
+COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS = 30
 
 
 # ── Shared Infrastructure ──────────────────────────────────────────────────────
@@ -250,42 +249,55 @@ def save_token(token, *, course_handoff_id=""):
     payload = {"token": token}
     if course_handoff_id:
         payload["course_handoff_id"] = course_handoff_id
-    _write_private_json(credentials_path(), payload)
+    with _course_handoff_lock():
+        _write_private_json(credentials_path(), payload)
 
 
 @contextlib.contextmanager
 def _course_handoff_lock():
-    """Serialize the short read-and-reserve credentials operation."""
+    """Serialize credential and course-handoff mutations across processes."""
     path = course_handoff_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(mode=0o600, exist_ok=True)
     deadline = time.monotonic() + COURSE_HANDOFF_LOCK_TIMEOUT_SECONDS
-    fd = None
-    while fd is None:
+    handle = path.open("r+b")
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        def lock():
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+
+        def unlock():
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        def lock():
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def unlock():
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    acquired = False
+    while not acquired:
         try:
-            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            os.write(fd, str(os.getpid()).encode("ascii"))
-        except FileExistsError:
-            try:
-                stale_stat = path.stat()
-                if time.time() - stale_stat.st_mtime > COURSE_HANDOFF_LOCK_STALE_SECONDS:
-                    current_stat = path.stat()
-                    if (
-                        current_stat.st_dev == stale_stat.st_dev
-                        and current_stat.st_ino == stale_stat.st_ino
-                    ):
-                        path.unlink()
-                        continue
-            except FileNotFoundError:
-                continue
+            handle.seek(0)
+            lock()
+            acquired = True
+        except OSError:
             if time.monotonic() >= deadline:
+                handle.close()
                 raise RuntimeError("Timed out reserving the course attribution handoff")
             time.sleep(0.05)
     try:
         yield
     finally:
-        os.close(fd)
-        with contextlib.suppress(FileNotFoundError):
-            path.unlink()
+        handle.seek(0)
+        unlock()
+        handle.close()
 
 
 def migrate_legacy_token():
@@ -2350,8 +2362,8 @@ def _outline_create_payload(item, parent_bid=None):
 @contextlib.contextmanager
 def _course_creation_attribution(active_token):
     """Reserve one handoff for one course request and restore it on failure."""
-    reserved_handoff_id = ""
     with _course_handoff_lock():
+        reserved_handoff_id = ""
         credentials = _read_json_file(credentials_path())
         if (
             isinstance(credentials, dict)
@@ -2360,27 +2372,36 @@ def _course_creation_attribution(active_token):
             reserved_handoff_id = str(credentials.get("course_handoff_id") or "")
             if reserved_handoff_id:
                 _write_private_json(credentials_path(), {"token": active_token})
-    attribution = {
-        "creation_source": COURSE_CREATION_SOURCE,
-        "source_product": COURSE_SOURCE_PRODUCT,
-        "handoff_id": reserved_handoff_id or str(uuid.uuid4()),
-    }
-    try:
-        yield attribution
-    except BaseException:
-        if reserved_handoff_id:
-            with _course_handoff_lock():
+        attribution = {
+            "creation_source": COURSE_CREATION_SOURCE,
+            "source_product": COURSE_SOURCE_PRODUCT,
+            "handoff_id": reserved_handoff_id or str(uuid.uuid4()),
+        }
+        try:
+            yield attribution
+        except BaseException:
+            if reserved_handoff_id:
                 credentials = _read_json_file(credentials_path())
                 if (
                     isinstance(credentials, dict)
                     and credentials.get("token") == active_token
                     and not credentials.get("course_handoff_id")
                 ):
-                    _write_private_json(
-                        credentials_path(),
-                        {"token": active_token, "course_handoff_id": reserved_handoff_id},
-                    )
-        raise
+                    try:
+                        _write_private_json(
+                            credentials_path(),
+                            {
+                                "token": active_token,
+                                "course_handoff_id": reserved_handoff_id,
+                            },
+                        )
+                    except OSError as restore_error:
+                        print(
+                            "Warning: could not restore the course attribution "
+                            f"handoff: {restore_error}",
+                            file=sys.stderr,
+                        )
+            raise
 
 
 def _import_flat(base_url, token, json_file, shifu_bid):

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -202,6 +202,10 @@ def course_handoff_lock_path():
     return config_dir() / "course-handoff.lock"
 
 
+def pending_course_creations_path():
+    return config_dir() / "pending-course-creations.json"
+
+
 def pending_auth_path():
     return config_dir() / "pending-device-auth.json"
 
@@ -1732,7 +1736,13 @@ def _auto_pull_overwrite(base_url, token, shifu_bid, course_dir, *, scope,
 def cmd_create(args):
     """Create a new empty course."""
     base_url, token = resolve_auth(args)
-    with _course_creation_attribution(token) as creation_attribution:
+    operation_key = _course_creation_operation_key(
+        "create",
+        {"name": args.name, "description": args.description or ""},
+    )
+    with _course_creation_attribution(
+        token, operation_key
+    ) as creation_attribution:
         result = api(
             base_url,
             token,
@@ -2359,49 +2369,63 @@ def _outline_create_payload(item, parent_bid=None):
     return payload
 
 
+def _course_creation_operation_key(command, payload):
+    """Return a non-sensitive stable identity for retrying one course operation."""
+    encoded = json.dumps(
+        {"command": command, "payload": payload},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 @contextlib.contextmanager
-def _course_creation_attribution(active_token):
-    """Reserve one handoff for one course request and restore it on failure."""
+def _course_creation_attribution(active_token, operation_key):
+    """Bind one handoff to one operation until creation is confirmed."""
     with _course_handoff_lock():
+        token_digest = hashlib.sha256(active_token.encode("utf-8")).hexdigest()
+        pending = _read_json_file(pending_course_creations_path())
+        if not isinstance(pending, dict):
+            pending = {}
+        existing_operation = pending.get(operation_key)
         reserved_handoff_id = ""
-        credentials = _read_json_file(credentials_path())
         if (
-            isinstance(credentials, dict)
-            and credentials.get("token") == active_token
+            isinstance(existing_operation, dict)
+            and existing_operation.get("token_digest") == token_digest
         ):
-            reserved_handoff_id = str(credentials.get("course_handoff_id") or "")
-            if reserved_handoff_id:
-                _write_private_json(credentials_path(), {"token": active_token})
+            reserved_handoff_id = str(existing_operation.get("handoff_id") or "")
+        if not reserved_handoff_id:
+            credentials = _read_json_file(credentials_path())
+            if (
+                isinstance(credentials, dict)
+                and credentials.get("token") == active_token
+            ):
+                reserved_handoff_id = str(credentials.get("course_handoff_id") or "")
+                if reserved_handoff_id:
+                    _write_private_json(credentials_path(), {"token": active_token})
+            reserved_handoff_id = reserved_handoff_id or str(uuid.uuid4())
+            pending[operation_key] = {
+                "token_digest": token_digest,
+                "handoff_id": reserved_handoff_id,
+            }
+            _write_private_json(pending_course_creations_path(), pending)
         attribution = {
             "creation_source": COURSE_CREATION_SOURCE,
             "source_product": COURSE_SOURCE_PRODUCT,
-            "handoff_id": reserved_handoff_id or str(uuid.uuid4()),
+            "handoff_id": reserved_handoff_id,
         }
-        try:
-            yield attribution
-        except BaseException:
-            if reserved_handoff_id:
-                credentials = _read_json_file(credentials_path())
-                if (
-                    isinstance(credentials, dict)
-                    and credentials.get("token") == active_token
-                    and not credentials.get("course_handoff_id")
-                ):
-                    try:
-                        _write_private_json(
-                            credentials_path(),
-                            {
-                                "token": active_token,
-                                "course_handoff_id": reserved_handoff_id,
-                            },
-                        )
-                    except OSError as restore_error:
-                        print(
-                            "Warning: could not restore the course attribution "
-                            f"handoff: {restore_error}",
-                            file=sys.stderr,
-                        )
-            raise
+        yield attribution
+        latest_pending = _read_json_file(pending_course_creations_path())
+        if isinstance(latest_pending, dict):
+            current = latest_pending.get(operation_key)
+            if (
+                isinstance(current, dict)
+                and current.get("token_digest") == token_digest
+                and current.get("handoff_id") == reserved_handoff_id
+            ):
+                latest_pending.pop(operation_key, None)
+                _write_private_json(pending_course_creations_path(), latest_pending)
 
 
 def _import_flat(base_url, token, json_file, shifu_bid):
@@ -2417,7 +2441,18 @@ def _import_flat(base_url, token, json_file, shifu_bid):
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        with _course_creation_attribution(token) as creation_attribution:
+        operation_key = _course_creation_operation_key(
+            "import-new",
+            {
+                "path": str(Path(json_file).resolve()),
+                "content_sha256": hashlib.sha256(
+                    Path(json_file).read_bytes()
+                ).hexdigest(),
+            },
+        )
+        with _course_creation_attribution(
+            token, operation_key
+        ) as creation_attribution:
             result = api(
                 base_url,
                 token,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2452,6 +2452,12 @@ def _course_creation_attribution(active_token, operation_key):
             and existing_operation.get("token_digest") == token_digest
         ):
             reserved_handoff_id = str(existing_operation.get("handoff_id") or "")
+            if reserved_handoff_id:
+                existing_operation["in_flight_count"] = max(
+                    int(existing_operation.get("in_flight_count") or 0), 0
+                ) + 1
+                pending[journal_key] = existing_operation
+                _write_private_json(pending_course_creations_path(), pending)
         if not reserved_handoff_id:
             credentials = _read_json_file(credentials_path())
             credential_handoff_id = ""
@@ -2473,6 +2479,7 @@ def _course_creation_attribution(active_token, operation_key):
             pending[journal_key] = {
                 "token_digest": token_digest,
                 "handoff_id": reserved_handoff_id,
+                "in_flight_count": 1,
             }
             # Persist the reservation first. If the process exits before the
             # credential slot is cleared, other operations still see this
@@ -2492,27 +2499,32 @@ def _course_creation_attribution(active_token, operation_key):
             "source_product": COURSE_SOURCE_PRODUCT,
             "handoff_id": reserved_handoff_id,
         }
+    succeeded = False
     try:
         yield attribution
-    except BaseException:
-        # Keep the reservation for an exact retry when the server result is
-        # unknown. The network request runs without holding the global lock.
-        raise
-    else:
+        succeeded = True
+    finally:
         with _course_handoff_lock():
             latest_pending = _read_json_file(pending_course_creations_path())
-            if not isinstance(latest_pending, dict):
-                return
-            current = latest_pending.get(journal_key)
-            if (
-                isinstance(current, dict)
-                and current.get("token_digest") == token_digest
-                and current.get("handoff_id") == reserved_handoff_id
-            ):
-                latest_pending.pop(journal_key, None)
-                _write_private_json(
-                    pending_course_creations_path(), latest_pending
-                )
+            if isinstance(latest_pending, dict):
+                current = latest_pending.get(journal_key)
+                if (
+                    isinstance(current, dict)
+                    and current.get("token_digest") == token_digest
+                    and current.get("handoff_id") == reserved_handoff_id
+                ):
+                    remaining = max(
+                        int(current.get("in_flight_count") or 1) - 1,
+                        0,
+                    )
+                    if succeeded and remaining == 0:
+                        latest_pending.pop(journal_key, None)
+                    else:
+                        current["in_flight_count"] = remaining
+                        latest_pending[journal_key] = current
+                    _write_private_json(
+                        pending_course_creations_path(), latest_pending
+                    )
 
 
 def _import_flat(

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2380,31 +2380,35 @@ def _course_creation_operation_key(command, payload):
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _course_directory_import_operation_key(course_dir, **build_options):
-    """Identify a directory import without generated IDs or export timestamps."""
+def _course_directory_import_operation_key(course_dir, json_file):
+    """Identify the built course semantics without generated IDs or timestamps."""
     root = Path(course_dir).resolve()
-    source_files = []
-    for relative_path in ("README.md", "course-prompt.md", "structure.json"):
-        path = root / relative_path
-        if path.is_file():
-            source_files.append(path)
-    lessons_dir = root / "lessons"
-    if lessons_dir.is_dir():
-        source_files.extend(
-            path
-            for path in sorted(lessons_dir.glob("lesson-*.md"))
-            if path.is_file()
-        )
+    import_data = json.loads(Path(json_file).read_text(encoding="utf-8"))
+    outline_items = import_data.get("outline_items") or []
+    outline_id_map = {
+        str(item.get("outline_item_bid") or ""): f"outline-{index}"
+        for index, item in enumerate(outline_items)
+        if item.get("outline_item_bid")
+    }
+    normalized_outlines = []
+    for item in outline_items:
+        normalized = {
+            key: value
+            for key, value in item.items()
+            if key != "outline_item_bid"
+        }
+        parent_bid = str(normalized.get("parent_bid") or "")
+        normalized["parent_bid"] = outline_id_map.get(parent_bid, parent_bid)
+        normalized_outlines.append(normalized)
+    shifu = {
+        key: value
+        for key, value in (import_data.get("shifu") or {}).items()
+        if key not in {"bid", "shifu_bid", "exported_at"}
+    }
     semantic_input = {
         "path": str(root),
-        "options": build_options,
-        "files": [
-            {
-                "path": str(path.relative_to(root)),
-                "content_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-            }
-            for path in source_files
-        ],
+        "shifu": shifu,
+        "outline_items": normalized_outlines,
     }
     return _course_creation_operation_key("import-new-directory", semantic_input)
 
@@ -2461,8 +2465,15 @@ def _course_creation_attribution(active_token, operation_key):
             # credential slot is cleared, other operations still see this
             # handoff in the journal and cannot consume it again.
             _write_private_json(pending_course_creations_path(), pending)
-            if credential_handoff_id == reserved_handoff_id:
-                _write_private_json(credentials_path(), {"token": active_token})
+        credentials = _read_json_file(credentials_path())
+        if (
+            isinstance(credentials, dict)
+            and credentials.get("token") == active_token
+            and credentials.get("course_handoff_id") == reserved_handoff_id
+        ):
+            # This also handles recovery after interruption between the journal
+            # write and the original credential cleanup.
+            _write_private_json(credentials_path(), {"token": active_token})
         attribution = {
             "creation_source": COURSE_CREATION_SOURCE,
             "source_product": COURSE_SOURCE_PRODUCT,
@@ -2668,13 +2679,13 @@ def cmd_import(args):
             "keywords": getattr(args, "keywords", None),
             "chapter_name": getattr(args, "chapter_name", None),
         }
-        creation_operation_key = _course_directory_import_operation_key(
-            args.course_dir,
-            **build_options,
-        )
         json_file = _build_import_json(
             course_dir=args.course_dir,
             **build_options,
+        )
+        creation_operation_key = _course_directory_import_operation_key(
+            args.course_dir,
+            json_file,
         )
         result_bid = _import_flat(
             base_url,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2380,9 +2380,8 @@ def _course_creation_operation_key(command, payload):
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _course_directory_import_operation_key(course_dir, json_file):
-    """Identify the built course semantics without generated IDs or timestamps."""
-    root = Path(course_dir).resolve()
+def _normalized_course_import_semantics(json_file):
+    """Return effective import content without generated IDs or timestamps."""
     import_data = json.loads(Path(json_file).read_text(encoding="utf-8"))
     outline_items = import_data.get("outline_items") or []
     outline_id_map = {
@@ -2405,12 +2404,26 @@ def _course_directory_import_operation_key(course_dir, json_file):
         for key, value in (import_data.get("shifu") or {}).items()
         if key not in {"bid", "shifu_bid", "exported_at"}
     }
-    semantic_input = {
-        "path": str(root),
+    return {
         "shifu": shifu,
         "outline_items": normalized_outlines,
     }
-    return _course_creation_operation_key("import-new-directory", semantic_input)
+
+
+def _course_import_operation_key(command, source_path, json_file):
+    """Identify one import from its stable source and effective content."""
+    semantic_input = {
+        "path": str(Path(source_path).resolve()),
+        "course": _normalized_course_import_semantics(json_file),
+    }
+    return _course_creation_operation_key(command, semantic_input)
+
+
+def _course_directory_import_operation_key(course_dir, json_file):
+    """Identify a directory import without generated IDs or timestamps."""
+    return _course_import_operation_key(
+        "import-new-directory", course_dir, json_file
+    )
 
 
 @contextlib.contextmanager
@@ -2521,12 +2534,10 @@ def _import_flat(
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        operation_key = creation_operation_key or _course_creation_operation_key(
+        operation_key = creation_operation_key or _course_import_operation_key(
             "import-new-json",
-            {
-                "path": str(Path(json_file).resolve()),
-                "content_sha256": hashlib.sha256(Path(json_file).read_bytes()).hexdigest(),
-            },
+            json_file,
+            json_file,
         )
         with _course_creation_attribution(
             token, operation_key

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2380,6 +2380,35 @@ def _course_creation_operation_key(command, payload):
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _course_directory_import_operation_key(course_dir, **build_options):
+    """Identify a directory import without generated IDs or export timestamps."""
+    root = Path(course_dir).resolve()
+    source_files = []
+    for relative_path in ("README.md", "course-prompt.md", "structure.json"):
+        path = root / relative_path
+        if path.is_file():
+            source_files.append(path)
+    lessons_dir = root / "lessons"
+    if lessons_dir.is_dir():
+        source_files.extend(
+            path
+            for path in sorted(lessons_dir.glob("lesson-*.md"))
+            if path.is_file()
+        )
+    semantic_input = {
+        "path": str(root),
+        "options": build_options,
+        "files": [
+            {
+                "path": str(path.relative_to(root)),
+                "content_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+            for path in source_files
+        ],
+    }
+    return _course_creation_operation_key("import-new-directory", semantic_input)
+
+
 @contextlib.contextmanager
 def _course_creation_attribution(active_token, operation_key):
     """Bind one handoff to one operation until creation is confirmed."""
@@ -2388,7 +2417,18 @@ def _course_creation_attribution(active_token, operation_key):
         pending = _read_json_file(pending_course_creations_path())
         if not isinstance(pending, dict):
             pending = {}
-        existing_operation = pending.get(operation_key)
+        journal_key = f"{token_digest}:{operation_key}"
+        existing_operation = pending.get(journal_key)
+        legacy_operation = pending.get(operation_key)
+        if (
+            not isinstance(existing_operation, dict)
+            and isinstance(legacy_operation, dict)
+            and legacy_operation.get("token_digest") == token_digest
+        ):
+            existing_operation = legacy_operation
+            pending.pop(operation_key, None)
+            pending[journal_key] = legacy_operation
+            _write_private_json(pending_course_creations_path(), pending)
         reserved_handoff_id = ""
         if (
             isinstance(existing_operation, dict)
@@ -2405,7 +2445,7 @@ def _course_creation_attribution(active_token, operation_key):
                 if reserved_handoff_id:
                     _write_private_json(credentials_path(), {"token": active_token})
             reserved_handoff_id = reserved_handoff_id or str(uuid.uuid4())
-            pending[operation_key] = {
+            pending[journal_key] = {
                 "token_digest": token_digest,
                 "handoff_id": reserved_handoff_id,
             }
@@ -2418,17 +2458,23 @@ def _course_creation_attribution(active_token, operation_key):
         yield attribution
         latest_pending = _read_json_file(pending_course_creations_path())
         if isinstance(latest_pending, dict):
-            current = latest_pending.get(operation_key)
+            current = latest_pending.get(journal_key)
             if (
                 isinstance(current, dict)
                 and current.get("token_digest") == token_digest
                 and current.get("handoff_id") == reserved_handoff_id
             ):
-                latest_pending.pop(operation_key, None)
+                latest_pending.pop(journal_key, None)
                 _write_private_json(pending_course_creations_path(), latest_pending)
 
 
-def _import_flat(base_url, token, json_file, shifu_bid):
+def _import_flat(
+    base_url,
+    token,
+    json_file,
+    shifu_bid,
+    creation_operation_key=None,
+):
     """Import from flat JSON file (original shifu-api-import.py logic)."""
     with open(json_file, "r", encoding="utf-8") as f:
         import_data = json.load(f)
@@ -2441,13 +2487,11 @@ def _import_flat(base_url, token, json_file, shifu_bid):
         print(f"Using existing shifu: {shifu_bid}")
     else:
         print(f"Creating new shifu: {shifu_info['title']}")
-        operation_key = _course_creation_operation_key(
-            "import-new",
+        operation_key = creation_operation_key or _course_creation_operation_key(
+            "import-new-json",
             {
                 "path": str(Path(json_file).resolve()),
-                "content_sha256": hashlib.sha256(
-                    Path(json_file).read_bytes()
-                ).hexdigest(),
+                "content_sha256": hashlib.sha256(Path(json_file).read_bytes()).hexdigest(),
             },
         )
         with _course_creation_attribution(
@@ -2605,14 +2649,27 @@ def cmd_import(args):
     result_bid = None
     if args.course_dir:
         # Build JSON first, then import
+        build_options = {
+            "title": getattr(args, "title", None),
+            "description": getattr(args, "description", None),
+            "keywords": getattr(args, "keywords", None),
+            "chapter_name": getattr(args, "chapter_name", None),
+        }
+        creation_operation_key = _course_directory_import_operation_key(
+            args.course_dir,
+            **build_options,
+        )
         json_file = _build_import_json(
             course_dir=args.course_dir,
-            title=getattr(args, "title", None),
-            description=getattr(args, "description", None),
-            keywords=getattr(args, "keywords", None),
-            chapter_name=getattr(args, "chapter_name", None),
+            **build_options,
         )
-        result_bid = _import_flat(base_url, token, json_file, shifu_bid)
+        result_bid = _import_flat(
+            base_url,
+            token,
+            json_file,
+            shifu_bid,
+            creation_operation_key=creation_operation_key,
+        )
     elif args.json_file:
         result_bid = _import_flat(base_url, token, args.json_file, shifu_bid)
     else:

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2437,19 +2437,32 @@ def _course_creation_attribution(active_token, operation_key):
             reserved_handoff_id = str(existing_operation.get("handoff_id") or "")
         if not reserved_handoff_id:
             credentials = _read_json_file(credentials_path())
+            credential_handoff_id = ""
             if (
                 isinstance(credentials, dict)
                 and credentials.get("token") == active_token
             ):
-                reserved_handoff_id = str(credentials.get("course_handoff_id") or "")
-                if reserved_handoff_id:
-                    _write_private_json(credentials_path(), {"token": active_token})
+                credential_handoff_id = str(
+                    credentials.get("course_handoff_id") or ""
+                )
+            handoffs_already_reserved = {
+                str(record.get("handoff_id") or "")
+                for record in pending.values()
+                if isinstance(record, dict)
+            }
+            if credential_handoff_id not in handoffs_already_reserved:
+                reserved_handoff_id = credential_handoff_id
             reserved_handoff_id = reserved_handoff_id or str(uuid.uuid4())
             pending[journal_key] = {
                 "token_digest": token_digest,
                 "handoff_id": reserved_handoff_id,
             }
+            # Persist the reservation first. If the process exits before the
+            # credential slot is cleared, other operations still see this
+            # handoff in the journal and cannot consume it again.
             _write_private_json(pending_course_creations_path(), pending)
+            if credential_handoff_id == reserved_handoff_id:
+                _write_private_json(credentials_path(), {"token": active_token})
         attribution = {
             "creation_source": COURSE_CREATION_SOURCE,
             "source_product": COURSE_SOURCE_PRODUCT,

--- a/skills/ai-shifu-course-creator/scripts/shifu-cli.py
+++ b/skills/ai-shifu-course-creator/scripts/shifu-cli.py
@@ -2416,12 +2416,12 @@ def _course_directory_import_operation_key(course_dir, json_file):
 @contextlib.contextmanager
 def _course_creation_attribution(active_token, operation_key):
     """Bind one handoff to one operation until creation is confirmed."""
+    token_digest = hashlib.sha256(active_token.encode("utf-8")).hexdigest()
+    journal_key = f"{token_digest}:{operation_key}"
     with _course_handoff_lock():
-        token_digest = hashlib.sha256(active_token.encode("utf-8")).hexdigest()
         pending = _read_json_file(pending_course_creations_path())
         if not isinstance(pending, dict):
             pending = {}
-        journal_key = f"{token_digest}:{operation_key}"
         existing_operation = pending.get(journal_key)
         legacy_operation = pending.get(operation_key)
         if (
@@ -2479,9 +2479,17 @@ def _course_creation_attribution(active_token, operation_key):
             "source_product": COURSE_SOURCE_PRODUCT,
             "handoff_id": reserved_handoff_id,
         }
+    try:
         yield attribution
-        latest_pending = _read_json_file(pending_course_creations_path())
-        if isinstance(latest_pending, dict):
+    except BaseException:
+        # Keep the reservation for an exact retry when the server result is
+        # unknown. The network request runs without holding the global lock.
+        raise
+    else:
+        with _course_handoff_lock():
+            latest_pending = _read_json_file(pending_course_creations_path())
+            if not isinstance(latest_pending, dict):
+                return
             current = latest_pending.get(journal_key)
             if (
                 isinstance(current, dict)
@@ -2489,7 +2497,9 @@ def _course_creation_attribution(active_token, operation_key):
                 and current.get("handoff_id") == reserved_handoff_id
             ):
                 latest_pending.pop(journal_key, None)
-                _write_private_json(pending_course_creations_path(), latest_pending)
+                _write_private_json(
+                    pending_course_creations_path(), latest_pending
+                )
 
 
 def _import_flat(

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -6,6 +6,7 @@ import io
 import json
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -343,12 +344,37 @@ class CourseCreationAttributionTests(unittest.TestCase):
             "test-token", course_handoff_id=handoff_id
         )
 
-        with course_creator_cli._course_creation_attribution("test-token") as first:
-            with course_creator_cli._course_creation_attribution("test-token") as second:
-                pass
+        first_reserved = threading.Event()
+        release_first = threading.Event()
+        second_finished = threading.Event()
+        values = []
 
-        self.assertEqual(first["handoff_id"], handoff_id)
-        self.assertNotEqual(second["handoff_id"], handoff_id)
+        def reserve_first():
+            with course_creator_cli._course_creation_attribution("test-token") as value:
+                values.append(value)
+                first_reserved.set()
+                release_first.wait(timeout=2)
+
+        def reserve_second():
+            first_reserved.wait(timeout=2)
+            with course_creator_cli._course_creation_attribution("test-token") as value:
+                values.append(value)
+            second_finished.set()
+
+        first_thread = threading.Thread(target=reserve_first)
+        second_thread = threading.Thread(target=reserve_second)
+        first_thread.start()
+        second_thread.start()
+        self.assertTrue(first_reserved.wait(timeout=2))
+        self.assertFalse(second_finished.wait(timeout=0.1))
+        release_first.set()
+        first_thread.join(timeout=2)
+        second_thread.join(timeout=2)
+        self.assertFalse(first_thread.is_alive())
+        self.assertFalse(second_thread.is_alive())
+
+        self.assertEqual(values[0]["handoff_id"], handoff_id)
+        self.assertNotEqual(values[1]["handoff_id"], handoff_id)
         self.assertEqual(course_creator_cli.load_saved_token(), "test-token")
 
     def test_explicit_token_does_not_consume_another_accounts_handoff(self):
@@ -376,6 +402,32 @@ class CourseCreationAttributionTests(unittest.TestCase):
             course_creator_cli.credentials_path()
         )
         self.assertEqual(saved["course_handoff_id"], handoff_id)
+
+    def test_restore_failure_does_not_replace_the_creation_failure(self):
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        course_creator_cli.save_token("test-token", course_handoff_id=handoff_id)
+        original_error = RuntimeError("request failed")
+        write_private_json = course_creator_cli._write_private_json
+
+        def fail_restore(path, payload):
+            if payload.get("course_handoff_id"):
+                raise OSError("disk unavailable")
+            write_private_json(path, payload)
+
+        with (
+            mock.patch.object(
+                course_creator_cli,
+                "_write_private_json",
+                side_effect=fail_restore,
+            ),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(RuntimeError) as raised,
+        ):
+            with course_creator_cli._course_creation_attribution("test-token"):
+                raise original_error
+
+        self.assertIs(raised.exception, original_error)
+        self.assertIn("could not restore", stderr.getvalue())
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib.util
 import io
 import json
@@ -433,6 +434,97 @@ class CourseCreationAttributionTests(unittest.TestCase):
 
         self.assertEqual(original["handoff_id"], handoff_id)
         self.assertNotEqual(independent["handoff_id"], handoff_id)
+
+    def test_failed_operations_with_same_fingerprint_are_isolated_by_token(self):
+        operation_key = "same-operation"
+
+        with self.assertRaisesRegex(RuntimeError, "token A response lost"):
+            with course_creator_cli._course_creation_attribution(
+                "token-a", operation_key
+            ) as first_a:
+                raise RuntimeError("token A response lost")
+        with self.assertRaisesRegex(RuntimeError, "token B response lost"):
+            with course_creator_cli._course_creation_attribution(
+                "token-b", operation_key
+            ) as first_b:
+                raise RuntimeError("token B response lost")
+        with course_creator_cli._course_creation_attribution(
+            "token-a", operation_key
+        ) as retried_a:
+            pass
+
+        self.assertNotEqual(first_a["handoff_id"], first_b["handoff_id"])
+        self.assertEqual(retried_a["handoff_id"], first_a["handoff_id"])
+
+    def test_legacy_pending_operation_is_migrated_for_its_token(self):
+        operation_key = "legacy-operation"
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        token_digest = hashlib.sha256(b"test-token").hexdigest()
+        course_creator_cli._write_private_json(
+            course_creator_cli.pending_course_creations_path(),
+            {
+                operation_key: {
+                    "token_digest": token_digest,
+                    "handoff_id": handoff_id,
+                }
+            },
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "response remains unknown"):
+            with course_creator_cli._course_creation_attribution(
+                "test-token", operation_key
+            ) as retried:
+                raise RuntimeError("response remains unknown")
+
+        pending = course_creator_cli._read_json_file(
+            course_creator_cli.pending_course_creations_path()
+        )
+        self.assertEqual(retried["handoff_id"], handoff_id)
+        self.assertNotIn(operation_key, pending)
+        self.assertIn(f"{token_digest}:{operation_key}", pending)
+
+    def test_directory_import_operation_key_ignores_generated_export_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = Path(tmp)
+            lessons_dir = course_dir / "lessons"
+            lessons_dir.mkdir()
+            (course_dir / "README.md").write_text("# Stable course\n", encoding="utf-8")
+            (course_dir / "course-prompt.md").write_text(
+                "Teach clearly.\n", encoding="utf-8"
+            )
+            lesson = lessons_dir / "lesson-01.md"
+            lesson.write_text("Lesson content\n", encoding="utf-8")
+            options = {
+                "title": None,
+                "description": None,
+                "keywords": None,
+                "chapter_name": None,
+            }
+
+            first_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, **options
+            )
+            first_export = course_creator_cli._build_import_json(
+                course_dir, **options
+            )
+            first_export_bytes = Path(first_export).read_bytes()
+            second_export = course_creator_cli._build_import_json(
+                course_dir, **options
+            )
+            second_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, **options
+            )
+
+            self.assertNotEqual(
+                first_export_bytes, Path(second_export).read_bytes()
+            )
+            self.assertEqual(second_key, first_key)
+
+            lesson.write_text("Changed content\n", encoding="utf-8")
+            changed_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, **options
+            )
+            self.assertNotEqual(changed_key, first_key)
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -8,6 +8,7 @@ import json
 import sys
 import tempfile
 import threading
+import time
 import types
 import unittest
 from pathlib import Path
@@ -477,6 +478,72 @@ class CourseCreationAttributionTests(unittest.TestCase):
         self.assertEqual(second["handoff_id"], first["handoff_id"])
         self.assertEqual(retried["handoff_id"], first["handoff_id"])
 
+    def test_matching_imports_serialize_the_complete_destructive_update(self):
+        import_data = {
+            "shifu": {"title": "Imported course", "description": "Description"},
+            "outline_items": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            import_file = Path(tmp) / "course.json"
+            import_file.write_text(json.dumps(import_data), encoding="utf-8")
+            first_create_started = threading.Event()
+            release_first_create = threading.Event()
+            create_handoffs = []
+            errors = []
+
+            def fake_api(_base_url, _token, method, path, **kwargs):
+                if method == "put" and path == "/shifus":
+                    create_handoffs.append(
+                        kwargs["json"]["creation_attribution"]["handoff_id"]
+                    )
+                    if len(create_handoffs) == 1:
+                        first_create_started.set()
+                        release_first_create.wait(timeout=2)
+                    return {"bid": "course-new"}
+                return []
+
+            def run_import():
+                try:
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        course_creator_cli._import_flat(
+                            self.base_url,
+                            "test-token",
+                            import_file,
+                            None,
+                        )
+                except BaseException as exc:
+                    errors.append(exc)
+
+            with (
+                mock.patch.object(course_creator_cli, "api", side_effect=fake_api),
+                mock.patch.object(course_creator_cli, "api_safe", return_value=[]),
+            ):
+                first_thread = threading.Thread(target=run_import)
+                second_thread = threading.Thread(target=run_import)
+                first_thread.start()
+                self.assertTrue(first_create_started.wait(timeout=2))
+                second_thread.start()
+                deadline = time.monotonic() + 1
+                while time.monotonic() < deadline:
+                    pending = course_creator_cli._read_json_file(
+                        course_creator_cli.pending_course_creations_path()
+                    ) or {}
+                    if any(
+                        len(record.get("leases") or []) == 2
+                        for record in pending.values()
+                        if isinstance(record, dict)
+                    ):
+                        break
+                    time.sleep(0.01)
+                self.assertEqual(len(create_handoffs), 1)
+                release_first_create.set()
+                first_thread.join(timeout=2)
+                second_thread.join(timeout=2)
+
+            self.assertEqual(errors, [])
+            self.assertEqual(len(create_handoffs), 2)
+            self.assertEqual(create_handoffs[1], create_handoffs[0])
+
     def test_legacy_pending_operation_is_migrated_for_its_token(self):
         operation_key = "legacy-operation"
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
@@ -654,6 +721,16 @@ class CourseCreationAttributionTests(unittest.TestCase):
 
         self.assertEqual(retried["handoff_id"], handoff_id)
         self.assertNotEqual(independent["handoff_id"], handoff_id)
+        pending = course_creator_cli._read_json_file(
+            course_creator_cli.pending_course_creations_path()
+        )
+        self.assertFalse(
+            any(
+                record.get("handoff_id") == handoff_id
+                for record in (pending or {}).values()
+                if isinstance(record, dict)
+            )
+        )
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -456,6 +456,27 @@ class CourseCreationAttributionTests(unittest.TestCase):
         self.assertNotEqual(first_a["handoff_id"], first_b["handoff_id"])
         self.assertEqual(retried_a["handoff_id"], first_a["handoff_id"])
 
+    def test_concurrent_success_does_not_clear_failed_requests_retry(self):
+        operation_key = "concurrent-operation"
+
+        with self.assertRaisesRegex(RuntimeError, "response lost"):
+            with course_creator_cli._course_creation_attribution(
+                "test-token", operation_key
+            ) as first:
+                with course_creator_cli._course_creation_attribution(
+                    "test-token", operation_key
+                ) as second:
+                    pass
+                raise RuntimeError("response lost")
+
+        with course_creator_cli._course_creation_attribution(
+            "test-token", operation_key
+        ) as retried:
+            pass
+
+        self.assertEqual(second["handoff_id"], first["handoff_id"])
+        self.assertEqual(retried["handoff_id"], first["handoff_id"])
+
     def test_legacy_pending_operation_is_migrated_for_its_token(self):
         operation_key = "legacy-operation"
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -350,14 +350,18 @@ class CourseCreationAttributionTests(unittest.TestCase):
         values = []
 
         def reserve_first():
-            with course_creator_cli._course_creation_attribution("test-token") as value:
+            with course_creator_cli._course_creation_attribution(
+                "test-token", "operation-one"
+            ) as value:
                 values.append(value)
                 first_reserved.set()
                 release_first.wait(timeout=2)
 
         def reserve_second():
             first_reserved.wait(timeout=2)
-            with course_creator_cli._course_creation_attribution("test-token") as value:
+            with course_creator_cli._course_creation_attribution(
+                "test-token", "operation-two"
+            ) as value:
                 values.append(value)
             second_finished.set()
 
@@ -381,7 +385,9 @@ class CourseCreationAttributionTests(unittest.TestCase):
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
         course_creator_cli.save_token("saved-token", course_handoff_id=handoff_id)
 
-        with course_creator_cli._course_creation_attribution("explicit-token") as value:
+        with course_creator_cli._course_creation_attribution(
+            "explicit-token", "explicit-operation"
+        ) as value:
             self.assertNotEqual(value["handoff_id"], handoff_id)
 
         saved = course_creator_cli._read_json_file(
@@ -390,44 +396,43 @@ class CourseCreationAttributionTests(unittest.TestCase):
         self.assertEqual(saved["token"], "saved-token")
         self.assertEqual(saved["course_handoff_id"], handoff_id)
 
-    def test_failed_course_creation_restores_reserved_handoff(self):
+    def test_failed_course_creation_keeps_handoff_with_the_same_operation(self):
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
         course_creator_cli.save_token("test-token", course_handoff_id=handoff_id)
 
         with self.assertRaisesRegex(RuntimeError, "request failed"):
-            with course_creator_cli._course_creation_attribution("test-token"):
+            with course_creator_cli._course_creation_attribution(
+                "test-token", "failed-operation"
+            ) as failed:
                 raise RuntimeError("request failed")
 
         saved = course_creator_cli._read_json_file(
             course_creator_cli.credentials_path()
         )
-        self.assertEqual(saved["course_handoff_id"], handoff_id)
+        self.assertNotIn("course_handoff_id", saved)
+        with course_creator_cli._course_creation_attribution(
+            "test-token", "failed-operation"
+        ) as retried:
+            pass
+        self.assertEqual(failed["handoff_id"], handoff_id)
+        self.assertEqual(retried["handoff_id"], handoff_id)
 
-    def test_restore_failure_does_not_replace_the_creation_failure(self):
+    def test_failed_handoff_is_not_assigned_to_another_operation(self):
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
         course_creator_cli.save_token("test-token", course_handoff_id=handoff_id)
-        original_error = RuntimeError("request failed")
-        write_private_json = course_creator_cli._write_private_json
 
-        def fail_restore(path, payload):
-            if payload.get("course_handoff_id"):
-                raise OSError("disk unavailable")
-            write_private_json(path, payload)
+        with self.assertRaisesRegex(RuntimeError, "response lost"):
+            with course_creator_cli._course_creation_attribution(
+                "test-token", "original-operation"
+            ) as original:
+                raise RuntimeError("response lost")
+        with course_creator_cli._course_creation_attribution(
+            "test-token", "independent-operation"
+        ) as independent:
+            pass
 
-        with (
-            mock.patch.object(
-                course_creator_cli,
-                "_write_private_json",
-                side_effect=fail_restore,
-            ),
-            contextlib.redirect_stderr(io.StringIO()) as stderr,
-            self.assertRaises(RuntimeError) as raised,
-        ):
-            with course_creator_cli._course_creation_attribution("test-token"):
-                raise original_error
-
-        self.assertIs(raised.exception, original_error)
-        self.assertIn("could not restore", stderr.getvalue())
+        self.assertEqual(original["handoff_id"], handoff_id)
+        self.assertNotEqual(independent["handoff_id"], handoff_id)
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -343,13 +343,39 @@ class CourseCreationAttributionTests(unittest.TestCase):
             "test-token", course_handoff_id=handoff_id
         )
 
-        first = course_creator_cli._new_course_creation_attribution()
-        course_creator_cli._consume_course_handoff_id(first["handoff_id"])
-        second = course_creator_cli._new_course_creation_attribution()
+        with course_creator_cli._course_creation_attribution("test-token") as first:
+            with course_creator_cli._course_creation_attribution("test-token") as second:
+                pass
 
         self.assertEqual(first["handoff_id"], handoff_id)
         self.assertNotEqual(second["handoff_id"], handoff_id)
         self.assertEqual(course_creator_cli.load_saved_token(), "test-token")
+
+    def test_explicit_token_does_not_consume_another_accounts_handoff(self):
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        course_creator_cli.save_token("saved-token", course_handoff_id=handoff_id)
+
+        with course_creator_cli._course_creation_attribution("explicit-token") as value:
+            self.assertNotEqual(value["handoff_id"], handoff_id)
+
+        saved = course_creator_cli._read_json_file(
+            course_creator_cli.credentials_path()
+        )
+        self.assertEqual(saved["token"], "saved-token")
+        self.assertEqual(saved["course_handoff_id"], handoff_id)
+
+    def test_failed_course_creation_restores_reserved_handoff(self):
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        course_creator_cli.save_token("test-token", course_handoff_id=handoff_id)
+
+        with self.assertRaisesRegex(RuntimeError, "request failed"):
+            with course_creator_cli._course_creation_attribution("test-token"):
+                raise RuntimeError("request failed")
+
+        saved = course_creator_cli._read_json_file(
+            course_creator_cli.credentials_path()
+        )
+        self.assertEqual(saved["course_handoff_id"], handoff_id)
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):
@@ -537,6 +563,40 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
 
         poll.assert_called_once_with("https://example.test", "secret-device-code")
         save_token.assert_called_once_with("new-token")
+
+    def test_login_wait_transfers_the_registration_handoff(self):
+        args = types.SimpleNamespace(wait=True, timeout=30)
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        with (
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"SHIFU_BASE_URL": "https://example.test/"},
+                clear=True,
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_read_json_file",
+                return_value={
+                    "device_code": "secret-device-code",
+                    "interval": 1,
+                    "expires_at": course_creator_cli.time.time() + 600,
+                    "course_handoff_id": handoff_id,
+                },
+            ),
+            mock.patch.object(
+                course_creator_cli,
+                "_poll_device_authorization",
+                return_value=("approved", "new-token"),
+            ),
+            mock.patch.object(course_creator_cli, "save_token") as save_token,
+            mock.patch.object(course_creator_cli.Path, "unlink"),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            course_creator_cli.cmd_login(args)
+
+        save_token.assert_called_once_with(
+            "new-token", course_handoff_id=handoff_id
+        )
 
     def test_login_wait_reports_a_denied_request(self):
         args = types.SimpleNamespace(wait=True, timeout=30)

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -501,18 +501,18 @@ class CourseCreationAttributionTests(unittest.TestCase):
                 "chapter_name": None,
             }
 
-            first_key = course_creator_cli._course_directory_import_operation_key(
-                course_dir, **options
-            )
             first_export = course_creator_cli._build_import_json(
                 course_dir, **options
+            )
+            first_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, first_export
             )
             first_export_bytes = Path(first_export).read_bytes()
             second_export = course_creator_cli._build_import_json(
                 course_dir, **options
             )
             second_key = course_creator_cli._course_directory_import_operation_key(
-                course_dir, **options
+                course_dir, second_export
             )
 
             self.assertNotEqual(
@@ -521,10 +521,73 @@ class CourseCreationAttributionTests(unittest.TestCase):
             self.assertEqual(second_key, first_key)
 
             lesson.write_text("Changed content\n", encoding="utf-8")
-            changed_key = course_creator_cli._course_directory_import_operation_key(
+            changed_export = course_creator_cli._build_import_json(
                 course_dir, **options
             )
+            changed_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, changed_export
+            )
             self.assertNotEqual(changed_key, first_key)
+
+    def test_directory_import_operation_key_covers_all_built_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            course_dir = Path(tmp)
+            lessons_dir = course_dir / "lessons"
+            lessons_dir.mkdir()
+            (lessons_dir / "lesson-placeholder.md").write_text(
+                "Required discovery file\n", encoding="utf-8"
+            )
+            custom_lesson = lessons_dir / "custom.md"
+            custom_lesson.write_text("Custom lesson\n", encoding="utf-8")
+            (course_dir / "course-description.md").write_text(
+                "Original description\n", encoding="utf-8"
+            )
+            (course_dir / "structure.json").write_text(
+                json.dumps(
+                    {
+                        "chapters": [
+                            {
+                                "title": "Chapter",
+                                "lessons": [{"file": "custom.md", "title": "Custom"}],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            options = {
+                "title": None,
+                "description": None,
+                "keywords": None,
+                "chapter_name": None,
+            }
+
+            original_export = course_creator_cli._build_import_json(
+                course_dir, **options
+            )
+            original_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, original_export
+            )
+
+            (course_dir / "course-description.md").write_text(
+                "Changed description\n", encoding="utf-8"
+            )
+            description_export = course_creator_cli._build_import_json(
+                course_dir, **options
+            )
+            description_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, description_export
+            )
+            self.assertNotEqual(description_key, original_key)
+
+            custom_lesson.write_text("Changed custom lesson\n", encoding="utf-8")
+            content_export = course_creator_cli._build_import_json(
+                course_dir, **options
+            )
+            content_key = course_creator_cli._course_directory_import_operation_key(
+                course_dir, content_export
+            )
+            self.assertNotEqual(content_key, description_key)
 
     def test_durable_reservation_prevents_credential_handoff_reuse(self):
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
@@ -553,16 +616,16 @@ class CourseCreationAttributionTests(unittest.TestCase):
                 pass
 
         with course_creator_cli._course_creation_attribution(
-            "test-token", "independent-operation"
-        ) as independent:
-            pass
-        with course_creator_cli._course_creation_attribution(
             "test-token", "original-operation"
         ) as retried:
             pass
+        with course_creator_cli._course_creation_attribution(
+            "test-token", "independent-operation"
+        ) as independent:
+            pass
 
-        self.assertNotEqual(independent["handoff_id"], handoff_id)
         self.assertEqual(retried["handoff_id"], handoff_id)
+        self.assertNotEqual(independent["handoff_id"], handoff_id)
 
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -507,6 +507,9 @@ class CourseCreationAttributionTests(unittest.TestCase):
             first_key = course_creator_cli._course_directory_import_operation_key(
                 course_dir, first_export
             )
+            first_json_key = course_creator_cli._course_import_operation_key(
+                "import-new-json", first_export, first_export
+            )
             first_export_bytes = Path(first_export).read_bytes()
             second_export = course_creator_cli._build_import_json(
                 course_dir, **options
@@ -514,11 +517,15 @@ class CourseCreationAttributionTests(unittest.TestCase):
             second_key = course_creator_cli._course_directory_import_operation_key(
                 course_dir, second_export
             )
+            second_json_key = course_creator_cli._course_import_operation_key(
+                "import-new-json", second_export, second_export
+            )
 
             self.assertNotEqual(
                 first_export_bytes, Path(second_export).read_bytes()
             )
             self.assertEqual(second_key, first_key)
+            self.assertEqual(second_json_key, first_json_key)
 
             lesson.write_text("Changed content\n", encoding="utf-8")
             changed_export = course_creator_cli._build_import_json(

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -339,7 +339,7 @@ class CourseCreationAttributionTests(unittest.TestCase):
                     else:
                         self.assertEqual(create_calls, [])
 
-    def test_first_course_reuses_registration_handoff_once(self):
+    def test_concurrent_course_reservations_do_not_hold_lock_during_request(self):
         handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
         course_creator_cli.save_token(
             "test-token", course_handoff_id=handoff_id
@@ -371,7 +371,7 @@ class CourseCreationAttributionTests(unittest.TestCase):
         first_thread.start()
         second_thread.start()
         self.assertTrue(first_reserved.wait(timeout=2))
-        self.assertFalse(second_finished.wait(timeout=0.1))
+        self.assertTrue(second_finished.wait(timeout=0.5))
         release_first.set()
         first_thread.join(timeout=2)
         second_thread.join(timeout=2)

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -526,6 +526,44 @@ class CourseCreationAttributionTests(unittest.TestCase):
             )
             self.assertNotEqual(changed_key, first_key)
 
+    def test_durable_reservation_prevents_credential_handoff_reuse(self):
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        course_creator_cli.save_token("test-token", course_handoff_id=handoff_id)
+        real_write = course_creator_cli._write_private_json
+        write_count = 0
+
+        def interrupt_after_journal(path, payload):
+            nonlocal write_count
+            write_count += 1
+            if write_count == 2:
+                raise RuntimeError("process interrupted before credential cleanup")
+            return real_write(path, payload)
+
+        with (
+            mock.patch.object(
+                course_creator_cli,
+                "_write_private_json",
+                side_effect=interrupt_after_journal,
+            ),
+            self.assertRaisesRegex(RuntimeError, "process interrupted"),
+        ):
+            with course_creator_cli._course_creation_attribution(
+                "test-token", "original-operation"
+            ):
+                pass
+
+        with course_creator_cli._course_creation_attribution(
+            "test-token", "independent-operation"
+        ) as independent:
+            pass
+        with course_creator_cli._course_creation_attribution(
+            "test-token", "original-operation"
+        ) as retried:
+            pass
+
+        self.assertNotEqual(independent["handoff_id"], handoff_id)
+        self.assertEqual(retried["handoff_id"], handoff_id)
+
 
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):
     def test_env_example_documents_base_url_and_token(self):

--- a/tests/test_course_creator_cli.py
+++ b/tests/test_course_creator_cli.py
@@ -255,6 +255,103 @@ class CourseCreatorVerificationUrlTests(unittest.TestCase):
                     self.assertEqual(output.getvalue(), "")
 
 
+class CourseCreationAttributionTests(unittest.TestCase):
+    def setUp(self):
+        tmp = self.enterContext(tempfile.TemporaryDirectory())
+        self.base_url = "https://app.ai-shifu.cn"
+        self.enterContext(
+            mock.patch.dict(
+                course_creator_cli.os.environ,
+                {"AI_SHIFU_CONFIG_DIR": tmp},
+                clear=True,
+            )
+        )
+        self.enterContext(
+            mock.patch.object(
+                course_creator_cli,
+                "resolve_auth",
+                return_value=(self.base_url, "test-token"),
+            )
+        )
+
+    def test_create_sends_lobster_attribution(self):
+        with mock.patch.object(
+            course_creator_cli, "api", return_value={"bid": "course-new"}
+        ) as api_call:
+            course_creator_cli.cmd_create(
+                types.SimpleNamespace(name="New course", description="Description")
+            )
+
+        payload = api_call.call_args.kwargs["json"]
+        self.assertEqual(
+            payload["creation_attribution"]["creation_source"], "ai_assistant"
+        )
+        self.assertEqual(
+            payload["creation_attribution"]["source_product"], "lobster"
+        )
+        self.assertRegex(
+            payload["creation_attribution"]["handoff_id"],
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        )
+
+    def test_new_import_sends_attribution_but_existing_import_does_not(self):
+        import_data = {
+            "shifu": {"title": "Imported course", "description": "Description"},
+            "outline_items": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            import_file = Path(tmp) / "course.json"
+            import_file.write_text(json.dumps(import_data), encoding="utf-8")
+
+            for existing_bid in (None, "existing-course"):
+                with self.subTest(existing_bid=existing_bid):
+                    calls = []
+
+                    def fake_api(_base_url, _token, method, path, **kwargs):
+                        calls.append((method, path, kwargs.get("json")))
+                        if method == "put" and path == "/shifus":
+                            return {"bid": "course-new"}
+                        return []
+
+                    with (
+                        mock.patch.object(course_creator_cli, "api", side_effect=fake_api),
+                        mock.patch.object(
+                            course_creator_cli, "api_safe", return_value=[]
+                        ),
+                        contextlib.redirect_stdout(io.StringIO()),
+                    ):
+                        course_creator_cli._import_flat(
+                            self.base_url,
+                            "test-token",
+                            import_file,
+                            existing_bid,
+                        )
+
+                    create_calls = [call for call in calls if call[1] == "/shifus"]
+                    if existing_bid is None:
+                        self.assertEqual(len(create_calls), 1)
+                        self.assertEqual(
+                            create_calls[0][2]["creation_attribution"]["source_product"],
+                            "lobster",
+                        )
+                    else:
+                        self.assertEqual(create_calls, [])
+
+    def test_first_course_reuses_registration_handoff_once(self):
+        handoff_id = "52cefd54-930a-4c06-b62d-00de456cd56f"
+        course_creator_cli.save_token(
+            "test-token", course_handoff_id=handoff_id
+        )
+
+        first = course_creator_cli._new_course_creation_attribution()
+        course_creator_cli._consume_course_handoff_id(first["handoff_id"])
+        second = course_creator_cli._new_course_creation_attribution()
+
+        self.assertEqual(first["handoff_id"], handoff_id)
+        self.assertNotEqual(second["handoff_id"], handoff_id)
+        self.assertEqual(course_creator_cli.load_saved_token(), "test-token")
+
+
 class CourseCreatorCliBaseUrlTests(unittest.TestCase):
     def test_env_example_documents_base_url_and_token(self):
         env_example = SCRIPT_DIR.parent / ".env.example"
@@ -369,6 +466,9 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
         self.assertEqual(called_base_url, "https://example.test")
         self.assertEqual(called_path, "/api/user/device/authorize")
         self.assertIn("device_name", payload)
+        attribution = payload["registration_attribution"]
+        self.assertEqual(attribution["creation_source"], "ai_assistant")
+        self.assertEqual(attribution["source_product"], "lobster")
 
         printed = stdout.getvalue()
         open_browser.assert_not_called()
@@ -379,6 +479,7 @@ class CourseCreatorCliBaseUrlTests(unittest.TestCase):
         self.assertNotIn("secret-device-code", printed)
         stored = write_json.call_args[0][1]
         self.assertEqual(stored["device_code"], "secret-device-code")
+        self.assertEqual(stored["course_handoff_id"], attribution["handoff_id"])
 
     def test_login_prints_plain_verification_uri_and_pairing_code(self):
         with (


### PR DESCRIPTION
## Summary
- send stable Lobster attribution with browser authorization and new-course requests
- bind uncertain requests to normalized effective course payloads and authenticated tokens in a durable retry journal
- validate course IDs for direct creation and imports before confirming creation
- keep directory reseeding inside the retry reservation and parse each import once for identity and application
- validate journal records strictly, coordinate complete imports, and recover stale process leases safely

## Related PR
- backend contract and persistence: https://github.com/ai-shifu/ai-shifu/pull/2800

## Rollout
- merge and deploy the AI Shifu backend migration and contract before releasing this Skill update
- existing-course imports remain unchanged

## Verification
- `python -m unittest tests.test_course_creator_cli` (75 passed)
- `python -m unittest discover -s tests` (247 passed)
- `python scripts/validate_skill_quality.py` (3 skills passed)
- `git diff --check`